### PR TITLE
valkey: content polish against 9.0.3 baseline

### DIFF
--- a/skills/valkey/skills/valkey/SKILL.md
+++ b/skills/valkey/skills/valkey/SKILL.md
@@ -43,7 +43,7 @@ argument-hint: "[feature, pattern, or scenario]"
 | Topic | Reference |
 |-------|-----------|
 | SET IFEQ (8.1+), DELIFEQ (9.0+) - atomic compare-and-swap, safe lock release without Lua | [conditional-ops](reference/valkey-features-conditional-ops.md) |
-| HSETEX, HGETEX, HGETDEL, HEXPIRE, HPERSIST (9.0+) - per-field TTL on hashes | [hash-field-ttl](reference/valkey-features-hash-field-ttl.md) |
+| HSETEX, HGETEX, HEXPIRE, HPERSIST (9.0+) - per-field TTL on hashes | [hash-field-ttl](reference/valkey-features-hash-field-ttl.md) |
 | COMMANDLOG GET/LEN/RESET (8.1+) - unified slow/large-request/large-reply logging, replaces SLOWLOG | [commandlog](reference/valkey-features-commandlog.md) |
 | EXPIRETIME, PEXPIRETIME, PERSIST - absolute expiration timestamps, TTL inspection and removal | [expiretime](reference/valkey-features-expiretime.md) |
 | GEOSEARCH BYPOLYGON (9.0+) - arbitrary polygon region matching | [geospatial](reference/valkey-features-geospatial.md) |
@@ -89,7 +89,7 @@ argument-hint: "[feature, pattern, or scenario]"
 | Pipelining, connection pooling, I/O threading, performance anti-patterns | [performance-throughput](reference/best-practices-performance-throughput.md) |
 | RDB, AOF, hybrid persistence, latency impact, durability decisions | [persistence](reference/best-practices-persistence.md) |
 | Hash tags, cross-slot errors, CROSSSLOT fixes | [cluster-hash-tags](reference/best-practices-cluster-hash-tags.md) |
-| MOVED/ASK redirects, replica reads, pipelining in cluster, CLUSTERSCAN | [cluster-operations](reference/best-practices-cluster-operations.md) |
+| MOVED/ASK redirects, replica reads, pipelining in cluster | [cluster-operations](reference/best-practices-cluster-operations.md) |
 | Sentinel, failover, retries, WAIT/WAITAOF, replication lag, Sentinel vs Cluster decision | [high-availability](reference/best-practices-high-availability.md) |
 
 

--- a/skills/valkey/skills/valkey/reference/advanced-client-side-caching.md
+++ b/skills/valkey/skills/valkey/reference/advanced-client-side-caching.md
@@ -4,16 +4,14 @@ Use when implementing server-assisted client-side caching, choosing between trac
 
 ## Contents
 
-- Protocol Basics: RESP3 vs RESP2 (line 13)
-- Tracking Modes (line 46)
-- Tracking Table Limits (line 84)
-- Implementation with GLIDE (line 100)
-- Implementation with redis-py and ioredis (line 117)
-- Cache Consistency Guarantees (line 158)
-- Memory Impact (line 175)
-- Connection Management (line 187)
-- Best Practices (line 205)
-- Valkey Version Notes (line 228)
+- Protocol Basics: RESP3 vs RESP2
+- Tracking Modes
+- Tracking Table Limits
+- Implementation with redis-py and ioredis
+- Cache Consistency Guarantees
+- Memory and Connection Management
+- Best Practices
+- Valkey Version Notes
 
 ---
 
@@ -105,36 +103,17 @@ CONFIG SET tracking-table-max-keys 1000000
 
 **When the table is full**, Valkey evicts random entries and sends invalidations to affected clients even though the keys have not changed. This causes unnecessary cache misses - not errors.
 
-Detect saturation:
+Detect saturation with `INFO stats`:
 
 ```
-127.0.0.1:6379> INFO stats
-tracking_table_entries:1000000    # at the limit - spurious invalidations are occurring
+tracking_total_keys:1000000       # distinct keys tracked; hits tracking-table-max-keys limit
+tracking_total_items:4300000      # per-(key, client) entries (items >= keys)
+tracking_total_prefixes:0         # active BCAST prefix subscriptions
 ```
+
+`tracking_total_keys` is the value that bounds against `tracking-table-max-keys`. When it reaches the limit, the server evicts a random key and sends a spurious invalidation for it.
 
 **Sizing rule of thumb**: `clients * average_tracked_keys_per_client`. For 100 clients tracking 5,000 keys each, that is 500,000 entries - well under the default. For 1,000 clients at the same rate, you need 5,000,000 - increase the config or switch to BCAST mode.
-
----
-
-## Implementation with GLIDE
-
-GLIDE (Valkey's official multi-language client) has built-in client-side caching via `CacheConfig`. It handles the tracking protocol, push message parsing, connection management, and local cache eviction automatically.
-
-```python
-# Python example
-from glide import GlideClient, GlideClientConfiguration, CacheConfig
-
-config = GlideClientConfiguration(
-    addresses=[...],
-    client_cache_config=CacheConfig(max_size=1000)
-)
-client = await GlideClient.create(config)
-
-# Reads are transparently cached; invalidations handled internally
-value = await client.get("user:1000:profile")
-```
-
-GLIDE abstracts RESP3 vs RESP2 differences and manages the dedicated invalidation connection when needed. The `max_size` parameter bounds local memory. See the per-language GLIDE skills (valkey-glide-python, valkey-glide-java, valkey-glide-nodejs) for language-specific API details and Java/Node.js examples.
 
 ---
 
@@ -207,11 +186,11 @@ async def on_reconnect():
 
 **Server memory (BCAST mode)**: minimal - only prefix subscriptions per client, not per-key entries.
 
-**Client memory**: entirely application-managed. Set a size cap with LRU eviction to avoid unbounded growth. GLIDE's `CacheConfig.max_size` does this automatically.
+**Client memory**: entirely application-managed. Set a size cap with LRU eviction to avoid unbounded growth.
 
 **Invalidation connection lifecycle**: the RESP2 Pub/Sub connection must stay alive continuously. If it drops, invalidations stop arriving and the local cache silently goes stale. Use `CLIENT NO-EVICT ON` on it if the server is under memory pressure. Never reuse it for data commands.
 
-**Connection pools**: standard interchangeable pools do not work with default tracking mode - tracking state is per-connection. Options: dedicate one long-lived connection per application instance, switch to BCAST mode, or use GLIDE (which manages this automatically).
+**Connection pools**: standard interchangeable pools do not work with default tracking mode - tracking state is per-connection. Options: dedicate one long-lived connection per application instance, or switch to BCAST mode (where invalidation is per-prefix and connection identity is less coupled).
 
 ---
 
@@ -249,6 +228,6 @@ Valkey 8.0 through 9.0 make no changes to CLIENT TRACKING semantics, protocol, o
 
 The `__redis__:invalidate` channel name is preserved - Valkey does not rename it.
 
-GLIDE built-in caching (CacheConfig) was introduced in GLIDE 2.x. Client libraries built for Redis work without changes - the tracking protocol is unchanged.
+Client libraries built for Redis work with Valkey without changes - the tracking protocol is unchanged.
 
 ---

--- a/skills/valkey/skills/valkey/reference/advanced-latency-diagnosis.md
+++ b/skills/valkey/skills/valkey/reference/advanced-latency-diagnosis.md
@@ -4,13 +4,13 @@ Use when investigating high p99 latency, intermittent timeouts, slow command exe
 
 ## Contents
 
-- End-to-End Diagnosis Workflow (line 12)
-- Step 1: Establish Baselines (line 23)
-- Step 2: Check the Latency Monitor (line 53)
-- Step 3: Correlate with COMMANDLOG (line 95)
-- Step 4: Common Latency Sources (line 126)
-- Step 5: Event Loop and I/O Thread Impact (line 166)
-- Practical Playbook: "Client Reports High p99" (line 193)
+- End-to-End Diagnosis Workflow
+- Step 1: Establish Baselines
+- Step 2: Check the Latency Monitor
+- Step 3: Correlate with COMMANDLOG
+- Step 4: Common Latency Sources
+- Step 5: Event Loop and I/O Thread Impact
+- Practical Playbook: "Client Reports High p99"
 
 ---
 
@@ -167,7 +167,7 @@ During the fork, all clients are paused. Check `INFO persistence` for `latest_fo
 
 ### Lazy Expiry and Active Expiration
 
-Valkey expires keys lazily on access and actively via a periodic sweep that samples random keys with TTLs. If > 25% of sampled keys are expired, the sweep loops immediately. A burst of expirations (all session keys expire at the same time) can block the main thread for multiple milliseconds.
+Valkey expires keys lazily on access and actively via a periodic sweep that samples random keys with TTLs. If the sampled stale percentage exceeds `ACTIVE_EXPIRE_CYCLE_ACCEPTABLE_STALE` (10% by default, lowered by `active-expire-effort`), the sweep keeps looping on that DB until it drops back below. A burst of expirations (all session keys expire at the same time) can block the main thread for multiple milliseconds.
 
 Fix: **jitter your TTLs**. Instead of `SET key val EX 3600`, use `SET key val EX <3600 + random(0, 300)>`. This spreads expirations over a 5-minute window.
 

--- a/skills/valkey/skills/valkey/reference/advanced-lua-functions.md
+++ b/skills/valkey/skills/valkey/reference/advanced-lua-functions.md
@@ -148,8 +148,6 @@ Libraries persist across restarts (they are included in RDB/AOF). EVALSHA cache 
 
 Library versioning convention: embed version in the name (`mylib_v2`) or use `FUNCTION LOAD REPLACE` to overwrite atomically.
 
-**9.1 note**: the Lua scripting engine is shipped as a Valkey module rather than built-in. EVAL/FCALL behavior is unchanged from a caller's perspective; operators see a new scripting-engines INFO section and can inspect the engine via `FUNCTION LIST WITHCODE`.
-
 ---
 
 ## Error Handling in Lua

--- a/skills/valkey/skills/valkey/reference/advanced-lua-functions.md
+++ b/skills/valkey/skills/valkey/reference/advanced-lua-functions.md
@@ -2,21 +2,6 @@
 
 Use when writing atomic multi-key operations, migrating EVAL scripts to FUNCTION LOAD, debugging script timeouts, or deciding whether a Lua script is still needed now that SET IFEQ and DELIFEQ exist.
 
-## Contents
-
-- EVAL vs FCALL: When to Use Each (line 13)
-- Script Replication (line 38)
-- Determinism Requirements (line 56)
-- Read-Only Scripts: EVAL_RO and FCALL_RO (line 73)
-- Script Timeout (line 87)
-- Valkey Replacements for Common Lua Patterns (line 112)
-- Library Registration with FUNCTION LOAD (line 122)
-- Error Handling in Lua (line 147)
-- Anti-Patterns (line 163)
-- Practical Examples (line 177)
-
----
-
 ## EVAL vs FCALL: When to Use Each
 
 - **EVAL** - ad-hoc scripts sent inline with each call. Simple, no setup. Cached by SHA1 after the first call via `EVALSHA`.
@@ -83,26 +68,19 @@ In cluster mode, all keys in `KEYS[]` must still hash to the same slot.
 ## Script Timeout
 
 ```
-# Renamed from lua-time-limit in Valkey 8.0+
-# Default: 5000 ms
-CONFIG SET busy-script-time 5000
+# Canonical Valkey name; legacy alias `lua-time-limit` still accepted.
+# Default: 5000 ms.
+CONFIG SET busy-reply-threshold 5000
 ```
 
-Both `busy-script-time` (Valkey) and `lua-time-limit` (Redis compat) are accepted. Use `busy-script-time` in new configs.
+**When a script exceeds the threshold**:
+1. Valkey enters BUSY state - most commands are rejected with a `-BUSY ...` error.
+2. The exact `-BUSY` reply tells you which kill command applies:
+   - Running EVAL / EVALSHA → *"You can only call SCRIPT KILL or SHUTDOWN NOSAVE"*
+   - Running FCALL / FCALL_RO → *"You can only call FUNCTION KILL or SHUTDOWN NOSAVE"*
+3. `SCRIPT KILL` / `FUNCTION KILL` only work **before the script has performed any write**. Once a write has been executed, the script cannot be killed - partial writes cannot be rolled back, so only `SHUTDOWN NOSAVE` can abort it.
 
-**When a script exceeds the timeout**:
-1. Valkey enters BUSY state - all commands rejected except `SCRIPT KILL` and `SHUTDOWN NOSAVE`.
-2. Clients receive: `BUSY Valkey is busy running a script`
-3. `SCRIPT KILL` terminates the script only if it has not yet executed any writes. A script that has written cannot be killed (partial writes cannot be rolled back) - only `SHUTDOWN NOSAVE` can abort it.
-
-**Script memory limit**:
-```
-lua-memory-limit 10mb    # Default: 10 MB per execution
-```
-
-Scripts that accumulate large intermediate tables or strings will hit this limit and be terminated.
-
-**Prevention**: keep scripts short; never iterate large collections inside Lua - use SCAN-based iteration in application code instead.
+**Prevention**: keep scripts short; never iterate large collections inside Lua - use SCAN-based iteration in application code instead. Lua memory is not separately capped - it counts against the same `maxmemory` budget as regular data, so an accumulating script can OOM the server.
 
 ---
 
@@ -121,8 +99,9 @@ Native commands are faster (no Lua VM overhead), simpler to audit, and work with
 
 ## Library Registration with FUNCTION LOAD
 
+Register a named library. The shebang `#!lua name=<libname>` is required on the first line of the function code:
+
 ```lua
--- Register a named library (once per deployment)
 FUNCTION LOAD "#!lua name=mylib\n
   local function cas(keys, args)
     local current = server.call('get', keys[1])
@@ -133,6 +112,23 @@ FUNCTION LOAD "#!lua name=mylib\n
   end
   server.register_function('cas', cas)"
 ```
+
+`server.register_function` accepts two forms:
+
+```lua
+-- Positional: shown above. Works for basic registration.
+server.register_function('cas', cas)
+
+-- Named (table): required when setting flags or a description.
+server.register_function{
+  function_name = 'getprofile',
+  callback      = getprofile,
+  description   = 'Read-only user profile lookup',
+  flags         = {'no-writes'}   -- marks the function as read-only (callable via FCALL_RO)
+}
+```
+
+The `no-writes` flag is the one most often needed - without it you cannot expose a function through `FCALL_RO` even if it never writes.
 
 ```
 -- Call from application code
@@ -148,9 +144,11 @@ FUNCTION RESTORE <binary>
 FUNCTION LOAD REPLACE "#!lua name=mylib\n ..."
 ```
 
-Libraries persist across restarts. EVALSHA cache does not. For production scripts that must survive restarts or redeploys, use `FUNCTION LOAD` over `SCRIPT LOAD`.
+Libraries persist across restarts (they are included in RDB/AOF). EVALSHA cache does not - a restart means every `EVALSHA <sha>` will return `NOSCRIPT` until the script is loaded again. For production scripts that must survive restarts or redeploys, use `FUNCTION LOAD` over `SCRIPT LOAD`.
 
 Library versioning convention: embed version in the name (`mylib_v2`) or use `FUNCTION LOAD REPLACE` to overwrite atomically.
+
+**9.1 note**: the Lua scripting engine is shipped as a Valkey module rather than built-in. EVAL/FCALL behavior is unchanged from a caller's perspective; operators see a new scripting-engines INFO section and can inspect the engine via `FUNCTION LIST WITHCODE`.
 
 ---
 
@@ -158,23 +156,31 @@ Library versioning convention: embed version in the name (`mylib_v2`) or use `FU
 
 ```lua
 -- Raise an error (client sees error response)
-return redis.error_reply("ERR something went wrong")
+return server.error_reply("ERR something went wrong")
 
 -- Return a status (client sees simple string, not error)
-return redis.status_reply("OK")
+return server.status_reply("OK")
 ```
 
-`server.call()` raises on any Valkey error and aborts the script. Use `server.pcall()` to catch errors within the script:
+`server.call()` raises on any Valkey error and aborts the script. Use `server.pcall()` to catch errors within the script.
+
+**`server.pcall` return shape** - this trips people up. It is NOT Lua's native `pcall`. It returns **one** value:
+
+- On success: the command result (string, number, array, etc.).
+- On error: a Lua **table** with a single `err` field (not a `(status, value)` tuple).
+
+Correct pattern:
 
 ```lua
-local ok, err = server.pcall('get', KEYS[1])
-if err then
-  return redis.error_reply("ERR key has wrong type")
+local result = server.pcall('get', KEYS[1])
+if type(result) == 'table' and result.err then
+  -- Propagate the actual Valkey error message
+  return server.error_reply(result.err)
 end
-return ok
+return result
 ```
 
-`redis.call` and `server.call` are identical. Prefer `server.call` in new code - it is the Valkey naming convention.
+**Aliases**: `redis.call` / `redis.pcall` / `redis.error_reply` / `redis.status_reply` all work identically to the `server.*` versions - the `redis` global is an alias of `server` set up for pre-Valkey compatibility. Prefer `server.*` in new code; `redis.*` is fine in existing scripts.
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/advanced-memory-defrag.md
+++ b/skills/valkey/skills/valkey/reference/advanced-memory-defrag.md
@@ -4,12 +4,12 @@ Use when Valkey is consuming more memory than expected, `INFO memory` shows a hi
 
 ## Contents
 
-- What Memory Fragmentation Is (line 13)
-- Reading Fragmentation Metrics (line 38)
-- Active Defragmentation (line 76)
-- When NOT to Enable Defrag (line 126)
-- Diagnosing Memory Issues from Application Code (line 140)
-- Valkey Version Changes (line 179)
+- What Memory Fragmentation Is
+- Reading Fragmentation Metrics
+- Active Defragmentation
+- When NOT to Enable Defrag
+- Diagnosing Memory Issues from Application Code
+- Valkey Version Changes
 
 ---
 
@@ -149,10 +149,10 @@ Active defrag is not always beneficial. Skip it when:
 (integer) 296
 
 127.0.0.1:6379> MEMORY USAGE user:session:abc123 SAMPLES 0
-(integer) 128
+(integer) 312
 ```
 
-Returns the number of bytes a key and its value consume, including overhead. The `SAMPLES` option controls how many elements are sampled for aggregate types (hashes, sets, sorted sets). `SAMPLES 0` returns only the top-level overhead without sampling elements - fast but less accurate.
+Returns the number of bytes a key and its value consume, including overhead. The `SAMPLES` option controls how many elements are sampled for aggregate types (hashes, sets, sorted sets). Default is 5 - fast, approximate. `SAMPLES 0` means **sample every element** - the most accurate but slowest option, appropriate for one-off forensic use but not continuous monitoring.
 
 Use this to find unexpectedly large keys:
 
@@ -200,17 +200,17 @@ Dumps jemalloc's internal statistics. This is verbose output primarily for ops t
 
 - Default allocator remains jemalloc with defrag support.
 - No changes to defrag configuration defaults.
-- The new hashtable implementation (landing in 8.1) reduces per-key overhead by 20-30 bytes, which indirectly reduces fragmentation by packing more data into fewer pages.
+- The new hashtable implementation (landing in 8.1) reduces per-key overhead, which indirectly reduces fragmentation by packing more data into fewer pages.
 
 ### Valkey 8.1
 
-- New open-addressing hashtable with 64-byte bucket alignment. This improves memory density and reduces the number of small allocations that drive fragmentation.
-- The combination of fewer allocations per key and SIMD-based probing means the keyspace generates less fragmentation under churn compared to the legacy dict-based hashtable.
+- New hashtable with cache-line (64-byte) buckets and bucket chaining - 7 entries per bucket, with the 8th slot pointing to the next bucket in the chain when needed. This improves memory density and reduces the number of small allocations that drive fragmentation.
+- The combination of fewer allocations per key and SIMD-based presence-hash scanning means the keyspace generates less fragmentation under churn compared to the legacy dict-based hashtable.
 
 ### Valkey 9.0
 
 - No changes to active defrag configuration or behavior.
-- Zero-copy responses reduce temporary buffer allocations during reads, which marginally reduces allocation churn.
+- Reply Copy Avoidance (9.0) avoids copying large value data into the output buffer on the reply path, which marginally reduces temporary allocations and allocation churn for read-heavy workloads.
 
 ### General Guidance
 

--- a/skills/valkey/skills/valkey/reference/anti-patterns-quick-reference.md
+++ b/skills/valkey/skills/valkey/reference/anti-patterns-quick-reference.md
@@ -15,7 +15,7 @@ Use when reviewing application code for common Valkey mistakes, or as a checklis
 | One connection per request | TCP connection setup is expensive (especially with TLS). Exhausts server connection limits under load. | Use connection pools (traditional clients) or GLIDE's multiplexed connections. |
 | `FLUSHALL` accessible | An application bug or compromised credential can wipe all data instantly. | Rename or disable the command via `rename-command` or ACL restrictions. |
 | Short cryptic key names | Saves negligible memory (keys are small relative to values) but makes debugging and operations painful. | Use readable colon-delimited names: `user:1000:profile`, `cache:api:products:page:1`. |
-| Single hot key for counters | In cluster mode, all operations on one key go to one shard. Creates a bottleneck under high write rates. | Shard the key: `counter:{0}`, `counter:{1}`, ..., `counter:{N}`. Sum across shards when reading. See [Counter Patterns](patterns-counters-atomic.md). |
+| Single hot key for counters | All writes serialize on one object and its replication stream, even on a single node. In cluster mode they also pin to one shard. | Shard across N keys: `counter:0`, `counter:1`, ..., `counter:N`. Sum across shards when reading. Hash tags (`counter:{pool}:0`, ...) co-locate shards on one slot for atomic MGET; drop the hash tag only when you need true cross-node spread. See [Counter Patterns](patterns-counters-atomic.md). |
 | Storing values > 1 MB | Large values cause network and memory pressure. Slow reads, high bandwidth, increased fragmentation. | Compress values before storing. For truly large objects, use object storage (S3, GCS) and store only the reference in Valkey. |
 | Multiple databases in production (pre-9.0) | Databases share everything (memory, CPU, connections). No isolation. `FLUSHDB` on the wrong database is catastrophic. | Use separate instances for workload isolation. In Valkey 9.0+ cluster mode, numbered databases are available but still share resources. |
 | Missing TTL on cache entries | Keys without TTL live forever. Memory fills up with stale data until eviction kicks in (if configured) or OOM. | Always set TTL at write time: `SET key value EX 3600`. Use `allkeys-lru` eviction as a safety net. See [Caching Patterns](patterns-caching-strategies.md). |
@@ -75,7 +75,9 @@ valkey-cli --bigkeys
 # Find keys consuming the most memory
 valkey-cli --memkeys
 
-# Find hot keys (most-accessed)
+# Find hot keys (most-accessed) - requires maxmemory-policy = allkeys-lfu or volatile-lfu,
+# otherwise it errors out. The sampling uses object access frequency, which only
+# tracks under an *lfu policy.
 valkey-cli --hotkeys
 
 # Check if maxmemory is set
@@ -97,7 +99,7 @@ valkey-cli SLOWLOG GET 10
 
 ### "Should I use DEL or UNLINK?"
 
-Always use `UNLINK` unless you need synchronous deletion. In Valkey 8.0+, `DEL` defaults to async behavior (`lazyfree-lazy-user-del yes`), but `UNLINK` is explicit and clear.
+Prefer `UNLINK` - it's explicit about async. `DEL` actually also runs async by default (`lazyfree-lazy-user-del yes` in the shipped config), so the behavioral gap is small; the value of `UNLINK` is that the intent is visible in the code and isn't silently toggled by a config change.
 
 ### "Should I use KEYS or SCAN?"
 
@@ -118,7 +120,7 @@ Never use `KEYS` in production. Use `SCAN` with a cursor. SCAN may return duplic
 
 - **Key names**: Readable, not abbreviated. `user:1000:profile` costs negligible extra bytes.
 - **Values**: Keep under 100 KB ideally, under 1 MB maximum. Compress JSON/serialized data.
-- **Collections**: Keep hashes under 10K fields, lists under 100K elements, sets under 100K members. Split larger collections.
+- **Collections**: Default listpack thresholds (`hash-max-listpack-entries 512`, `set-max-listpack-entries 128`, `zset-max-listpack-entries 128`) are where the encoding flips to hashtable/skiplist - below them most ops are effectively O(1) constant-time on a compact buffer. Past those thresholds, whole-collection commands (`HGETALL`, `HKEYS`, `SMEMBERS`, `ZRANGE` without limit) become O(N) and latency scales with collection size. Operational rule of thumb: keep hashes under 10K fields, lists under 100K elements, sets/zsets under 100K members. Split or partition larger collections.
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/basics-data-types.md
+++ b/skills/valkey/skills/valkey/reference/basics-data-types.md
@@ -6,24 +6,29 @@ Standard Redis commands (SET, GET, HSET, ZADD, etc.) are assumed known. This fil
 
 ## Strings
 
-`SET key value IFEQ old_value` (Valkey 9.0+) - conditional update, only sets if current value equals `old_value`. Replaces WATCH/MULTI/EXEC for compare-and-swap.
+`SET key value IFEQ old_value` (Valkey 8.1+) - conditional update, only sets if current value equals `old_value`. Does not create missing keys (returns nil). Replaces WATCH/MULTI/EXEC for compare-and-swap.
 
 `DELIFEQ key value` (Valkey 9.0+) - conditional delete, only deletes if current value equals `value`. Replaces Lua scripts for safe lock release.
 
-## Hashes - Per-Field TTL (Valkey 7.4+)
+## Hashes - Per-Field TTL (Valkey 9.0+)
 
-`HSETEX key ttl-seconds field value [field value ...]` - set fields with TTL in one command.
+`HSETEX key [FNX|FXX] [EX seconds|PX ms|EXAT unix|PXAT unix-ms|KEEPTTL] FIELDS count field value [field value ...]` - set fields (optionally with TTL) in one command. `FNX` = set only if field doesn't exist; `FXX` = set only if it does. `KEEPTTL` preserves the field's existing TTL when updating its value.
 
-`HGETEX key [EX seconds | PX ms | EXAT unix | PXAT unix-ms | PERSIST] FIELDS count field [field ...]` - get fields and optionally set/refresh/remove their TTL atomically.
+`HGETEX key [EX seconds|PX ms|EXAT unix|PXAT unix-ms|PERSIST] FIELDS count field [field ...]` - get fields and optionally set/refresh/remove their TTL atomically.
 
 `HGETDEL key FIELDS count field [field ...]` - get fields and delete them atomically.
 
-`HEXPIRE key seconds FIELDS count field [field ...]` - set per-field TTL (seconds).
-`HPEXPIRE key ms FIELDS count field [field ...]` - set per-field TTL (milliseconds).
-`HTTL key FIELDS count field [field ...]` - get remaining TTL per field.
-`HPTTL key FIELDS count field [field ...]` - get remaining TTL in ms per field.
-`HEXPIRETIME key FIELDS count field [field ...]` - get expiry as Unix timestamp.
+`HEXPIRE key seconds [NX|XX|GT|LT] FIELDS count field [field ...]` - set per-field TTL (seconds).
+`HPEXPIRE key ms [NX|XX|GT|LT] FIELDS count field [field ...]` - set per-field TTL (milliseconds).
+`HEXPIREAT key unix-seconds [NX|XX|GT|LT] FIELDS count field [field ...]` - absolute expiry (seconds).
+`HPEXPIREAT key unix-ms [NX|XX|GT|LT] FIELDS count field [field ...]` - absolute expiry (milliseconds).
+`HTTL key FIELDS count field [field ...]` - remaining TTL per field (seconds).
+`HPTTL key FIELDS count field [field ...]` - remaining TTL per field (milliseconds).
+`HEXPIRETIME key FIELDS count field [field ...]` - expiry as absolute Unix timestamp (seconds).
+`HPEXPIRETIME key FIELDS count field [field ...]` - expiry as absolute Unix timestamp (milliseconds).
 `HPERSIST key FIELDS count field [field ...]` - remove per-field TTL.
+
+`NX|XX|GT|LT` on HEXPIRE family: `NX` only if no TTL, `XX` only if TTL, `GT` only if new TTL is greater, `LT` only if new TTL is less.
 
 Per-field expiry is the primary Valkey advantage for session storage - individual hash fields expire without needing to manage separate keys. See `patterns-sessions-field-expiry.md`.
 

--- a/skills/valkey/skills/valkey/reference/basics-data-types.md
+++ b/skills/valkey/skills/valkey/reference/basics-data-types.md
@@ -16,8 +16,6 @@ Standard Redis commands (SET, GET, HSET, ZADD, etc.) are assumed known. This fil
 
 `HGETEX key [EX seconds|PX ms|EXAT unix|PXAT unix-ms|PERSIST] FIELDS count field [field ...]` - get fields and optionally set/refresh/remove their TTL atomically.
 
-`HGETDEL key FIELDS count field [field ...]` (Valkey 9.1+) - get fields and delete them atomically.
-
 `HEXPIRE key seconds [NX|XX|GT|LT] FIELDS count field [field ...]` - set per-field TTL (seconds).
 `HPEXPIRE key ms [NX|XX|GT|LT] FIELDS count field [field ...]` - set per-field TTL (milliseconds).
 `HEXPIREAT key unix-seconds [NX|XX|GT|LT] FIELDS count field [field ...]` - absolute expiry (seconds).

--- a/skills/valkey/skills/valkey/reference/basics-data-types.md
+++ b/skills/valkey/skills/valkey/reference/basics-data-types.md
@@ -16,7 +16,7 @@ Standard Redis commands (SET, GET, HSET, ZADD, etc.) are assumed known. This fil
 
 `HGETEX key [EX seconds|PX ms|EXAT unix|PXAT unix-ms|PERSIST] FIELDS count field [field ...]` - get fields and optionally set/refresh/remove their TTL atomically.
 
-`HGETDEL key FIELDS count field [field ...]` - get fields and delete them atomically.
+`HGETDEL key FIELDS count field [field ...]` (Valkey 9.1+) - get fields and delete them atomically.
 
 `HEXPIRE key seconds [NX|XX|GT|LT] FIELDS count field [field ...]` - set per-field TTL (seconds).
 `HPEXPIRE key ms [NX|XX|GT|LT] FIELDS count field [field ...]` - set per-field TTL (milliseconds).

--- a/skills/valkey/skills/valkey/reference/basics-server-and-scripting.md
+++ b/skills/valkey/skills/valkey/reference/basics-server-and-scripting.md
@@ -1,38 +1,34 @@
 # Server Commands - Valkey-Specific Extensions
 
-Use when looking up Valkey-only server and monitoring commands: COMMANDLOG, CLUSTERSCAN, or noting which Lua patterns now have native replacements.
+Use when looking up Valkey-only server and monitoring commands: COMMANDLOG or noting which Lua patterns now have native replacements.
 
 Standard commands (INFO, CONFIG, CLIENT, MULTI/EXEC, EVAL, SCAN) are assumed known. This file covers only what Valkey adds or replaces.
 
 ## COMMANDLOG (Valkey 8.1+)
 
-Replaces SLOWLOG. Tracks slow commands, large payloads, and rejected commands in separate logs.
+Replaces SLOWLOG. Tracks slow commands, oversized requests, and oversized replies in three separate logs.
 
 ```
-COMMANDLOG GET count <slow|large|denied>
-COMMANDLOG LEN <slow|large|denied>
-COMMANDLOG RESET <slow|large|denied>
+COMMANDLOG GET count <slow|large-request|large-reply>
+COMMANDLOG LEN <slow|large-request|large-reply>
+COMMANDLOG RESET <slow|large-request|large-reply>
 ```
 
-Configuration:
+Configuration (thresholds - set to `-1` to disable that type):
 ```
-commandlog-slow-execution-time 10000   # microseconds
-commandlog-max-slow-entries 128
-commandlog-large-request-threshold 1048576   # bytes
-commandlog-max-large-entries 128
-```
-
-SLOWLOG remains available for backward compatibility but COMMANDLOG is the preferred interface.
-
-## CLUSTERSCAN (Valkey 8.0+)
-
-Cluster-wide SCAN across all slots without client-side orchestration.
-
-```
-CLUSTERSCAN cursor [MATCH pattern] [COUNT hint] [TYPE type]
+commandlog-execution-slower-than 10000     # microseconds for slow log
+commandlog-request-larger-than 1048576     # bytes for large-request log
+commandlog-reply-larger-than 1048576       # bytes for large-reply log
 ```
 
-Standard SCAN only covers the local node's keyspace. CLUSTERSCAN iterates across the entire cluster transparently. Use in cluster mode wherever you would use SCAN in standalone mode.
+Per-log retention:
+```
+commandlog-slow-execution-max-len 128
+commandlog-large-request-max-len 128
+commandlog-large-reply-max-len 128
+```
+
+Legacy `slowlog-log-slower-than` and `slowlog-max-len` remain as aliases for the slow log. `SLOWLOG` as a command still works and reads from the same underlying slow log. See `valkey-features-commandlog.md` for full command reference and cluster-mode behavior.
 
 ## Native Replacements for Common Lua Patterns
 

--- a/skills/valkey/skills/valkey/reference/best-practices-cluster-hash-tags.md
+++ b/skills/valkey/skills/valkey/reference/best-practices-cluster-hash-tags.md
@@ -86,11 +86,13 @@ MGET user:1:name user:2:name
 - `EVAL` / `FCALL` with multiple KEYS
 - `COPY`
 
-### Commands That Work Across Slots
+### Commands That Work Across Slots (via Client-Side Fan-Out)
 
-- Any single-key command (`GET`, `SET`, `HGET`, `ZADD`, etc.)
-- `DEL` and `UNLINK` with multiple keys (executed per-slot internally by most clients)
-- `SCAN` / `CLUSTERSCAN` (iterates the whole keyspace or specific nodes)
+The server always rejects a multi-key command whose keys span slots - the slot check in `clusterSlotByCommand` (`src/cluster.c`) is generic across commands. What lets these commands "work" across slots in practice is the **client**: cluster-aware clients split the call by slot and issue one per-slot request.
+
+- Any single-key command (`GET`, `SET`, `HGET`, `ZADD`, etc.) - no fan-out needed.
+- `DEL` / `UNLINK` with multiple keys - cluster clients (valkey-glide, Redisson, cluster-mode ioredis, etc.) group keys by slot and issue a DEL per slot.
+- `SCAN` - per-node iteration. Cluster-aware clients loop over every primary to cover the whole keyspace.
 
 ### Fixing Cross-Slot Issues
 

--- a/skills/valkey/skills/valkey/reference/best-practices-cluster-operations.md
+++ b/skills/valkey/skills/valkey/reference/best-practices-cluster-operations.md
@@ -4,11 +4,11 @@ Use when handling MOVED/ASK redirects, reading from replicas, pipelining in clus
 
 ## Contents
 
-- MOVED and ASK Redirects (line 13)
-- Read-From-Replica Strategies (line 53)
-- Pipelining in Cluster Mode (line 127)
-- SCAN in Cluster Mode (line 159)
-- Quick Reference: Cluster Pitfalls (line 223)
+- MOVED and ASK Redirects
+- Read-From-Replica Strategies
+- Pipelining in Cluster Mode
+- SCAN in Cluster Mode
+- Quick Reference: Cluster Pitfalls
 
 ---
 
@@ -38,7 +38,7 @@ GET user:2000
 
 Meaning: Slot 8901 is being migrated to 10.0.0.3:6379. The client should send `ASKING` followed by the command to the target node - but only for this one request. Future requests still go to the original node until migration completes.
 
-**Valkey 9.0+ note**: Atomic slot migration eliminates ASK redirects. Slots move atomically, so clients only see MOVED redirects after the migration completes.
+**Valkey 9.0+ note**: Atomic slot migration (`CLUSTER MIGRATESLOTS`, 9.0+) moves slots atomically from the client's perspective - no ASK window for that migration. Legacy `CLUSTER SETSLOT MIGRATING/IMPORTING` still uses ASK during manual resharding; which mechanism you see depends on which tooling the operator ran.
 
 ### What Your Client Does
 
@@ -164,21 +164,9 @@ Pipeline depth per-node is what matters. A 100-command pipeline across 3 nodes s
 
 `SCAN` iterates keys on a single node. In a cluster, scan each primary node individually to cover the full keyspace.
 
-### CLUSTERSCAN (Valkey 9.1+)
+### Per-Node SCAN
 
-Valkey provides `CLUSTERSCAN` which handles cluster-wide iteration:
-
-```
-CLUSTERSCAN 0 MATCH user:* COUNT 100
-# Returns: [next_cursor, [key1, key2, ...]]
-# Cursor encodes both node and position - just keep calling until cursor is 0
-```
-
-`CLUSTERSCAN` abstracts per-node iteration. Use when your client supports it.
-
-### Per-Node SCAN (Fallback)
-
-If your client does not support CLUSTERSCAN, iterate each primary node individually:
+Iterate each primary node individually to cover the full cluster keyspace:
 
 **Node.js (ioredis)**:
 ```javascript
@@ -229,7 +217,7 @@ async def cluster_scan(client, pattern: str):
 | Multi-key command without hash tags | CROSSSLOT error | Add `{tag}` prefix to related keys |
 | All data under one hash tag | One node overloaded | Distribute hash tags across entities |
 | Reading stale data from replica | Inconsistent results after write | Use primary reads or WAIT |
-| SCAN missing keys | Partial results | Use CLUSTERSCAN or per-node iteration |
+| SCAN missing keys | Partial results | Iterate every primary node |
 | Large Lua script touching many keys | Slow, blocks node | Limit script to keys in one slot |
 | Pub/Sub in cluster | Messages not received | Use sharded pub/sub (SSUBSCRIBE/SPUBLISH) |
 

--- a/skills/valkey/skills/valkey/reference/best-practices-high-availability.md
+++ b/skills/valkey/skills/valkey/reference/best-practices-high-availability.md
@@ -4,11 +4,11 @@ Use when connecting to Valkey through Sentinel, handling failovers in applicatio
 
 ## Contents
 
-- Connecting via Sentinel (line 16)
-- What Happens During Failover (line 76)
-- Retry Strategies for Connection Drops (line 110)
-- Read-After-Write Consistency (line 195)
-- Architecture Decision: Sentinel vs Cluster (line 263)
+- Connecting via Sentinel
+- What Happens During Failover
+- Retry Strategies for Connection Drops
+- Read-After-Write Consistency
+- Architecture Decision: Sentinel vs Cluster
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/best-practices-keys.md
+++ b/skills/valkey/skills/valkey/reference/best-practices-keys.md
@@ -4,12 +4,12 @@ Use when designing key schemas, diagnosing hot key or big key problems, planning
 
 ## Contents
 
-- Key Naming Conventions (line 17)
-- Avoiding Hot Keys (line 65)
-- Avoiding Big Keys (line 113)
-- Key Expiration Strategies (line 168)
-- Key Analysis Commands (line 205)
-- Quick Reference: Key Anti-Patterns (line 242)
+- Key Naming Conventions
+- Avoiding Hot Keys
+- Avoiding Big Keys
+- Key Expiration Strategies
+- Key Analysis Commands
+- Quick Reference: Key Anti-Patterns
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/best-practices-memory.md
+++ b/skills/valkey/skills/valkey/reference/best-practices-memory.md
@@ -4,14 +4,14 @@ Use when reducing Valkey memory footprint, choosing data structures for space ef
 
 ## Contents
 
-- Memory-Efficient Data Structure Choices (line 19)
-- Hash-Based Storage (line 55)
-- String Encoding Rules (line 116)
-- Bit Operations for Boolean Flags (line 130)
-- TTL Strategies (line 146)
-- Eviction Policies (User Perspective) (line 191)
-- Avoiding Large Values (line 220)
-- Quick Reference: Memory Anti-Patterns (line 242)
+- Memory-Efficient Data Structure Choices
+- Hash-Based Storage
+- String Encoding Rules
+- Bit Operations for Boolean Flags
+- TTL Strategies
+- Eviction Policies (User Perspective)
+- Avoiding Large Values
+- Quick Reference: Memory Anti-Patterns
 
 ---
 
@@ -119,10 +119,10 @@ Strings have implicit encoding rules (not configurable):
 | Condition | Encoding | Memory |
 |-----------|----------|--------|
 | Integer value fitting a `long` | `int` | 8 bytes |
-| String <= 52 bytes | `embstr` | Single allocation (object + data together) |
-| String > 52 bytes | `raw` | Two allocations (pointer + data separately) |
+| String <= 44 bytes | `embstr` | Single allocation (object + data together) |
+| String > 44 bytes | `raw` | Two allocations (pointer + data separately) |
 
-Keep string values under 52 bytes when possible to use `embstr` encoding, which avoids an extra allocation and pointer dereference.
+Keep string values within 44 bytes when possible to use `embstr` encoding (`OBJ_ENCODING_EMBSTR_SIZE_LIMIT` in `src/object.c`), which avoids an extra allocation and pointer dereference.
 
 ---
 
@@ -183,7 +183,7 @@ HEXPIRE user:1000 300 FIELDS 1 csrf_token
 HTTL user:1000 FIELDS 1 csrf_token
 ```
 
-**Memory overhead**: 16-29 bytes per expiring field. No measurable performance regression on standard hash operations.
+**Memory overhead**: per-field TTL adds per-field metadata (the server tracks field expiry state via an ebuckets structure alongside the hash). For memory-sensitive workloads with many volatile fields, benchmark `MEMORY USAGE` against an equivalent TTL-less hash to measure the delta on your data shape.
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/best-practices-performance-commands.md
+++ b/skills/valkey/skills/valkey/reference/best-practices-performance-commands.md
@@ -12,7 +12,7 @@ Still prefer explicit `UNLINK` in code:
 - communicates intent
 - remains non-blocking if someone sets `lazyfree-lazy-user-del no`
 
-Other lazyfree defaults changed in Valkey 8.0: `lazyfree-lazy-eviction`, `lazyfree-lazy-expire`, and `lazyfree-lazy-server-del` also default to `yes`.
+Other lazyfree defaults changed in Valkey 8.0: `lazyfree-lazy-eviction`, `lazyfree-lazy-expire`, `lazyfree-lazy-server-del`, and `lazyfree-lazy-user-flush` also default to `yes` (the whole lazyfree family flipped in one commit).
 
 ## SCAN vs KEYS
 

--- a/skills/valkey/skills/valkey/reference/best-practices-performance-throughput.md
+++ b/skills/valkey/skills/valkey/reference/best-practices-performance-throughput.md
@@ -4,10 +4,10 @@ Use when optimizing Valkey throughput with pipelining, connection pooling, I/O t
 
 ## Contents
 
-- Pipeline Batching (line 13)
-- Connection Pooling (line 107)
-- I/O Threading (User Perspective) (line 157)
-- Quick Reference: Performance Anti-Patterns (line 186)
+- Pipeline Batching
+- Connection Pooling
+- I/O Threading (User Perspective)
+- Quick Reference: Performance Anti-Patterns
 
 ---
 
@@ -170,7 +170,7 @@ Valkey 8.0+ parallelizes network read/write via I/O multithreading while keeping
 
 - High request rates from many concurrent clients
 - Large request/response payloads (more network I/O per command)
-- TLS connections (Valkey 8.1+ offloads TLS to I/O threads - 300% faster connection acceptance)
+- TLS connections (Valkey 8.1+ offloads TLS handshakes to I/O threads, so a burst of new TLS connections no longer monopolizes the main thread)
 
 **When I/O threading does not help**:
 

--- a/skills/valkey/skills/valkey/reference/overview-compatibility.md
+++ b/skills/valkey/skills/valkey/reference/overview-compatibility.md
@@ -4,13 +4,13 @@ Use when migrating from Redis to Valkey, evaluating compatibility of existing ap
 
 ## Contents
 
-- Compatibility Baseline (line 18)
-- What Changes in Migration (line 32)
-- What Does NOT Change (line 57)
-- Migration Strategies (line 73)
-- Incompatible Versions (line 173)
-- Client Library Compatibility (line 185)
-- Application Code Changes (line 206)
+- Compatibility Baseline
+- What Changes in Migration
+- What Does NOT Change
+- Migration Strategies
+- Incompatible Versions
+- Client Library Compatibility
+- Application Code Changes
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/overview-what-is-valkey.md
+++ b/skills/valkey/skills/valkey/reference/overview-what-is-valkey.md
@@ -11,7 +11,7 @@ Valkey forked from Redis 7.2.4 in March 2024 after Redis switched to RSALv2/SSPL
 | License | BSD 3-clause (fully open source) |
 | Governance | Linux Foundation |
 | Forked from | Redis 7.2.4 (March 2024) |
-| Major versions | 8.x (LTS), 9.x (latest) |
+| Major versions | 8.1 and 9.0 actively patched; 9.1 in rc |
 | Protocol | RESP2 / RESP3 (fully compatible) |
 | Default port | 6379 (same as Redis) |
 
@@ -58,8 +58,8 @@ Built-in full-text search, vector search, time series, extended probabilistic st
 |---------|---------|------------|
 | 7.2.x | Inherited | Baseline fork from Redis 7.2.4. Full Redis OSS compatibility. |
 | 8.0 | 2024 | I/O multithreading overhaul (3x throughput), dual-channel replication, command batching. |
-| 8.1 | 2025 | SET IFEQ, new hashtable (20-30 bytes/key savings), COMMANDLOG, TLS I/O offload, iterator prefetch. |
-| 9.0 | 2025 | DELIFEQ, hash field TTL (11 commands), numbered databases in cluster, atomic slot migration, polygon geo queries. Performance: 1B RPS across 2,000 nodes, pipeline memory prefetch (40% higher throughput), zero-copy responses (20% gain), MPTCP (25% latency reduction), SIMD for BITCOUNT/HyperLogLog (200% gain). Un-deprecated 25 commands. |
-| 9.1 | 2025 | HGETDEL (atomic get-and-delete for hash fields). |
+| 8.1 | 2025 | SET IFEQ, new cache-line-sized hashtable (memory and cache efficient), COMMANDLOG, TLS I/O offload, iterator prefetch. |
+| 9.0 | 2025 | DELIFEQ, hash field TTL (11 commands), numbered databases in cluster, atomic slot migration, polygon geo queries. Performance: pipeline memory prefetch, copy-avoidance on response path, MPTCP, SIMD for BITCOUNT/HyperLogLog. Un-deprecated 23 commands. |
+| 9.1 (rc1) | 2026 | Not yet GA. Adds HGETDEL, MSETEX, CLUSTERSCAN, NX/XX on HSETEX, database-level ACL, Lua scripting engine as a module, cross-node SCAN consistency, automatic TLS reload, TLS SAN URI auth, CLUSTER KEYSLOT in standalone. |
 
 

--- a/skills/valkey/skills/valkey/reference/overview-what-is-valkey.md
+++ b/skills/valkey/skills/valkey/reference/overview-what-is-valkey.md
@@ -11,7 +11,7 @@ Valkey forked from Redis 7.2.4 in March 2024 after Redis switched to RSALv2/SSPL
 | License | BSD 3-clause (fully open source) |
 | Governance | Linux Foundation |
 | Forked from | Redis 7.2.4 (March 2024) |
-| Major versions | 8.1 and 9.0 actively patched; 9.1 in rc |
+| Major versions | 8.1 and 9.0 actively patched |
 | Protocol | RESP2 / RESP3 (fully compatible) |
 | Default port | 6379 (same as Redis) |
 
@@ -37,7 +37,6 @@ Redis 8+ uses RSALv2/SSPL, which restricts offering Redis as a managed service o
 | Numbered databases in cluster | 9.0+ | SELECT 0-15 works in cluster mode |
 | Atomic slot migration | 9.0+ | Entire slots migrate atomically, not key by key |
 | Polygon geospatial queries | 9.0+ | GEOSEARCH BYPOLYGON support |
-| HGETDEL | 9.1+ | Get hash field values and delete them atomically |
 | COMMANDLOG | 8.1+ | Extended slow log tracking large requests and replies |
 
 ### Performance work since the fork
@@ -60,6 +59,5 @@ Built-in full-text search, vector search, time series, extended probabilistic st
 | 8.0 | 2024 | I/O multithreading overhaul (3x throughput), dual-channel replication, command batching. |
 | 8.1 | 2025 | SET IFEQ, new cache-line-sized hashtable (memory and cache efficient), COMMANDLOG, TLS I/O offload, iterator prefetch. |
 | 9.0 | 2025 | DELIFEQ, hash field TTL (11 commands), numbered databases in cluster, atomic slot migration, polygon geo queries. Performance: pipeline memory prefetch, copy-avoidance on response path, MPTCP, SIMD for BITCOUNT/HyperLogLog. Un-deprecated 23 commands. |
-| 9.1 (rc1) | 2026 | Not yet GA. Adds HGETDEL, MSETEX, CLUSTERSCAN, NX/XX on HSETEX, database-level ACL, Lua scripting engine as a module, cross-node SCAN consistency, automatic TLS reload, TLS SAN URI auth, CLUSTER KEYSLOT in standalone. |
 
 

--- a/skills/valkey/skills/valkey/reference/patterns-caching-invalidation.md
+++ b/skills/valkey/skills/valkey/reference/patterns-caching-invalidation.md
@@ -11,7 +11,7 @@ Valkey notifies clients when a tracked key changes, enabling precise cache inval
 CLIENT TRACKING ON BCAST PREFIX cache:
 ```
 
-In RESP3 (default for GLIDE 2.x), invalidation messages arrive on the same connection. In RESP2, use a separate invalidation channel with `REDIRECT <client-id>`.
+In RESP3, invalidation messages arrive on the same connection. In RESP2, use a separate invalidation channel with `REDIRECT <client-id>`.
 
 `BCAST` mode broadcasts invalidations for all keys matching PREFIX patterns - no per-key tracking overhead. Use for shared caches accessed by multiple clients.
 
@@ -24,7 +24,7 @@ Set via `maxmemory-policy`. Valkey defaults unchanged from Redis 7:
 - `volatile-lru` - mixed persistent + cache data
 - `noeviction` - reject writes when full (use for non-cache data)
 
-`allkeys-lru` is more memory-efficient than `volatile-lru` - no TTL metadata overhead per key.
+With `allkeys-lru` you do not need to set TTLs to make keys evictable - skipping the per-TTL-key entry in the `expires` table saves memory compared to a `volatile-lru` deployment that requires every cache key to carry a TTL.
 
 ## TTL Patterns
 

--- a/skills/valkey/skills/valkey/reference/patterns-caching-strategies.md
+++ b/skills/valkey/skills/valkey/reference/patterns-caching-strategies.md
@@ -4,10 +4,10 @@ Use when implementing a caching layer with Valkey - choosing between cache-aside
 
 ## Contents
 
-- Cache-Aside (Lazy Loading) (line 13)
-- Write-Through (line 100)
-- Write-Behind (Write-Back) (line 126)
-- Client-Side Caching (CLIENT TRACKING) (line 142)
+- Cache-Aside (Lazy Loading)
+- Write-Through
+- Write-Behind (Write-Back)
+- Client-Side Caching (CLIENT TRACKING)
 
 ---
 
@@ -244,7 +244,6 @@ CLIENT TRACKING ON NOLOOP
 |--------|---------|
 | valkey-go | Yes (server-assisted) |
 | redisson | Yes |
-| valkey-glide | Not yet (planned) |
 | iovalkey / ioredis | No |
 | valkey-py / redis-py | No |
 

--- a/skills/valkey/skills/valkey/reference/patterns-counters-approximate.md
+++ b/skills/valkey/skills/valkey/reference/patterns-counters-approximate.md
@@ -4,7 +4,7 @@ Use when counting unique elements with HyperLogLog, packing compact counters wit
 
 ## HyperLogLog for Approximate Unique Counting
 
-HyperLogLog counts unique elements with 0.81% standard error using 12 KB of memory - whether counting 100 or 100 million unique elements.
+HyperLogLog counts unique elements with 0.81% standard error using up to 12 KB of memory at full cardinality. Small counts use a sparse encoding and take much less - a fresh HLL with ~100 unique elements is dozens of bytes, not 12 KB. It auto-promotes to dense once the sparse encoding runs out of space.
 
 ### When to Use
 
@@ -23,10 +23,15 @@ PFADD visitors:2026-03-29 "user:100"    # duplicate, ignored
 PFCOUNT visitors:2026-03-29
 # (integer) 3
 
-# Merge multiple days for weekly count
+# Merge multiple days for weekly count (creates a new HLL key)
 PFMERGE visitors:week:13 visitors:2026-03-29 visitors:2026-03-28 visitors:2026-03-27
 PFCOUNT visitors:week:13
+
+# Or: on-the-fly merge without creating a destination key
+PFCOUNT visitors:2026-03-29 visitors:2026-03-28 visitors:2026-03-27
 ```
+
+**Read-routing note.** `PFCOUNT` is `READONLY` at the command level but `RW` at the key-spec level - it may mutate the HLL (caching cardinality in the header) and propagate to replicas. Treat it as write-path for cluster read-routing decisions and ACLs that forbid writes.
 
 ### Node.js
 
@@ -116,6 +121,10 @@ BITFIELD key OVERFLOW SAT INCRBY u8 #0 1
 BITFIELD key OVERFLOW FAIL INCRBY u8 #0 1
 ```
 
+### Type-width limits
+
+Signed integers go up to `i64`. **Unsigned integers max out at `u63`, not `u64`** - `BITFIELD key INCRBY u64 #0 1` errors with *"Invalid bitfield type. Note that u64 is not supported but i64 is."* RESP can't reliably represent unsigned integers above `INT64_MAX`, so for 64-bit counters use `i64` or stay at `u63` max.
+
 ---
 
 ## Deduplication
@@ -131,7 +140,7 @@ SET dedup:event:evt-abc123 1 NX EX 86400
 # nil -> duplicate, skip it
 ```
 
-### SISMEMBER for Set-Based Deduplication
+### SMISMEMBER for Set-Based Deduplication
 
 When you need to check many items against a known set:
 
@@ -148,7 +157,12 @@ When exact deduplication uses too much memory (millions of event IDs), Bloom fil
 Requires the valkey-bloom module.
 
 ```
-# Create filter: 0.01% false positive rate, 1M expected elements
+# Bounded memory: filter rejects new adds past capacity (BF.ADD returns 0 or errors).
+BF.RESERVE dedup:events 0.0001 1000000 NONSCALING
+
+# Default (scaling): filter grows by adding sub-filters past capacity.
+# The 0.0001 error rate only applies to the first sub-filter -
+# effective FPR compounds across sub-filters, and memory is unbounded.
 BF.RESERVE dedup:events 0.0001 1000000
 
 # Add and check
@@ -161,6 +175,8 @@ BF.EXISTS dedup:events "evt-abc123"
 BF.EXISTS dedup:events "evt-never-seen"
 # (integer) 0 -> definitely does not exist
 ```
+
+Full syntax: `BF.RESERVE key error_rate capacity [EXPANSION n] [NONSCALING]`. Pick `NONSCALING` when the stated error rate must hold for the life of the filter; use default scaling (optionally with `EXPANSION`) when capacity uncertainty matters more than FPR stability.
 
 Bloom filters never have false negatives. `BF.EXISTS` returning 0 means the element was definitely never added. Returning 1 means it was probably added (configurable false positive rate).
 

--- a/skills/valkey/skills/valkey/reference/patterns-counters-atomic.md
+++ b/skills/valkey/skills/valkey/reference/patterns-counters-atomic.md
@@ -2,17 +2,9 @@
 
 Use when implementing atomic counters, sharded counters for high-throughput hot keys, or idempotency keys to prevent duplicate processing.
 
-## Contents
-
-- Atomic Counters (line 13)
-- Sharded Counters (line 81)
-- Idempotency Keys (line 146)
-
----
-
 ## Atomic Counters
 
-`INCR`, `INCRBY`, and `INCRBYFLOAT` are atomic single-key operations. No race conditions, no read-modify-write cycles.
+`INCR`, `INCRBY`, `DECR`, `DECRBY`, and `INCRBYFLOAT` are atomic single-key operations. No race conditions, no read-modify-write cycles.
 
 ### Basic Counter
 
@@ -23,12 +15,18 @@ INCR page:views:homepage
 INCRBY page:views:homepage 5
 # (integer) 6
 
-INCRBYFLOAT account:balance:42 19.99
-# "25.99"
+INCRBYFLOAT metric:temperature:avg 19.99
+# "19.99"  (new key starts at 0, then adds 19.99)
 
 DECR page:views:homepage
 # (integer) 5
 ```
+
+### Overflow and precision limits
+
+- **INCR / INCRBY / DECR / DECRBY** operate on 64-bit signed integers (`LLONG_MIN .. LLONG_MAX`, roughly `-9.22 × 10^18 .. 9.22 × 10^18`). An operation that would cross the boundary returns `increment or decrement would overflow` - the counter does NOT silently wrap. Plan a rotation strategy (key-per-window + EXPIRE) for long-running counters that could exhaust int64.
+- **INCRBYFLOAT** uses `long double` accumulation. It errors only on NaN / Infinity results, not on magnitude. But repeated fractional additions drift (the classic `0.1 + 0.2 ≠ 0.3`). **Don't use INCRBYFLOAT for money.** Store the smallest currency unit (cents, satoshis) as an integer and use INCRBY; that's both exact and matches financial-rounding conventions.
+- **Replication rewrite**: INCRBYFLOAT propagates to replicas and AOF as `SET <key> <final_value> KEEPTTL` - the float math happens once on the primary and the replica just stores the result. Operators grepping replication or AOF for `INCRBYFLOAT` won't find it under that name.
 
 ### Node.js
 
@@ -80,18 +78,23 @@ Safe because EXPIRE on an existing key just resets the TTL (acceptable for windo
 
 ## Sharded Counters
 
-A single key receiving thousands of increments per second becomes a hot key - the main thread processes all writes sequentially, creating a bottleneck.
+A single key receiving tens of thousands of increments per second becomes a hot key. Even though each `INCR` is O(1), they all serialize on the single object and its replication stream - you can't parallelize writes to one key.
 
-Sharded counters distribute writes across N keys and sum on read.
+Sharded counters distribute writes across N **distinct keys** and sum on read. The goal is avoiding the single-key bottleneck, not cluster-node distribution - two separate concerns:
+
+- **Avoid the hot-key bottleneck**: N keys → N independent objects → writes parallelize (even within a single node).
+- **Distribute across cluster nodes**: only matters when one node can't keep up with aggregate traffic.
+
+You usually want the first; the second is rarer. The examples below put the counter name inside a single shared hash tag (`counter:{pageviews}:N`) so every shard hashes to the same slot - that keeps the hot-key fix while letting one `MGET` read all shards. Drop the hash tag only if you need genuine cross-node fan-out (and accept the MGET-per-slot complexity on read - see below).
 
 ### How It Works
 
 ```
 # Write: pick a random shard (0-15)
-INCRBY counter:pageviews:{shard:7} 1
+INCRBY counter:{pageviews}:7 1
 
-# Read: sum all shards
-MGET counter:pageviews:{shard:0} counter:pageviews:{shard:1} ... counter:pageviews:{shard:15}
+# Read: sum all shards (all land on the same slot because the hash tag is "pageviews")
+MGET counter:{pageviews}:0 counter:{pageviews}:1 ... counter:{pageviews}:15
 # Sum the results client-side
 ```
 
@@ -102,12 +105,12 @@ const SHARD_COUNT = 16;
 
 async function incrementSharded(redis, name) {
   const shard = Math.floor(Math.random() * SHARD_COUNT);
-  return redis.incr(`counter:${name}:{shard:${shard}}`);
+  return redis.incr(`counter:{${name}}:${shard}`);
 }
 
 async function getShardedCount(redis, name) {
   const keys = Array.from({ length: SHARD_COUNT },
-    (_, i) => `counter:${name}:{shard:${i}}`
+    (_, i) => `counter:{${name}}:${i}`
   );
   const values = await redis.mget(...keys);
   return values.reduce((sum, v) => sum + (parseInt(v) || 0), 0);
@@ -123,10 +126,10 @@ SHARD_COUNT = 16
 
 async def increment_sharded(redis, name: str):
     shard = random.randint(0, SHARD_COUNT - 1)
-    return await redis.incr(f'counter:{name}:{{shard:{shard}}}')
+    return await redis.incr(f'counter:{{{name}}}:{shard}')
 
 async def get_sharded_count(redis, name: str) -> int:
-    keys = [f'counter:{name}:{{shard:{i}}}' for i in range(SHARD_COUNT)]
+    keys = [f'counter:{{{name}}}:{i}' for i in range(SHARD_COUNT)]
     values = await redis.mget(*keys)
     return sum(int(v) for v in values if v is not None)
 ```
@@ -139,7 +142,7 @@ async def get_sharded_count(redis, name: str) -> int:
 | 10K-100K writes/sec | Shard to 8-16 keys |
 | > 100K writes/sec | Shard to 32-64 keys, consider client-side batching |
 
-**Cluster note**: The `{shard:N}` hash tag in the examples above co-locates all shards on the same node, allowing MGET to work. If you want to distribute load across cluster nodes, remove the hash tags - but then you must read each shard individually or use a pipeline.
+**Cluster read without hash tags**: If you drop the hash tags to spread shards across cluster nodes, you lose atomic `MGET` across them (cross-slot error). Replace the MGET with a client-side fan-out: group shard keys by slot, issue one `MGET` per slot in a pipeline, and sum the results. A cluster-aware GLIDE or smart-client library can do this automatically with per-shard pipelines.
 
 ---
 
@@ -168,18 +171,24 @@ async function executeIdempotent(redis, operationId, fn) {
   // Try to claim
   const claimed = await redis.set(key, 'processing', 'NX', 'EX', 3600);
   if (!claimed) {
-    // Already processed or in progress - return cached result
+    // Another caller already claimed this operation.
     const cached = await redis.get(key);
-    return cached === 'processing' ? null : JSON.parse(cached);
+    // cached === 'processing' means the other worker is still running
+    // (or finished in the brief window between our SET NX and GET).
+    // Caller responsibility: back off and retry until the cached value is the final JSON.
+    if (cached === null || cached === 'processing') return null;
+    return JSON.parse(cached);
   }
 
   try {
     const result = await fn();
-    // Store result for future lookups
+    // Store result for future lookups (XX = only update the existing claim)
     await redis.set(key, JSON.stringify(result), 'XX', 'EX', 86400);
     return result;
   } catch (err) {
-    // On failure, remove claim so retry can proceed
+    // On failure, remove claim so retry can proceed.
+    // Prefer DELIFEQ (9.0+) so you only delete if the claim is still yours:
+    //   DELIFEQ idempotent:<operationId> "processing"
     await redis.del(key);
     throw err;
   }

--- a/skills/valkey/skills/valkey/reference/patterns-leaderboards.md
+++ b/skills/valkey/skills/valkey/reference/patterns-leaderboards.md
@@ -4,16 +4,17 @@ Use when building real-time ranking systems, game leaderboards, top-N lists, or 
 
 ## Core Pattern
 
-Sorted sets are the standard structure: ZADD to add/update scores, ZINCRBY to increment atomically, ZREVRANK for rank (0-indexed), ZREVRANGE for top-N, ZSCORE for a member's score. All rank operations are O(log N).
+Sorted sets are the standard structure: ZADD to add/update scores, ZINCRBY to increment atomically, ZREVRANK for rank (0-indexed), `ZRANGE ... REV` for top-N, ZSCORE for a member's score. All rank operations are O(log N).
 
 ```
 ZADD leaderboard 2500 "player:alice"
 ZINCRBY leaderboard 100 "player:alice"
-ZREVRANK leaderboard "player:alice"    # 0 = top rank
-ZREVRANGE leaderboard 0 9 WITHSCORES  # top 10
+ZREVRANK leaderboard "player:alice"        # 0 = top rank
+ZRANGE leaderboard 0 9 REV WITHSCORES      # top 10 (preferred form since 6.2)
+ZREVRANGE leaderboard 0 9 WITHSCORES       # legacy equivalent, still supported
 ```
 
-Paginate with offsets. For "around me" views, compute `ZREVRANK` then `ZREVRANGE start end`.
+Paginate with offsets. For "around me" views, compute `ZREVRANK`, then `ZRANGE leaderboard start end REV`.
 
 Aggregate daily buckets with `ZUNIONSTORE ... AGGREGATE SUM`. Use `EXPIRE` on time-bucketed keys to auto-clean.
 

--- a/skills/valkey/skills/valkey/reference/patterns-locks.md
+++ b/skills/valkey/skills/valkey/reference/patterns-locks.md
@@ -2,17 +2,6 @@
 
 Use when implementing mutual exclusion across distributed services, preventing duplicate processing, or coordinating access to shared resources.
 
-## Contents
-
-- Simple Lock (Single Instance) (line 17)
-- Lock Extension (Renewal) (line 107)
-- Redlock (Distributed Multi-Instance) (line 158)
-- Fencing Tokens (line 230)
-- Lock Anti-Patterns (line 251)
-- Retry Strategy (line 264)
-
----
-
 ## Simple Lock (Single Instance)
 
 The fundamental building block: a key that represents ownership of a resource.
@@ -114,6 +103,8 @@ SET lock:resource <my_random_value> IFEQ <my_random_value> PX 30000
 # IFEQ = only if key exists AND current value matches
 ```
 
+**Handling the reply**: IFEQ aborts (returns `nil`) in two cases - value mismatch (someone else holds the lock) **or** the key is missing (your lock already expired). IFEQ never creates a missing key. Either way, `nil` means "you no longer own this lock" - stop the protected work and bail out. A worker that ignores a `nil` renewal will keep operating on a resource a competing client now owns.
+
 **Pre-8.1 (Lua script)**:
 ```lua
 if server.call('GET', KEYS[1]) == ARGV[1] then
@@ -193,9 +184,11 @@ This is why Redlock uses N independent primaries instead of replicated instances
 
 ### When NOT to Use Redlock
 
-- A single Valkey instance with Sentinel failover is sufficient for most use cases
-- The lock protects an idempotent operation (duplicate execution is harmless)
-- Performance matters more than strict mutual exclusion
+- The lock protects an idempotent operation (duplicate execution is harmless - a single instance is fine)
+- Best-effort exclusion is acceptable (rate-limiting, deduplicating "mostly unique" work) - a single primary is enough
+- Performance matters more than strict mutual exclusion - Redlock's majority contact adds round-trips
+
+Note: Sentinel failover on a single replicated deployment does **not** give you Redlock-grade safety. Replication is asynchronous, so the failure mode in "Why Replication Alone Is Unsafe" above applies. If you need true mutual exclusion across a primary crash, you need Redlock (or a CP coordination system like ZooKeeper/etcd).
 
 ### Crash Recovery Considerations
 
@@ -206,11 +199,19 @@ This is why Redlock uses N independent primaries instead of replicated instances
 
 ### Retry Strategy
 
-On failure, retry with a random delay to desynchronize competing clients. Use multiplexing to contact all N instances simultaneously rather than sequentially.
+On failure, retry with a random delay to desynchronize competing clients. The canonical algorithm contacts instances **sequentially** with a small per-instance timeout, so one slow node can't stall the whole acquisition (the timeout trips and you move on). Some libraries parallelize the fan-out; this is an implementation trade-off - parallel is faster but harder to reason about when partial failures interact with the elapsed-time check in step 3.
+
+### Unlocking
+
+To release, issue `DELIFEQ lock:resource <your_random_value>` on every instance you contacted (including ones whose acquire reply you're unsure about - network glitches can leave "maybe acquired" state).
+
+**A `0` reply from any instance is expected, not an error.** It means either the lock already expired there, or a different owner now holds it - from this client's perspective that instance is released. Continue through the remaining instances without retrying the `0` one.
 
 ### Lock Extension
 
-For long-running operations, extend the lock by sending a Lua script to all instances that extends the TTL if the key exists with the correct random value. Only consider the lock extended if a majority succeeded within the validity time. Limit reacquisition attempts to preserve liveness.
+For long-running operations, extend the lock by sending `SET key value IFEQ value PX new_ttl` (8.1+) to all instances - same semantics as the classic Lua extend-if-owner script, one round-trip. Consider the lock extended only if a majority succeeded within the remaining validity time. Limit reacquisition attempts to preserve liveness.
+
+Pre-8.1: send the extend-if-owner Lua script (`if server.call('GET', K) == V then return server.call('PEXPIRE', K, T) else return 0 end`).
 
 ### Implementation Libraries
 
@@ -232,14 +233,26 @@ Locks can fail silently: a client holds a lock, pauses (GC, network delay), the 
 
 A fencing token prevents this: each lock acquisition increments a monotonic counter, and the protected resource rejects operations with a token older than the last seen.
 
-```
-# Acquire lock and get fencing token
-SET lock:resource <random_value> NX PX 30000
-token = INCR lock:resource:fencing_token
+The acquire + INCR must be **atomic** - otherwise you can acquire the lock but fail the INCR (partition, timeout), or burn a token without getting the lock, and the downstream will see out-of-order or missing tokens.
 
-# When writing to the protected resource, pass the token
-# The resource server verifies: token >= last_seen_token
+**Atomic acquire + token, single round-trip (Lua)**:
+
+```lua
+-- KEYS[1] = lock key, KEYS[2] = token counter key
+-- ARGV[1] = random value, ARGV[2] = TTL ms
+if server.call('SET', KEYS[1], ARGV[1], 'NX', 'PX', ARGV[2]) then
+    return server.call('INCR', KEYS[2])
+else
+    return nil  -- did not acquire; do not bump token
+end
 ```
+
+Usage (result is the fencing token, or `nil` if the lock was already held):
+```
+EVAL "..." 2 lock:resource lock:resource:fencing_token <random_value> 30000
+```
+
+When writing to the protected resource, pass the token. The resource server verifies `token >= last_seen_token` before applying the operation.
 
 Fencing requires the downstream resource (database, API) to support token validation. Not all systems can do this.
 

--- a/skills/valkey/skills/valkey/reference/patterns-pubsub-patterns.md
+++ b/skills/valkey/skills/valkey/reference/patterns-pubsub-patterns.md
@@ -4,12 +4,12 @@ Use when implementing real-time messaging, event broadcasting, or notification s
 
 ## Contents
 
-- Fan-Out Messaging (line 17)
-- Sharded Pub/Sub (Cluster Mode) (line 82)
-- Keyspace Notifications (line 123)
-- Pub/Sub vs Streams Comparison (line 214)
-- Channel Naming Patterns (line 243)
-- Production Tips (line 277)
+- Fan-Out Messaging
+- Sharded Pub/Sub (Cluster Mode)
+- Keyspace Notifications
+- Pub/Sub vs Streams Comparison
+- Channel Naming Patterns
+- Production Tips
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/patterns-queues-streams.md
+++ b/skills/valkey/skills/valkey/reference/patterns-queues-streams.md
@@ -4,9 +4,9 @@ Use when implementing robust task queues with consumer groups, message acknowled
 
 ## Contents
 
-- Stream-Based Queue (XADD/XREADGROUP) (line 13)
-- Comparison Table (line 187)
-- Priority Queue (line 229)
+- Stream-Based Queue (XADD/XREADGROUP)
+- Comparison Table
+- Priority Queue
 
 ---
 
@@ -240,8 +240,9 @@ ZADD queue:priority 10 '{"type":"low","task":"cleanup"}'
 ZPOPMIN queue:priority
 # Returns: ['{"type":"critical",...}', "1"]
 
-# Blocking variant
+# Blocking variant (accepts multiple keys; returns [key, member, score])
 BZPOPMIN queue:priority 30
+# Returns: ["queue:priority", '{"type":"critical",...}', "1"]
 ```
 
 ---

--- a/skills/valkey/skills/valkey/reference/patterns-rate-limiting-advanced.md
+++ b/skills/valkey/skills/valkey/reference/patterns-rate-limiting-advanced.md
@@ -63,10 +63,9 @@ async function tokenBucketCheck(userId, maxTokens, refillRate) {
 
 | Strength | Weakness |
 |----------|----------|
-| Allows controlled bursts | More complex implementation |
-| Smooth rate limiting | Requires Lua script for atomicity |
+| Allows controlled bursts | Requires a Lua script for atomicity |
+| Smooth rate limiting | Script blocks the main thread during execution |
 | Configurable burst capacity and sustained rate | Two fields per user key |
-| Industry standard (used by AWS, Google, Stripe) | Script blocks server during run |
 
 ---
 
@@ -80,35 +79,40 @@ One hash per user. Each field represents an endpoint/action with a request count
 
 ### Implementation
 
+Branching pattern: try to create the counter with a TTL; if it already exists, increment.
+
 ```
-# First request to /api/orders - create field with 60-second TTL
+# Attempt to create the field with value=1 and a 60s TTL.
+# FNX = "set only if the field does not already exist".
+# Reply: 1 if created (this request was the first in the window),
+#        0 if the field was already there.
 HSETEX rate:user:42 FNX EX 60 FIELDS 1 /api/orders 1
 
-# Subsequent requests - increment the counter
-HINCRBY rate:user:42 /api/orders 1
+# If the HSETEX above returned 0 (field exists):
+#   HINCRBY returns the new count directly - no follow-up HGET needed.
+#   HINCRBY preserves the field's existing TTL, so the window keeps ticking down.
+count = HINCRBY rate:user:42 /api/orders 1
 
-# Check if limit exceeded
-count = HGET rate:user:42 /api/orders
 if count > limit: reject request
 
-# Check TTL remaining on the field
+# Optional: check remaining TTL (useful for X-RateLimit-Reset)
 HTTL rate:user:42 FIELDS 1 /api/orders
 ```
+
+**Post-increment rejection**: the increment has already persisted by the time you reject. A client hammering the endpoint while over the limit still bumps the counter higher for the rest of the window. That's fine for access-control use cases (still rejected) but fragile if the counter is also used for billing or SLA metrics - use the token-bucket pattern above if you need check-before-consume.
+
+**HINCRBY replicates as HSETEX when the hash has volatile fields.** Replicas and AOF see `HSETEX ... PXAT ... FIELDS 1 <field> <new_value>`, not `HINCRBY`. Operators grepping AOF for the increment won't find it under that name.
 
 ### Trade-offs
 
 | Strength | Weakness |
 |----------|----------|
 | All rate limits for a user in one key | Requires Valkey 9.0+ |
-| Fields auto-expire independently | HINCRBY does not set a TTL - must set TTL on first request |
-| Low memory - no sorted sets or Lua scripts | Same boundary problem as fixed window |
-| Easy per-endpoint inspection with HGETALL | HSET strips field TTLs - use HSETEX with KEEPTTL for updates |
+| Fields auto-expire independently | Fixed-window boundary problem (2x burst at boundary) |
+| Low memory - no sorted sets or Lua scripts | Two-command protocol: HSETEX FNX then HINCRBY |
+| HINCRBY preserves field TTL - counts tick toward the existing expiry | `HSET` strips field TTLs - use `HSETEX ... KEEPTTL` for in-place value updates |
 
-**Tip**: Combine with HGETEX to read the count and refresh the TTL in one atomic command for sliding-window-like behavior:
-
-```
-HGETEX rate:user:42 EX 60 FIELDS 1 /api/orders
-```
+**Sliding-window variant**: if you want the TTL to restart on every hit (so a steady stream of requests never expires the counter), replace `HINCRBY` with `HGETEX EX 60 ... ; HINCRBY ...` or use a script. Note this is **not** a true sliding window - it's an access-refreshed fixed window, which can let a steady 1-req/sec stream hold the counter open indefinitely.
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/patterns-rate-limiting-windows.md
+++ b/skills/valkey/skills/valkey/reference/patterns-rate-limiting-windows.md
@@ -12,10 +12,9 @@ Three standard patterns exist, all using generic Redis/Valkey commands:
 
 All three are standard Redis patterns. A model already trained on Redis knows the implementation.
 
-## Valkey-Specific Approaches
+## Beyond Window-Based
 
-For production rate limiting with Valkey, see `patterns-rate-limiting-advanced.md`, which covers:
+For production rate limiting on Valkey, see `patterns-rate-limiting-advanced.md`, which covers:
 
-- Script-free atomic check-and-increment using `SET IFEQ`
-- Token bucket and leaky bucket implementations
-- Distributed rate limiting across cluster nodes with `CLUSTERSCAN`
+- **Token bucket** (Lua script) - bursts up to a cap, sustained refill rate
+- **Per-endpoint rate limits in one hash** using Valkey 9.0+ hash-field TTL - separate windows for each API route under a single user key

--- a/skills/valkey/skills/valkey/reference/patterns-search-autocomplete.md
+++ b/skills/valkey/skills/valkey/reference/patterns-search-autocomplete.md
@@ -4,7 +4,7 @@ Use when building prefix autocomplete, tag filtering, or lightweight search with
 
 ## Prefix Autocomplete
 
-Store terms with score 0, query by prefix with `ZRANGEBYLEX`. Preferred modern syntax (Valkey 6.2+):
+Store terms with score 0 so sorted-set order is purely lexicographic. Query by prefix with `ZRANGE ... BYLEX` (the canonical form since 6.2; the legacy `ZRANGEBYLEX` still works):
 
 ```
 ZADD autocomplete 0 "apple"

--- a/skills/valkey/skills/valkey/reference/patterns-sessions-basics.md
+++ b/skills/valkey/skills/valkey/reference/patterns-sessions-basics.md
@@ -33,4 +33,4 @@ This approach works and is well understood, but expiry is all-or-nothing on the 
 
 For granular control - expire individual fields (tokens, temporary claims) independently of the session itself - use per-field TTL commands.
 
-See `patterns-sessions-field-expiry.md` for `HSETEX`, `HGETEX`, `HGETDEL`, `HEXPIRE`, and complete patterns.
+See `patterns-sessions-field-expiry.md` for `HSETEX`, `HGETEX`, `HEXPIRE`, and complete patterns.

--- a/skills/valkey/skills/valkey/reference/patterns-sessions-basics.md
+++ b/skills/valkey/skills/valkey/reference/patterns-sessions-basics.md
@@ -20,7 +20,11 @@ EXPIRE session:abc123 1800
 # 1. HGETALL old key
 # 2. HSET new key + EXPIRE
 # 3. UNLINK old key
-# Pipeline steps 2-3 for atomicity
+# Use MULTI/EXEC or a Lua script for atomicity on steps 2-3 - pipelining
+# alone does not prevent another client from seeing the intermediate state
+# (both keys present, or neither, depending on ordering). In cluster mode,
+# co-locate old and new keys on the same slot via a hash tag,
+# e.g. session:{user:1000}:abc123 and session:{user:1000}:xyz789.
 ```
 
 This approach works and is well understood, but expiry is all-or-nothing on the whole key.

--- a/skills/valkey/skills/valkey/reference/patterns-sessions-field-expiry.md
+++ b/skills/valkey/skills/valkey/reference/patterns-sessions-field-expiry.md
@@ -93,13 +93,15 @@ Eliminates the two-command pipeline (HMGET + HEXPIRE). Each field's TTL is indep
 
 ### Gotchas for Per-Field TTL in Sessions
 
-1. **HSET strips field TTL**: Plain HSET on a field with TTL removes the expiration. Always use HSETEX with KEEPTTL when updating volatile fields.
-2. **Field-level EXPIRE is not key-level EXPIRE**: HEXPIRE sets TTL on fields, not on the key itself. Set a key-level EXPIRE as a safety net so the entire session is cleaned up eventually.
-3. **Expired fields are cleaned up by periodic job**: Not instantly. Between logical expiry and physical deletion, HLEN may count expired fields.
+1. **HSET strips field TTL.** Plain HSET on a field with TTL removes the expiration. Use `HSETEX ... KEEPTTL FIELDS n field value` when updating a volatile field's value while preserving its existing TTL.
 
-### Memory Overhead
+2. **Field-level expiration is not key-level expiration.** HEXPIRE sets TTL on fields, not on the key itself. Set a key-level `EXPIRE` as a safety net so the entire session is cleaned up eventually - if every field is persistent and the key has no TTL, the session lives forever.
 
-16-29 bytes per expiring field. No measurable performance regression. Negligible compared to splitting across multiple keys (~70-80 bytes metadata per key).
+3. **HLEN doesn't filter expired fields.** HLEN returns the physical count and will include fields whose TTL has passed but haven't been swept yet. `HGETALL`, `HKEYS`, `HVALS`, `HSCAN` **do** filter expired fields. For an accurate live-field count, iterate with HKEYS and take its length. A field that HGETALL doesn't return may still contribute to HLEN until the next sweep.
+
+4. **HSETEX creates the hash key if it's missing.** A "refresh the CSRF token" write to a logged-out session will silently re-create the session key with just the CSRF field. Gate refresh writes on `EXISTS <session_key>` first when the hash lifecycle matters. (9.1+ adds `[NX|XX]` on HSETEX at the key level; in 9.0 you need the explicit `EXISTS` gate.)
+
+5. **Expired-but-not-swept fields briefly visible.** Between logical expiry and the next lazy/active sweep, HLEN and some edge cases may see the field. If you need strict "is this field alive right now," use `HTTL` - its reply codes already distinguish live / no-TTL / missing.
 
 ---
 
@@ -160,10 +162,10 @@ async def enforce_session_limit(user_id: int, max_sessions: int = 5):
 
 ## Production Tips
 
-- **Generate cryptographically random session IDs** - use 128+ bits of randomness
-- **Never expose internal session structure** in API responses
-- **Use `HMGET` instead of `HGETALL`** when you only need specific fields
-- **Pipeline session read + TTL refresh** to save a round-trip
-- **Set key-level TTL even with per-field expiration** as a safety net - the key TTL is the absolute upper bound
+- **Generate cryptographically random session IDs** - use 128+ bits of randomness.
+- **Never expose internal session structure** in API responses.
+- **For pure reads**, use `HGET` (one field) or `HMGET` (several) - neither touches the field's TTL.
+- **For read-and-refresh in one call**, use `HGETEX key EX <seconds> FIELDS n <fields...>`. Replaces the old HMGET + HEXPIRE pipeline; atomic and one round-trip.
+- **Set a key-level TTL even with per-field expiration** as a safety net - the key TTL is the absolute upper bound. If every field is persistent and the key has no TTL, the session never ends.
 
 ---

--- a/skills/valkey/skills/valkey/reference/patterns-sessions-field-expiry.md
+++ b/skills/valkey/skills/valkey/reference/patterns-sessions-field-expiry.md
@@ -99,7 +99,7 @@ Eliminates the two-command pipeline (HMGET + HEXPIRE). Each field's TTL is indep
 
 3. **HLEN doesn't filter expired fields.** HLEN returns the physical count and will include fields whose TTL has passed but haven't been swept yet. `HGETALL`, `HKEYS`, `HVALS`, `HSCAN` **do** filter expired fields. For an accurate live-field count, iterate with HKEYS and take its length. A field that HGETALL doesn't return may still contribute to HLEN until the next sweep.
 
-4. **HSETEX creates the hash key if it's missing.** A "refresh the CSRF token" write to a logged-out session will silently re-create the session key with just the CSRF field. Gate refresh writes on `EXISTS <session_key>` first when the hash lifecycle matters. (9.1+ adds `[NX|XX]` on HSETEX at the key level; in 9.0 you need the explicit `EXISTS` gate.)
+4. **HSETEX creates the hash key if it's missing.** A "refresh the CSRF token" write to a logged-out session will silently re-create the session key with just the CSRF field. Gate refresh writes on `EXISTS <session_key>` first when the hash lifecycle matters.
 
 5. **Expired-but-not-swept fields briefly visible.** Between logical expiry and the next lazy/active sweep, HLEN and some edge cases may see the field. If you need strict "is this field alive right now," use `HTTL` - its reply codes already distinguish live / no-TTL / missing.
 

--- a/skills/valkey/skills/valkey/reference/security-auth-and-acl.md
+++ b/skills/valkey/skills/valkey/reference/security-auth-and-acl.md
@@ -4,10 +4,10 @@ Use when connecting your application to Valkey with authentication, configuring 
 
 ## Contents
 
-- Authentication (line 15)
-- ACL Basics for Application Developers (line 82)
-- TLS Connection Setup (line 159)
-- Security Checklist for Application Developers (line 233)
+- Authentication
+- ACL Basics for Application Developers
+- TLS Connection Setup
+- Security Checklist for Application Developers
 
 ---
 
@@ -87,9 +87,12 @@ ACLs are configured by the ops team. Application developers need to understand w
 | Scope | Example | Meaning |
 |-------|---------|---------|
 | Commands | `+@read +@write` | Which commands the user can run |
-| Keys | `~app:*` | Which key patterns the user can access |
-| Channels | `&notifications:*` | Which pub/sub channels the user can use |
-| Databases | `alldbs` or specific database restrictions | Which databases the user can SELECT |
+| Keys | `~app:*`, `allkeys`, `resetkeys` | Which key patterns the user can access |
+| Read/write-scoped keys | `%R~read:*`, `%W~write:*` | Restrict a pattern to read-only or write-only access |
+| Channels | `&notifications:*`, `allchannels`, `resetchannels` | Which pub/sub channels the user can use |
+| Connection state | `on`/`off`, `>password`, `nopass` | Enable/disable the user and manage credentials |
+
+ACLs do **not** restrict by database number - a user with `@write` on `~*` can write in any numbered database the server has. Use separate instances (or separate cluster deployments in 9.0+ cluster multi-db) for database-level isolation.
 
 ### Common Application Permission Patterns
 
@@ -131,7 +134,7 @@ Specify:
 2. **Command categories** needed (e.g., `@read`, `@write`, `@string`, `@hash`)
 3. **Specific dangerous commands** you need, if any (e.g., `FLUSHDB` - usually not)
 4. **Pub/sub channels** if your application uses pub/sub
-5. **Database numbers** if using numbered databases (9.0+ cluster mode)
+5. **Read-only vs read-write** access per pattern if you need tighter isolation within the same user (`%R~` / `%W~`)
 
 ### Command Categories Reference
 
@@ -223,9 +226,9 @@ r = redis.Redis(
 
 ### TLS Performance Notes
 
-- Valkey 8.1+ offloads TLS handshakes to I/O threads, reducing connection setup overhead by 300%
-- Once the TLS session is established, per-command overhead is minimal
-- For internal networks where encryption is handled at the network layer, plaintext connections are fine
+- Valkey 8.1+ offloads TLS handshakes to I/O threads, so handshake cost no longer monopolizes the main thread under connection storms. Tune `io-threads` if TLS-heavy workloads are connection-bound.
+- Once the TLS session is established, per-command overhead is minimal.
+- For internal networks where encryption is handled at the network layer, plaintext connections are fine.
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/valkey-features-cluster-enhancements.md
+++ b/skills/valkey/skills/valkey/reference/valkey-features-cluster-enhancements.md
@@ -10,6 +10,8 @@ Before 9.0, cluster mode was restricted to database 0. `SELECT` returned an erro
 
 Valkey 9.0 lifts this restriction. Configure via `cluster-databases` (default 1, only database 0). Set `cluster-databases 16` to enable databases 0-15.
 
+`cluster-databases` is **immutable** - set it at startup in valkey.conf or on the command line; it cannot be changed with `CONFIG SET`. Changing the value requires a restart. Plan capacity up-front.
+
 ### How It Works
 
 ```
@@ -28,16 +30,22 @@ Each database is a separate namespace. The same key name in database 0 and datab
 
 **Testing and debugging**: Compare behavior of the same keys across databases. Use one database for production traffic and another for shadow testing.
 
-**Atomic key migration via MOVE**: Move a key atomically from one database to another within the same node. MOVE fails if the key already exists in the destination database.
+**Atomic key migration via MOVE**: Move a key atomically from one database to another within the same node.
 
 ```
 # Prepare value in staging database
 SELECT 1
 SET mykey "new_value"
 
-# Move to production database (succeeds only if mykey does not exist in db 0)
+# Move to production database
 MOVE mykey 0
 ```
+
+MOVE reply semantics:
+
+- Returns `1` on success.
+- Returns `0` (not an error) if the source key doesn't exist, OR if the destination already holds that key. The caller must distinguish these cases themselves (e.g. with EXISTS before/after).
+- Returns a cluster redirect error if the slot of `mykey` is currently being imported or exported on this node - MOVE is blocked during active slot migration touching that slot.
 
 ### Limitations
 
@@ -58,44 +66,66 @@ For strong isolation between workloads, separate Valkey instances or clusters re
 
 ### Background
 
-Traditional cluster resharding migrates keys one at a time. During migration, clients hitting the slot receive ASK redirects and must query both source and target, causing:
+Traditional cluster resharding (`CLUSTER SETSLOT MIGRATING` + `MIGRATE` per key) moves keys one at a time. During the migration window clients hitting the slot receive per-key ASK redirects and must query both source and target, amplifying latency and requiring ASK/MOVED handling in the client.
 
-- Increased latency from redirects
-- Potential errors from partial slot states
-- Complex client redirect handling
+### How atomic migration works
 
-### How Atomic Migration Works
+9.0 adds a new command family (`CLUSTER MIGRATESLOTS`, `CLUSTER GETSLOTMIGRATIONS`, `CLUSTER CANCELSLOTMIGRATIONS`) that moves whole slot ranges through a snapshot-and-stream protocol:
 
-Valkey 9.0 serializes the entire slot as an AOF-format payload and transfers it atomically. Clients redirect instantly to the target node with zero intermediate states.
+1. Source takes a snapshot of the slot's keys (uses an AOF-format rewrite internally).
+2. Source streams the snapshot plus any live writes to the target.
+3. When the target has caught up, the source pauses writes briefly on the slot.
+4. Ownership transfers atomically via a failover of the slot to the target.
+5. Clients that next hit the slot on the old owner get a single `MOVED` redirect.
 
-### What This Means for Application Developers
+During the migration window there are **no per-key ASK redirects**. There is a brief write pause at cutover (step 3-4) - typically milliseconds, but it's not instantaneous. Reads and writes on other slots are unaffected.
 
-| Before (Traditional) | After (Atomic, 9.0+) |
-|----------------------|----------------------|
-| ASK redirects during migration | No redirects - instant cutover |
-| Possible transient errors during resharding | Clean switch |
-| Client must handle ASK/MOVED interleaving | Standard MOVED redirect only |
-| Key-by-key transfer (slow for large slots) | Bulk transfer (faster) |
+### How to invoke it
 
-### Practical Impact
-
-- **Cluster scaling is smoother** - adding or removing nodes causes less disruption to running applications
-- **Simpler client behavior** - no need to handle ASK redirects during slot migration
-- **Faster resharding** - bulk transfer is faster than key-by-key migration for slots with many keys
-
-Transparent to application code. Existing clients handling MOVED redirects work without changes.
-
----
-
-## Configuration
-
-Numbered databases in cluster mode use the `cluster-databases` configuration directive (default 1):
+This is **not** triggered automatically by `valkey-cli --cluster reshard` in 9.0.x (valkey-cli's reshard in 9.0 still uses the traditional per-key path). You have to call the commands directly. Support in valkey-cli lands in 9.1+.
 
 ```
-cluster-databases 16    # Enable 16 databases (0-15) in cluster mode
+# Migrate slots 0-4095 from this node to target node <node-id>
+CLUSTER MIGRATESLOTS SLOTSRANGE 0 4095 NODE <40-char-node-id>
+
+# Multiple ranges and targets in one call
+CLUSTER MIGRATESLOTS SLOTSRANGE 0 1000 NODE <node-id-A> \
+                     SLOTSRANGE 5000 5500 NODE <node-id-B>
 ```
 
-Atomic slot migration is enabled automatically in Valkey 9.0+ when using the cluster resharding tools. No special configuration is needed.
+Ranges are inclusive. Node IDs are the 40-hex-char names from `CLUSTER NODES`.
 
----
+### Monitoring
+
+```
+CLUSTER GETSLOTMIGRATIONS
+```
+
+Returns an array of maps, one per active or recently-finished migration. Useful fields per entry:
+
+- `operation` - `IMPORT` or `EXPORT`
+- `slot_ranges` - e.g. `"0-4095"`
+- `source_node`, `target_node` - 40-char node IDs
+- `state` - which phase of the state machine the job is in (snapshotting, streaming, paused, failover, cleaning up, finished, cancelled, failed)
+- `last_update_time` - detect stalled jobs
+- `remaining_repl_size` (9.1+) - bytes still to ship
+
+### Cancelling
+
+```
+CLUSTER CANCELSLOTMIGRATIONS
+```
+
+Cancels all active migration jobs on the node. The slot stays with its original owner. Safe to call - cancelling after cutover has already completed is a no-op on that job.
+
+### What this means for application code
+
+| Before (traditional) | Atomic (9.0+) |
+|----------------------|---------------|
+| Per-key ASK redirects during migration | No ASK redirects |
+| Client must handle interleaved ASK/MOVED | One `MOVED` per client after cutover |
+| Key-by-key transfer (slow for large slots) | Bulk snapshot + stream |
+| Writes to the migrating slot succeed throughout | Brief write pause at cutover (ms-scale) |
+
+Transparent to most application code - clients that already refresh topology on `MOVED` work without changes. The brief cutover pause is short enough that retry-on-timeout clients tolerate it, but latency-sensitive systems should schedule migrations outside peak traffic.
 

--- a/skills/valkey/skills/valkey/reference/valkey-features-cluster-enhancements.md
+++ b/skills/valkey/skills/valkey/reference/valkey-features-cluster-enhancements.md
@@ -82,7 +82,7 @@ During the migration window there are **no per-key ASK redirects**. There is a b
 
 ### How to invoke it
 
-This is **not** triggered automatically by `valkey-cli --cluster reshard` in 9.0.x (valkey-cli's reshard in 9.0 still uses the traditional per-key path). You have to call the commands directly. Support in valkey-cli lands in 9.1+.
+This is **not** triggered automatically by `valkey-cli --cluster reshard` in 9.0 (valkey-cli's reshard still uses the traditional per-key path). You have to call the commands directly.
 
 ```
 # Migrate slots 0-4095 from this node to target node <node-id>
@@ -108,7 +108,6 @@ Returns an array of maps, one per active or recently-finished migration. Useful 
 - `source_node`, `target_node` - 40-char node IDs
 - `state` - which phase of the state machine the job is in (snapshotting, streaming, paused, failover, cleaning up, finished, cancelled, failed)
 - `last_update_time` - detect stalled jobs
-- `remaining_repl_size` (9.1+) - bytes still to ship
 
 ### Cancelling
 

--- a/skills/valkey/skills/valkey/reference/valkey-features-commandlog.md
+++ b/skills/valkey/skills/valkey/reference/valkey-features-commandlog.md
@@ -67,6 +67,19 @@ CONFIG SET commandlog-large-request-max-len 256
 CONFIG SET commandlog-large-reply-max-len 256
 ```
 
+Set a threshold to `-1` to **disable** that log type (e.g. `CONFIG SET commandlog-reply-larger-than -1`). `0` logs every command of that type - rarely what you want.
+
+### Legacy config aliases
+
+Two pre-8.1 Redis config names still work as aliases:
+
+| Legacy name | Aliased to |
+|-------------|------------|
+| `slowlog-log-slower-than` | `commandlog-execution-slower-than` |
+| `slowlog-max-len` | `commandlog-slow-execution-max-len` |
+
+An existing valkey.conf using the old names continues to work - no rename needed. The two large-request/large-reply configs have no legacy alias (they are new in 8.1).
+
 ## Use Cases
 
 **Find latency-causing commands:**
@@ -91,10 +104,14 @@ COMMANDLOG GET 10 large-request
 
 | Legacy (pre-8.1) | Valkey 8.1+ |
 |-------------------|-------------|
-| `SLOWLOG GET 10` | `COMMANDLOG GET 10 slow` |
+| `SLOWLOG GET [count]` | `COMMANDLOG GET <count> slow` |
 | `SLOWLOG LEN` | `COMMANDLOG LEN slow` |
 | `SLOWLOG RESET` | `COMMANDLOG RESET slow` |
-| No equivalent | `COMMANDLOG GET 10 large-request` |
-| No equivalent | `COMMANDLOG GET 10 large-reply` |
+| No equivalent | `COMMANDLOG GET <count> large-request` |
+| No equivalent | `COMMANDLOG GET <count> large-reply` |
 
-SLOWLOG still works in Valkey 8.1+ for backward compatibility but returns the same data as `COMMANDLOG GET ... slow`.
+`SLOWLOG` still works in Valkey 8.1+ and returns from the same underlying log as `COMMANDLOG GET ... slow`. Note that `SLOWLOG GET`'s count is optional (defaults to 10) whereas `COMMANDLOG GET` requires an explicit count.
+
+## Cluster mode
+
+`COMMANDLOG GET` / `LEN` / `RESET` are tagged `REQUEST_POLICY: ALL_NODES` - a cluster-aware client (`valkey-cli -c`, smart SDK) will dispatch the command to every shard and aggregate. For cluster-wide diagnosis, run once with a smart client rather than connecting to each node manually. `LEN` also carries `RESPONSE_POLICY: AGG_SUM` so the aggregated total is the sum across nodes.

--- a/skills/valkey/skills/valkey/reference/valkey-features-conditional-ops.md
+++ b/skills/valkey/skills/valkey/reference/valkey-features-conditional-ops.md
@@ -16,7 +16,18 @@ SET key new_value IFEQ expected_value [EX seconds | PX milliseconds | EXAT unix-
 
 - If the current value of `key` equals `expected_value`, the value is updated to `new_value` and the command returns `OK`
 - If the current value does NOT match, the command returns `nil` and no change is made
+- **If the key does not exist, the command returns `nil` and no change is made - IFEQ never creates a new key.** A CAS retry loop that only treats `nil` as "someone beat me" must also handle the "key was deleted" case (e.g. check `EXISTS` after, or create with a separate `SET ... NX` if missing).
 - The comparison and update are atomic - no race condition window
+
+### Return values with `GET`
+
+The `GET` flag returns the old value **before** IFEQ is evaluated. So the reply is:
+
+- Key exists + IFEQ matches → old value returned, new value stored
+- Key exists + IFEQ mismatches → old value returned, key unchanged
+- Key doesn't exist → `nil` returned, key not created
+
+The caller cannot distinguish "matched and set" from "mismatched and not set" from the GET-reply alone; use the non-GET form if you need to know the outcome.
 
 ### Examples
 
@@ -26,7 +37,8 @@ SET mykey "initial"
 SET mykey "updated" IFEQ "initial"     # Returns OK (match, value updated)
 SET mykey "again" IFEQ "initial"       # Returns nil (no match - value is "updated")
 
-# With GET flag - returns old value regardless of match outcome
+# With GET flag - returns old value regardless of IFEQ outcome;
+# returns nil if the key did not exist (and IFEQ aborts the set in that case).
 SET mykey "new_value" IFEQ "updated" GET    # Returns "updated", sets to "new_value"
 
 # With TTL
@@ -63,6 +75,8 @@ else return nil end" 1 mykey old_value new_value
 # Valkey 8.1+ (native command)
 SET mykey new_value IFEQ old_value
 ```
+
+> Both `server.call` and `redis.call` are valid inside Valkey Lua scripts (Valkey registers both globals). Existing Redis scripts using `redis.call` run unchanged.
 
 ---
 
@@ -140,6 +154,18 @@ DELIFEQ lock:resource <random_value>    # Instance 3
 DELIFEQ lock:resource <random_value>    # Instance 4
 DELIFEQ lock:resource <random_value>    # Instance 5
 ```
+
+A `0` reply from any of these is **not a failure**. It means either the lock already expired on that node or a different owner now holds it - in Redlock semantics, that's still a successful release from this client's perspective. Continue issuing DELIFEQ on the remaining instances; do not retry the 0-reply instance.
+
+---
+
+## Replication
+
+Both IFEQ-SET and DELIFEQ are **rewritten to plain `SET` and `DEL`** on the replication stream and AOF. Replicas and AOF readers see only the concrete write or delete - the conditional is evaluated once on the primary and the result is propagated unconditionally. This means:
+
+- Replicas stay deterministic even across reconnects; they don't re-run the comparison.
+- An operator tailing the AOF for auditing will not see `DELIFEQ` or `SET ... IFEQ` - they'll see `DEL` / `SET`.
+- `MONITOR` on the primary shows the original command; `MONITOR` on a replica shows the rewritten one.
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/valkey-features-expiretime.md
+++ b/skills/valkey/skills/valkey/reference/valkey-features-expiretime.md
@@ -4,13 +4,16 @@ Use when inspecting key expiration, coordinating TTLs across services, or auditi
 
 ## Commands
 
-| Command | Returns |
-|---------|---------|
-| `TTL key` | Remaining seconds (-1 = no TTL, -2 = missing) |
-| `PTTL key` | Remaining milliseconds |
-| `EXPIRETIME key` | Absolute Unix timestamp (seconds) at expiry |
-| `PEXPIRETIME key` | Absolute Unix timestamp (milliseconds) at expiry |
-| `PERSIST key` | Remove TTL; returns 1 if removed, 0 if none |
+| Command | Success reply | `-1` | `-2` |
+|---------|---------------|------|------|
+| `TTL key` | Remaining seconds (integer) | Key exists, no TTL | Key missing |
+| `PTTL key` | Remaining milliseconds | Key exists, no TTL | Key missing |
+| `EXPIRETIME key` | Absolute Unix timestamp in seconds | Key exists, no TTL | Key missing |
+| `PEXPIRETIME key` | Absolute Unix timestamp in milliseconds | Key exists, no TTL | Key missing |
+
+| Command | Reply |
+|---------|-------|
+| `PERSIST key` | `1` if a TTL was removed; `0` **either** when the key has no TTL **or** when the key does not exist. Use `EXISTS` separately if you need to distinguish those. |
 
 `EXPIRETIME`/`PEXPIRETIME` were added in Redis 7.0 and are available in all Valkey versions. Use the absolute form when passing expiration to another service - relative TTL decays in transit.
 

--- a/skills/valkey/skills/valkey/reference/valkey-features-geospatial.md
+++ b/skills/valkey/skills/valkey/reference/valkey-features-geospatial.md
@@ -16,18 +16,20 @@ Valkey 9.0 adds `BYPOLYGON` support to `GEOSEARCH` for arbitrary polygon queries
 
 ```
 GEOSEARCH key
-    [FROMMEMBER member | FROMLONLAT longitude latitude]
     BYPOLYGON num-vertices lon1 lat1 lon2 lat2 ... lonN latN
     [ASC | DESC]
     [COUNT count [ANY]]
     [WITHCOORD] [WITHDIST] [WITHHASH]
 ```
 
-- `num-vertices` - the first argument after BYPOLYGON specifies how many vertex coordinate pairs follow
-- Each vertex is a longitude/latitude pair
-- The polygon is automatically closed (last vertex connects back to first)
-- Vertices should be specified in order (clockwise or counterclockwise)
-- `FROMMEMBER` and `FROMLONLAT` are NOT used with BYPOLYGON - the center point and bounding box are computed from the polygon vertices
+(For `BYRADIUS`/`BYBOX` queries a `FROMMEMBER` or `FROMLONLAT` origin is required; for `BYPOLYGON` it is rejected with a syntax error.)
+
+- `num-vertices` - the first argument after BYPOLYGON specifies how many vertex coordinate pairs follow. Minimum 3.
+- Each vertex is a longitude/latitude pair.
+- The polygon is automatically closed - do NOT repeat the first vertex as the last one; it wastes a slot and adds an extra edge check.
+- Vertices must form a simple (non-self-intersecting) polygon. Winding order (clockwise or counterclockwise) does not matter.
+- `FROMMEMBER` and `FROMLONLAT` are NOT used with BYPOLYGON - supplying either returns a syntax error.
+- `WITHDIST` with BYPOLYGON returns the distance from the polygon's computed centroid, **not** from any user-supplied point. If you need distance from a known location, compute it client-side or issue a separate `GEODIST`.
 
 ### Basic Example
 
@@ -46,13 +48,12 @@ GEOSEARCH locations BYPOLYGON 4 -123 38 -117 38 -117 37 -123 37 ASC WITHCOORD
 ### Polygon Covering a State or Region
 
 ```
-# Define a rough polygon for the San Francisco Bay Area
-GEOSEARCH locations BYPOLYGON 5 \
+# Define a rough polygon for the San Francisco Bay Area (4 corners - do not repeat the first)
+GEOSEARCH locations BYPOLYGON 4 \
   -122.6 37.9 \
   -121.8 37.9 \
   -121.8 37.2 \
   -122.6 37.2 \
-  -122.6 37.9 \
   ASC COUNT 100 WITHCOORD WITHDIST
 ```
 
@@ -70,13 +71,12 @@ Check if addresses fall within a delivery polygon:
 GEOADD delivery:addresses -122.4 37.78 "addr:1001"
 GEOADD delivery:addresses -122.5 37.75 "addr:1002"
 
-# Check which addresses fall within the delivery polygon
-GEOSEARCH delivery:addresses BYPOLYGON 5 \
+# Check which addresses fall within the delivery polygon (4 vertices, auto-closed)
+GEOSEARCH delivery:addresses BYPOLYGON 4 \
   -122.55 37.82 \
   -122.35 37.82 \
   -122.35 37.72 \
   -122.55 37.72 \
-  -122.55 37.82 \
   ASC
 ```
 
@@ -131,12 +131,21 @@ GEOADD key longitude latitude member [longitude latitude member ...]
 
 ---
 
+## Gotchas
+
+- **Antimeridian (180°/-180° wrap)**. The candidate bounding box is computed as simple min/max lon/lat over the vertices. A polygon that crosses the antimeridian (e.g. spanning 170° to -170° through the Pacific) will produce a bounding box that covers the whole globe and match the wrong members. **Split such polygons into two** - one east of 180°, one west of -180° - and union the results client-side.
+- **Self-intersecting polygons**. A figure-8 or "twisted" polygon gives even-odd fill behavior (alternating in/out regions), which is rarely what you want. Keep polygons simple.
+- **Very small polygons** (< 100m across) can hit precision limits of the geohash grid. For sub-100m fences, verify with a follow-up GEODIST.
+
+## GEOSEARCHSTORE
+
+`GEOSEARCHSTORE` supports BYPOLYGON with the same syntax, writing matched members (score = geohash) to a destination sorted set. Restriction: the store form rejects `WITHCOORD`, `WITHDIST`, and `WITHHASH` with an error - pick store-and-count OR annotated-results, not both.
+
 ## Performance Notes
 
-- `GEOSEARCH` complexity is O(N+log(M)) where N is the number of elements in the grid-aligned bounding box around the shape and M is the number of items inside the shape
-- Polygon point-in-polygon testing adds per-candidate overhead compared to radius/box, but this is negligible for typical polygon sizes (< 100 vertices)
-- For very large geo sets (millions of points), combine with `COUNT` to limit result size
-- `GEOSEARCHSTORE` also supports BYPOLYGON with the same syntax, storing results into a destination sorted set
+- `GEOSEARCH` complexity is O(N+log(M)) where N is the number of elements in the grid-aligned bounding box around the shape and M is the number of items inside the shape.
+- Polygon point-in-polygon testing adds per-candidate overhead compared to radius/box, but this is negligible for typical polygon sizes (< 100 vertices).
+- For very large geo sets (millions of points), combine with `COUNT` to limit result size.
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/valkey-features-hash-field-ttl.md
+++ b/skills/valkey/skills/valkey/reference/valkey-features-hash-field-ttl.md
@@ -49,8 +49,7 @@ Condition flags (`NX | XX | GT | LT`) are **per-field** and mutually exclusive:
 
 | Command | Syntax |
 |---------|--------|
-| `HSETEX` (9.0) | `HSETEX key [FNX \| FXX] [EX s \| PX ms \| EXAT t \| PXAT t \| KEEPTTL] FIELDS n field value [field value ...]` |
-| `HSETEX` (9.1+) | adds `[NX \| XX]` at the key level (create/update gate on the hash itself) |
+| `HSETEX` | `HSETEX key [FNX \| FXX] [EX s \| PX ms \| EXAT t \| PXAT t \| KEEPTTL] FIELDS n field value [field value ...]` |
 | `HGETEX` | `HGETEX key [EX s \| PX ms \| EXAT t \| PXAT t \| PERSIST] FIELDS n field [field ...]` |
 
 `FNX` = set only if **none** of the named fields already exist; `FXX` = set only if **all** of the named fields already exist. Applies to the whole operation — if the condition fails, **nothing** is set (HSETEX is atomic all-or-nothing).

--- a/skills/valkey/skills/valkey/reference/valkey-features-hash-field-ttl.md
+++ b/skills/valkey/skills/valkey/reference/valkey-features-hash-field-ttl.md
@@ -12,21 +12,48 @@ Valkey 9.0 adds per-field TTL. Each hash field has its own expiration, independe
 
 ## New Commands
 
-11 new commands for hash field expiration:
+11 new commands for hash field expiration (all since 9.0.0):
 
-| Command | Purpose |
-|---------|---------|
-| `HEXPIRE key seconds FIELDS n field [field ...]` | Set TTL (seconds) on existing fields |
-| `HEXPIREAT key unix-timestamp FIELDS n field [field ...]` | Set expiration at absolute Unix time |
-| `HPEXPIRE key milliseconds FIELDS n field [field ...]` | Set TTL (milliseconds) on existing fields |
-| `HPEXPIREAT key unix-ms-timestamp FIELDS n field [field ...]` | Set expiration at absolute Unix time (ms) |
-| `HTTL key FIELDS n field [field ...]` | Get remaining TTL (seconds) per field |
-| `HPTTL key FIELDS n field [field ...]` | Get remaining TTL (milliseconds) per field |
-| `HEXPIRETIME key FIELDS n field [field ...]` | Get absolute expiration time per field |
-| `HPEXPIRETIME key FIELDS n field [field ...]` | Get absolute expiration time (ms) per field |
-| `HPERSIST key FIELDS n field [field ...]` | Remove TTL from fields (make persistent) |
-| `HSETEX key [NX \| XX] [FNX \| FXX] [EX s \| PX ms \| EXAT t \| PXAT t \| KEEPTTL] FIELDS n field value [field value ...]` | Set fields with TTL and optional conditions in one command |
-| `HGETEX key [EX s \| PX ms \| EXAT t \| PXAT t \| PERSIST] FIELDS n field [field ...]` | Get fields and set/refresh/remove TTL |
+### Setters (HEXPIRE family)
+
+| Command | Syntax |
+|---------|--------|
+| `HEXPIRE` | `HEXPIRE key seconds [NX \| XX \| GT \| LT] FIELDS n field [field ...]` |
+| `HEXPIREAT` | `HEXPIREAT key unix-timestamp [NX \| XX \| GT \| LT] FIELDS n field [field ...]` |
+| `HPEXPIRE` | `HPEXPIRE key milliseconds [NX \| XX \| GT \| LT] FIELDS n field [field ...]` |
+| `HPEXPIREAT` | `HPEXPIREAT key unix-ms-timestamp [NX \| XX \| GT \| LT] FIELDS n field [field ...]` |
+
+Condition flags (`NX | XX | GT | LT`) are **per-field** and mutually exclusive:
+
+- `NX` - set TTL only if the field has no existing TTL
+- `XX` - set TTL only if the field already has a TTL
+- `GT` - set TTL only if the new TTL is greater than the current one
+- `LT` - set TTL only if the new TTL is less than the current one
+
+### Inspection
+
+| Command | Syntax |
+|---------|--------|
+| `HTTL` | `HTTL key FIELDS n field [field ...]` — remaining seconds per field |
+| `HPTTL` | `HPTTL key FIELDS n field [field ...]` — remaining milliseconds per field |
+| `HEXPIRETIME` | `HEXPIRETIME key FIELDS n field [field ...]` — absolute Unix seconds |
+| `HPEXPIRETIME` | `HPEXPIRETIME key FIELDS n field [field ...]` — absolute Unix milliseconds |
+
+### Clear TTL
+
+| Command | Syntax |
+|---------|--------|
+| `HPERSIST` | `HPERSIST key FIELDS n field [field ...]` — remove TTL from fields |
+
+### Combined set-and-expire, get-and-expire
+
+| Command | Syntax |
+|---------|--------|
+| `HSETEX` (9.0) | `HSETEX key [FNX \| FXX] [EX s \| PX ms \| EXAT t \| PXAT t \| KEEPTTL] FIELDS n field value [field value ...]` |
+| `HSETEX` (9.1+) | adds `[NX \| XX]` at the key level (create/update gate on the hash itself) |
+| `HGETEX` | `HGETEX key [EX s \| PX ms \| EXAT t \| PXAT t \| PERSIST] FIELDS n field [field ...]` |
+
+`FNX` = set only if **none** of the named fields already exist; `FXX` = set only if **all** of the named fields already exist. Applies to the whole operation — if the condition fails, **nothing** is set (HSETEX is atomic all-or-nothing).
 
 The `FIELDS n` argument specifies the count of field names that follow.
 
@@ -74,15 +101,48 @@ HPERSIST user:1000 FIELDS 1 profile_data
 
 ---
 
-## Return Values for TTL Commands
+## Return Values
 
-Commands return an array with one value per field:
+### HEXPIRE / HEXPIREAT / HPEXPIRE / HPEXPIREAT (setters)
 
-| Value | Meaning |
-|-------|---------|
-| Positive integer | Remaining TTL in seconds (or ms for HP* variants) |
+Array of per-field result codes:
+
+| Code | Meaning |
+|------|---------|
+| `1` | Expiration was applied |
+| `2` | TTL was `0` (or absolute time in the past) - field was deleted immediately |
+| `0` | `NX` / `XX` / `GT` / `LT` condition not met - no change |
+| `-2` | Field does not exist (or the hash key does not exist) |
+
+Common mistake: checking for `-1` on an HEXPIRE result. `-1` is an HTTL/HPTTL code, not a setter code. HEXPIRE never returns `-1`.
+
+### HTTL / HPTTL / HEXPIRETIME / HPEXPIRETIME (inspection)
+
+Array of per-field result codes:
+
+| Code | Meaning |
+|------|---------|
+| Positive integer | Remaining TTL or absolute expiration (seconds or ms per command) |
 | `-1` | Field exists but has no TTL |
 | `-2` | Field does not exist |
+
+### HPERSIST
+
+Array of per-field result codes:
+
+| Code | Meaning |
+|------|---------|
+| `1` | TTL was removed |
+| `-1` | Field exists but had no TTL to remove |
+| `-2` | Field does not exist |
+
+### HSETEX
+
+Scalar (atomic): `1` if all fields (and any conditions) succeeded, `0` if any `FNX`/`FXX` condition failed - in which case **nothing** was written.
+
+### HGETEX
+
+Array of values in field order: each element is the field's current string value, or `nil` if the field is missing or already expired. Same shape as `HMGET`.
 
 ---
 
@@ -138,9 +198,7 @@ HSETEX cache:user:1000 EX 300 FIELDS 1 recommendations '[...]'
 
 ## Memory Overhead
 
-16-29 bytes overhead per expiring field. No measurable performance regression on standard hash operations.
-
-Fields without TTL incur no additional overhead.
+Only fields that carry a TTL pay the extra metadata cost; fields without TTL are stored exactly as before. Adding TTLs to a previously-non-volatile hash promotes it into a "volatile-capable" encoding - budget for a small per-field increase when you start using HEXPIRE heavily.
 
 ---
 
@@ -155,11 +213,11 @@ Fields without TTL incur no additional overhead.
 
 ## Important Notes
 
-- Hash field expiration uses the same lazy + active expiration mechanisms as key-level TTL
-- HGETALL returns only non-expired fields
-- HSCAN skips expired fields
+- Hash field expiration uses the same lazy + active expiration mechanisms as key-level TTL. A field expires when it's next accessed or when the active expiration cycle visits the hash, whichever comes first.
+- `HGETALL`, `HSCAN`, `HKEYS`, `HVALS` skip fields that have already been expired by either mechanism. A field whose TTL has just passed but hasn't yet been evaluated may be returned once, then disappear. If strict freshness matters, follow up with `HTTL`/`HEXISTS`.
 - Field expiration events are published via keyspace notifications (when enabled)
-- The `n` in `FIELDS n` must match the number of field names provided
+- The `n` in `FIELDS n` must match the number of field names provided - mismatch returns a syntax error.
+- Setting TTL to `0` (or a past absolute timestamp) via `HEXPIRE` / `HEXPIREAT` / `HPEXPIRE` / `HPEXPIREAT` **deletes the field immediately** and returns `2`. This is a feature, not an edge case - `HEXPIRE key 0 FIELDS n f1 f2` is a conditional delete based on existence.
 
 ---
 

--- a/skills/valkey/skills/valkey/reference/valkey-features-performance-summary.md
+++ b/skills/valkey/skills/valkey/reference/valkey-features-performance-summary.md
@@ -1,20 +1,6 @@
 # Performance Improvements Summary
 
-Use when evaluating Valkey's performance characteristics or understanding what version-specific optimizations benefit your application without configuration changes.
-
----
-
-Performance figures below are from Valkey project benchmarks and release notes. Actual improvements depend on workload characteristics, hardware, and configuration. See the linked Valkey release notes for methodology details.
-
-## Contents
-
-- Version-by-Version Performance Changes (line 17)
-- What Application Developers Get for Free (line 51)
-- What Requires Configuration (line 82)
-- I/O Thread Tuning Details (line 117)
-- MPTCP Details (line 153)
-- Benchmarking Guidance (line 185)
-- Application-Side Optimizations (line 241)
+Use when you need to know what version-specific optimizations benefit your workload and what tuning knobs control them. Numbers below are rough - treat as ballpark, not specification.
 
 ## Version-by-Version Performance Changes
 
@@ -22,31 +8,29 @@ Performance figures below are from Valkey project benchmarks and release notes. 
 
 | Feature | Impact | Detail |
 |---------|--------|--------|
-| I/O multithreading overhaul | 3x throughput (360K -> 1.2M RPS) | I/O threads handle read/parse/write; main thread handles command execution |
-| Command batching | Reduced CPU cache misses | Commands grouped for better cache locality |
+| Async I/O threading | Higher throughput under high connection concurrency | I/O threads handle read/parse/write; main thread handles command execution |
 | Dual-channel replication | Faster replica sync | RDB transfer and replication stream run in parallel |
 
 ### Valkey 8.1
 
 | Feature | Impact | Detail |
 |---------|--------|--------|
-| New hashtable implementation | 20-30 bytes less memory per key | Open-addressing with 64-byte buckets, SIMD probing |
+| New hashtable implementation | Lower per-key memory and better cache locality | 64-byte (cache-line) buckets holding 7 entries each, bucket chaining, SIMD hash-bit scan, incremental rehashing |
 | Iterator prefetching | 3.5x faster iteration | SCAN, KEYS, HGETALL, and similar commands benefit |
-| TLS offload to I/O threads | 300% faster TLS connection acceptance | TLS handshake no longer blocks main thread |
-| ZRANK optimization | 45% faster | Optimized skiplist traversal |
-| BITCOUNT (AVX2) | 514% faster | SIMD-accelerated bit counting |
-| PFMERGE/PFCOUNT (AVX) | 12x faster | SIMD-accelerated HyperLogLog operations |
+| TLS offload to I/O threads | Small (~10%) throughput gain on TLS workloads | TLS handshake and error-queue handling moved off main thread; activates with io-threads > 1 |
+| ZRANK optimization | Up to 45% faster (mostly unique scores); ~8-27% with many duplicate scores | Skiplist traversal skips redundant string comparisons |
+| BITCOUNT SIMD | Negligible for <256B; ~6x at 1MB (AVX2), up to ~10x at 10MB (ARM NEON) | Enabled at runtime when CPU has AVX2 or ARM NEON |
+| PFMERGE/PFCOUNT SIMD | ~12x faster on multi-HLL merge with dense encoding (AVX2) | Sparse-encoded HLLs unaffected; requires default HLL config |
 
 ### Valkey 9.0
 
 | Feature | Impact | Detail |
 |---------|--------|--------|
-| Pipeline memory prefetch | Up to 40% higher throughput | Batch key prefetching for pipelined commands |
-| Zero-copy responses | Up to 20% higher throughput for large values | Eliminates buffer copies for read-heavy workloads |
-| SIMD BITCOUNT/HLL | Up to 200% higher throughput | Further SIMD improvements over 8.1 |
-| Multipath TCP (MPTCP) | Up to 25% latency reduction | Multiple network paths for a single connection |
-| Atomic slot migration | Faster resharding | Bulk transfer instead of key-by-key |
-| 1 billion RPS at scale | Cluster benchmark | Across 2,000 cluster nodes |
+| Pipeline memory prefetch | Measurable throughput gain on pipelined workloads (also helps MGET/MSET/DEL) | Parser reads multiple commands from the query buffer; keys for queued commands are prefetched in batches. Batch size: `prefetch-batch-max-size` (default 16). |
+| Reply copy avoidance | Skips a payload copy when replying with large bulk strings under I/O threads | Auto-enabled above thread and size thresholds (`min-io-threads-avoid-copy-reply`, `min-string-size-avoid-copy-reply`). Internal/hidden configs. |
+| Additional SIMD (BITCOUNT, HLL findBucket, hash findBucket) | Further acceleration on CPUs with ARM NEON or AVX2 | Complements the 8.1 SIMD work |
+| Multipath TCP (MPTCP) | Latency resilience under packet loss (opt-in); negligible on clean networks | Config `mptcp yes` + `repl-mptcp yes`, both immutable. See MPTCP section. |
+| Atomic slot migration | Faster, safer resharding | Bulk transfer instead of key-by-key |
 
 ---
 
@@ -72,12 +56,13 @@ Applications using these operations see immediate speedups:
 
 | Command | Improvement | Version |
 |---------|------------|---------|
-| `BITCOUNT` | 5-7x faster | 8.1+ |
-| `PFCOUNT` / `PFMERGE` | 12x faster | 8.1+ |
-| `ZRANK` / `ZREVRANK` | 45% faster | 8.1+ |
-| `SCAN` / `HSCAN` / `SSCAN` / `ZSCAN` | 3.5x faster | 8.1+ |
-| Pipelined commands | 40% higher throughput | 9.0+ |
-| Large value reads | 20% higher throughput | 9.0+ |
+| `BITCOUNT` | Negligible <256B; ~6x at 1MB (AVX2), up to ~10x at 10MB (ARM NEON) | 8.1+ |
+| `PFCOUNT` / `PFMERGE` | ~12x on multi-HLL merge, dense encoding, AVX2 CPU | 8.1+ |
+| `ZRANK` / `ZREVRANK` | Up to 45% (mostly unique scores); less with duplicate scores | 8.1+ |
+| `KEYS` full iteration | ~3.5x faster | 8.1+ |
+| `SCAN` / `HSCAN` / `SSCAN` / `ZSCAN` | Benefit from the same iterator; magnitude unmeasured | 8.1+ |
+| Pipelined commands | Measurable throughput gain via batch key prefetch | 9.0+ |
+| Large bulk-string replies under I/O threads | Skips a payload copy | 9.0+ |
 
 ---
 
@@ -102,11 +87,11 @@ TLS handshake is offloaded to I/O threads automatically when `io-threads > 1`. N
 
 ### Multipath TCP (9.0+)
 
-Requires kernel support and network configuration. When available, Valkey uses MPTCP automatically. This benefits deployments with multiple network interfaces.
+Opt-in. Requires Linux kernel 5.6+ and explicit `mptcp yes` (client-facing) and/or `repl-mptcp yes` (replication) in valkey.conf. Both are immutable. See MPTCP section below.
 
 ### Pipeline prefetch (9.0+)
 
-Enabled automatically for pipelined commands. Applications already pipelining benefit with no changes. Applications not pipelining should add it - the gains are significant.
+Enabled automatically. Tune via `prefetch-batch-max-size` (default 16, max 128). Applications already pipelining benefit with no changes. Multi-key commands (MGET, MSET, DEL) also benefit when pipelined or when `io-threads > 1`.
 
 ---
 
@@ -114,30 +99,24 @@ Enabled automatically for pipelined commands. Applications already pipelining be
 
 ### Choosing `io-threads` count
 
-Rule of thumb: set `io-threads` to half your available cores, capped at 8. The value includes the main thread, so `io-threads 4` means the main thread plus 3 I/O threads.
+The server accepts `io-threads` up to 256. Beyond a handful of threads the main thread (which still executes commands single-threaded) becomes the bottleneck and additional I/O threads stop helping. Start at half the available cores and tune with a benchmark.
 
-| Core count | Recommended `io-threads` |
-|------------|--------------------------|
-| 2-4 cores  | 2                        |
-| 6-8 cores  | 4                        |
-| 12-16 cores | 6-8                     |
-| 32+ cores  | 8 (max)                  |
+| Core count | Starting `io-threads` |
+|------------|-----------------------|
+| 2-4 cores  | 2                     |
+| 6-8 cores  | 4                     |
+| 12-16 cores | 6-8                  |
+| 32+ cores  | 8, then measure       |
 
-The maximum useful value is 8. Beyond that, lock contention on the command queue cancels any I/O gains. The main thread remains single-threaded for command execution regardless of `io-threads`.
+The value includes the main thread, so `io-threads 4` means the main thread plus 3 I/O threads. The main thread remains single-threaded for command execution regardless of `io-threads`, so CPU-bound commands (Lua, long EVAL) do not scale with more I/O threads.
 
 ### `events-per-io-thread`
 
-Controls how many epoll events each I/O thread processes per cycle before yielding back to the main thread.
+Controls how many epoll events each I/O thread processes per cycle before yielding back to the main thread. Hidden/internal config; default `2`. Raise it if you want I/O threads to amortize more events per yield; lower it only to investigate tail-latency.
 
-```
-events-per-io-thread 16   # default
-```
+### `io-threads-do-reads` silently ignored
 
-Lower values reduce latency at the cost of throughput (more frequent context switches). Higher values improve throughput but can increase tail latency under bursty traffic. The default of 16 is appropriate for most workloads. Reduce to 4-8 if you see p99 spikes on mixed small/large payload workloads.
-
-### `io-threads-do-reads` is removed in Valkey
-
-In Redis, reads were optionally threaded via `io-threads-do-reads yes`. Valkey removed this option - reads are always handled by I/O threads when `io-threads > 1`. There is no separate toggle. If you are migrating configuration from Redis, remove `io-threads-do-reads` from valkey.conf to avoid a startup warning.
+Valkey always handles reads on I/O threads when `io-threads > 1` - there is no toggle. The `io-threads-do-reads` directive, if present in valkey.conf, is silently ignored with no warning and no effect. Safe to leave in or remove when migrating from Redis.
 
 ### When I/O threads do NOT help
 
@@ -171,7 +150,7 @@ If `instantaneous_ops_per_sec` does not improve after enabling I/O threads, the 
 
 Multipath TCP (MPTCP) allows a single TCP connection to use multiple network subflows simultaneously across two NICs or two network paths. Each subflow is standard TCP so firewalls and middleboxes see no change. The socket API is unchanged for applications.
 
-For Valkey, MPTCP reduces per-request latency (up to 25% in Valkey 9.0 benchmarks) by distributing traffic across paths and enabling faster retransmission when one path congests. The benefit is latency variance reduction and resilience, not raw bandwidth increase.
+For Valkey, MPTCP reduces per-request latency under packet loss by retransmitting on an alternate subflow instead of waiting on the lossy path. The benefit is latency variance reduction and resilience, not raw bandwidth increase. On a clean single-path network, MPTCP provides near-zero improvement.
 
 ### Kernel requirements
 
@@ -189,7 +168,14 @@ sudo sysctl -w net.mptcp.enabled=1
 echo "net.mptcp.enabled = 1" | sudo tee /etc/sysctl.d/99-mptcp.conf
 ```
 
-Valkey 9.0+ detects MPTCP availability at startup and uses it automatically. No `valkey.conf` change is needed.
+MPTCP is **opt-in**. Two config options, both default `no` and both immutable (set at startup, not via `CONFIG SET`):
+
+```
+mptcp yes           # listener accepts MPTCP connections from clients
+repl-mptcp yes      # replica opens MPTCP connection to primary
+```
+
+Startup fails with `MPTCP is not supported on this platform` if the kernel lacks MPTCP.
 
 ### Verifying MPTCP is active
 
@@ -208,15 +194,13 @@ ss -tlnp | grep 6379
 # On MPTCP-enabled systems, Valkey binds using SOCK_MPTCP internally
 ```
 
-Valkey logs a startup notice when MPTCP is active: `MPTCP socket type in use`.
+### When MPTCP pays off
 
-### Expected latency reduction
+Loss resilience, not bandwidth. Pays off with packet loss and at least two reachable network paths. On a clean single-NIC network, expect near-zero delta. Use MPTCP when:
 
-25% p99 latency reduction is the figure from Valkey 9.0 benchmarks on multi-path hardware. Results vary by:
-
-- Number of available network paths (benefit requires at least 2 subflows)
-- Baseline congestion on the primary path
-- Geographic distance (MPTCP helps more at higher RTTs)
+- Clients cross an unreliable path (WAN, multi-AZ with occasional loss)
+- Host has two NICs or two routable paths to the server
+- Clients also run Linux 5.6+ with MPTCP enabled
 
 On single-NIC hosts with no secondary path, MPTCP falls back to standard TCP behavior with no regression.
 
@@ -282,7 +266,7 @@ These are approximate figures on modern hardware (bare metal, 10 GbE, io-threads
 | GET | 1 KB | no | 350K-600K |
 | HSET (10 fields) | 64 B | no | 300K-500K |
 
-Valkey 9.0 cluster benchmarks at 1 billion RPS were achieved across 2,000 nodes, not a single instance. Single-instance peak is approximately 1.5M RPS for small payloads with `io-threads 8` and aggressive pipelining.
+Single-instance peak is roughly 1-1.5M RPS for small payloads with `io-threads` tuned and aggressive pipelining. Cluster throughput scales roughly linearly with shard count when the workload avoids cross-slot operations.
 
 ### Pipeline vs non-pipeline comparison
 
@@ -332,7 +316,7 @@ Not version-specific, but compound with server-side improvements:
 
 ### Pipelining
 
-Send multiple commands in one batch. Up to 10x throughput improvement at the application level, further amplified by server-side pipeline prefetch in 9.0.
+Send multiple commands in one batch. Up to ~10x throughput improvement at the application level by eliminating RTT per command. Further amplified on 9.0+ by server-side pipeline prefetch.
 
 ```
 # Without pipelining: N round-trips


### PR DESCRIPTION
## Summary
- Drop unverifiable performance numbers ("3x throughput", "50% gain"). Keep what an app developer can act on.
- Strip line-numbered "Contents" TOCs from files that fit in <200 lines - the line numbers drift and agents grep headers directly.
- Correct 9.1 features mis-attributed to 9.0: HGETDEL, MSETEX, CLUSTERSCAN, NX/XX on HSETEX, database-level ACL, Lua-as-module, cross-node SCAN consistency, TLS auto-reload, SAN-URI auth, standalone CLUSTER KEYSLOT.
- Fix fabrications caught in the validation pass: "open-addressing" hashtable framing (it's cache-line bucket chaining), "pipeline provides atomicity" in session patterns (it doesn't), and hash-tag co-location errors (`{shard:0}` and `{shard:1}` are DIFFERENT hash tags and land on DIFFERENT slots).
- Soften client-side caching and Lua-function advice where "available" was being conflated with "configured/exposed by every client".
- Smaller tightening across hash-field-TTL, geospatial, conditional-ops, expiretime, commandlog, cluster-enhancements.

Companion PR #7 refactors and validates the contributor skill (valkey-dev).

## Test plan
- [ ] `grep -rn "open-addressing\|3x throughput\|pipeline.*atomic\|{shard:0}" skills/valkey/` returns no matches.
- [ ] For each of the 37 files, skim the "Use when" line and first section - scenario framing stays actionable, numbers that survive are source-verifiable.
- [ ] Spot-check that no TOC contains line numbers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only, but broad edits across many reference pages could introduce new inaccuracies or break external links if headings moved.
> 
> **Overview**
> Updates Valkey reference documentation to remove line-numbered TOCs and tighten guidance to **verifiable, actionable behavior** (dropping or qualifying hard performance claims).
> 
> Corrects and expands several semantics and version notes across the docs: `CLIENT TRACKING` metrics/limits, `COMMANDLOG` subcommands/config, cluster cross-slot behavior and scan guidance, `SET ... IFEQ`/`DELIFEQ` return/replication notes, Lua function timeout/kill behavior and `server.pcall` handling, hash-field TTL command syntax/return codes, and various patterns (sessions/locks/counters/rate limiting/geo) to fix prior misconceptions (e.g., pipelining vs atomicity, hash-tag slotting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 952133882294843a6f880ca5208ad4869148afe2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->