### PR TITLE
valkey-bloom-dev: trim rule violations, validate against 1.0.1

### DIFF
--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/SKILL.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/SKILL.md
@@ -1,96 +1,75 @@
 ---
 name: valkey-bloom-dev
-description: "Use when contributing to valkey-io/valkey-bloom source - Rust bloom filter internals, building, testing, RDB/AOF, replication, or reviewing PRs. Not for using BF commands in apps (valkey) or Valkey server internals (valkey-dev)."
-version: 1.0.0
+description: "Use when contributing to valkey-io/valkey-bloom source - Rust bloom filter internals, scaling, persistence (RDB/AOF), replication, build, tests, CI, or reviewing module PRs. Not for using BF commands in apps (valkey) or Valkey server internals (valkey-dev)."
+version: 2.0.0
 argument-hint: "[area or task]"
 ---
 
-# Valkey Bloom Module - Contributor Reference
+# valkey-bloom contributor reference
 
-## Not This Skill
+Targets valkey-bloom 1.0.1. Module registers itself as `bf` (not `bloom`). All Rust, loaded as `libvalkey_bloom.{so,dylib}`.
 
-- Using BF.ADD/BF.EXISTS/BF.RESERVE in applications -> use valkey
-- Valkey server internals -> use valkey-dev
+## Not this skill
 
-## Routing
+- Apps calling BF.ADD / BF.EXISTS -> use `valkey`.
+- Valkey server internals -> use `valkey-dev`.
 
-- BloomObject struct, scaling, sub-filters, tightening ratio, fp_rate, expansion, VALIDATESCALETO -> Architecture (bloom-object)
-- BloomFilter struct, bloomfilter crate, seed handling, random vs fixed, item add/check -> Architecture (bloom-filter)
-- RDB save/load, AOF rewrite, bincode serialization, BF.LOAD encoding, copy callback -> Architecture (persistence)
-- Defrag callbacks, cursor-based defrag, INFO bf metrics, atomic counters -> Architecture (defrag-metrics)
-- Memory layout, SipHash, memory limit, validate_size, bloom-memory-usage-limit -> Architecture (bloom-object)
-- Module initialization, valid_server_version, HANDLE_IO_ERRORS -> Architecture (bloom-object)
-- BF.ADD, BF.MADD, BF.EXISTS, BF.MEXISTS, BF.CARD, BF.INFO, auto-creation -> Commands (command-handlers)
-- BF.INFO field queries: CAPACITY, SIZE, FILTERS, ITEMS, ERROR, EXPANSION -> Commands (command-handlers)
-- BF.RESERVE, BF.INSERT, BF.LOAD, NOCREATE, argument parsing -> Commands (bf-reserve-insert)
-- TIGHTENING/SEED as replication-only args, BF.LOAD deserialization, BUSYKEY -> Commands (bf-reserve-insert)
-- Replication strategy, ReplicateArgs, reserve vs add-only, deterministic replication -> Commands (replication)
-- must_obey_client, valkey_8_0 feature, 8.0 vs 8.1 compat, size limit bypass -> Commands (replication)
-- Keyspace notifications, bloom.add, bloom.reserve, replicate_verbatim -> Commands (replication)
-- bloom-memory-usage-limit, bloom-capacity, bloom-expansion, bloom-defrag-enabled -> Commands (module-configs)
-- bloom-fp-rate, bloom-tightening-ratio, on_string_config_set, string->f64 validation -> Commands (module-configs)
-- bloom-use-random-seed, FIXED_SEED, module_args_as_configuration -> Commands (module-configs)
-- Cargo build, feature flags, clippy, cdylib, ValkeyAlloc, build.sh -> Contributing (build)
-- Unit tests, rstest, parameterized tests, cargo test -> Contributing (testing)
-- Python integration tests, pytest, valkey-test-framework, conftest -> Contributing (testing)
-- CI pipeline, GitHub Actions, build-ubuntu, build-macos, asan-build -> Contributing (ci-pipeline)
-- ASAN, LeakSanitizer, skip_for_asan, sanitizer detection -> Contributing (ci-pipeline)
-- Code structure, adding commands, command_handler.rs, data_type.rs, directory layout -> Contributing (code-structure)
-- ACL category, BloomError, command metadata JSON, module registration -> Contributing (code-structure)
+## Route by work area
 
-## Quick Start
+| Working on... | File |
+|---------------|------|
+| BloomObject struct, scale-out sequence, FP tightening, memory-limit validators, VALIDATESCALETO / MAXSCALEDCAPACITY, accessors, Drop | `reference/architecture-bloom-object.md` |
+| BloomFilter struct, `bloomfilter` crate (3.0.1), seed modes (random / FIXED_SEED), per-filter add/check, sizing, COPY deep-copy | `reference/architecture-bloom-filter.md` |
+| RDB save format and load validation, AOF rewrite via BF.LOAD, bincode encode/decode, version bytes, COPY callback, AUX ignore, BLOOM_TYPE registration | `reference/architecture-persistence.md` |
+| 5-layer defrag order, cursor-incremental resume, DEFRAG_BLOOM_FILTER swap placeholder, `external_vec_defrag`, `bloom-defrag-enabled`, INFO bf sections, 7 atomic counters | `reference/architecture-defrag-metrics.md` |
+| BF.ADD / BF.MADD / BF.EXISTS / BF.MEXISTS / BF.CARD / BF.INFO handlers, auto-creation defaults, `handle_bloom_add` multi-mode, INFO field table, command flags and ACL | `reference/commands-command-handlers.md` |
+| BF.RESERVE / BF.INSERT argument parsing, TIGHTENING and SEED replication-internal args, VALIDATESCALETO check, NOCREATE, internal BF.LOAD, error summary | `reference/commands-bf-reserve-insert.md` |
+| Deterministic replication, three cases, synthetic BF.INSERT form, ReplicateArgs, must_obey_client (8.0 vs 8.1+), size-limit bypass, keyspace events | `reference/commands-replication.md` |
+| 7 module configs (defaults + ranges), string-as-f64 pattern, `on_string_config_set`, storage (AtomicI64 vs ValkeyGILGuard + Mutex<f64>), FIXED_SEED, BLOOM_MIN_SUPPORTED_VERSION, `module_args_as_configuration` | `reference/commands-module-configs.md` |
+| Cargo setup (cdylib, `valkey_bloom`), feature flags (`enable-system-alloc`, `valkey_8_0`), ValkeyAlloc, `build.sh` env vars, build.sh vs CI differences | `reference/contributing-build.md` |
+| Unit tests (rstest seed parameterization), integration tests (pytest + valkey-test-framework), base class helpers, test inventory, ASAN skip, running tests | `reference/contributing-testing.md` |
+| CI jobs (ubuntu / macos / asan), matrix, LeakSanitizer detection scan, release-trigger workflow dispatching to valkey-bundle, debug tips | `reference/contributing-ci-pipeline.md` |
+| Directory layout, `valkey_module!` registration, command registration pattern, command JSON metadata, `BloomError` enum + error strings, adding a new command | `reference/contributing-code-structure.md` |
+
+## Critical rules
+
+1. **ValkeyAlloc is the global allocator.** Unit tests fail without `--features enable-system-alloc`.
+2. **Seeds must be deterministic for replication.** Primary replicates creation as a synthetic `BF.INSERT ... TIGHTENING <r> SEED <32 bytes> ...` so the replica's filter hashes identically.
+3. **Size limit is primary-only.** When `must_obey_client(ctx)` is true (replica / AOF replay), `validate_size_limit` is false - replicas must accept whatever the primary accepted.
+4. **`valkey_8_0` feature flag swaps `must_obey_client`** from `ValkeyModule_MustObeyClient` (8.1+) to `ContextFlags::REPLICATED` fallback.
+5. **AOF rewrite emits BF.LOAD; replication emits synthetic BF.INSERT** - two different paths. Don't conflate.
+6. **All sub-filters in an object share the first filter's seed.** `BloomObject::seed()` returns `filters[0].seed()`. Scale-out uses `with_fixed_seed(self.seed())`.
+
+## Grep hazards
+
+Names that differ from similar modules or that an agent might get wrong:
+
+- **Module name is `bf`, not `bloom`**. `MODULE_NAME = "bf"`, ACL category is `"bloom"`, data type is `"bloomfltr"` (9 chars, max). Configs prefixed with `bf.` in `CONFIG SET`.
+- `MODULE_VERSION = 999999` on dev, Cargo version `99.99.99-dev`. Both rewritten at release. `MODULE_RELEASE_STAGE` runs `"dev"` -> `"rc1"..` -> `"ga"`.
+- `BLOOM_TYPE_ENCODING_VERSION` (RDB encver) and `BLOOM_OBJECT_VERSION` (bincode prefix) are **distinct**, both currently 1. Bumping rules: `BLOOM_OBJECT_VERSION` bumps when `BloomObject` struct layout changes; `BLOOM_TYPE_ENCODING_VERSION` bumps when RDB field layout changes.
+- `BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX = i32::MAX` - the hard filter-count ceiling. 128 MB memory limit hits first in practice.
+- `BLOOM_MIN_SUPPORTED_VERSION = &[8, 0, 0]` - module refuses to load on Valkey 7.x.
+- `expansion == 0` is the in-memory representation of `NONSCALING`. Config register-range allows 0; command-level `EXPANSION` arg enforces `>= 1`.
+- Seed RDB-load check: `!is_seed_random && filter.seed() != FIXED_SEED` aborts load. Catches mismatched `FIXED_SEED` constants across builds.
+- RDB per-filter layout stores `num_items` **only for the last filter**; others are assumed `num_items == capacity`. Don't add `num_items` reads in a straight loop.
+- `on_string_config_set` handles both `bloom-fp-rate` and `bloom-tightening-ratio` - paired with `BLOOM_FP_RATE_F64` / `BLOOM_TIGHTENING_F64` `Mutex<f64>` caches to avoid repeated string parsing.
+- `module_args_as_configuration: true` means load args feed the config system - `initialize`'s `_args: &[ValkeyString]` is unused by design.
+- `extern "C"` callbacks live in `src/wrapper/bloom_callback.rs`, not alongside the type definitions in `src/bloom/`.
+- **Vec defrag counter bug**: step 4 of defrag (the `Vec<Box<BloomFilter>>` backing array) increments `BLOOM_DEFRAG_HITS` in **both** branches instead of splitting hits/misses. Known source issue.
+- BF.LOAD is the only write command without the `fast` flag (`"write deny-oom"`). It deserializes a full bloom.
+- `ValidateScaleToExceedsMaxSize` and `ValidateScaleToFalsePositiveInvalid` errors are produced by `calculate_max_scaled_capacity` during BF.INSERT's VALIDATESCALETO check. Not replicated.
+- `DEFRAG_BLOOM_FILTER` is a global `lazy_static Mutex<Option<Box<Bloom<[u8]>>>>` used only as a swap placeholder during defrag of the inner bloom pointer. Don't interpret it as live state.
+
+## Quick-start
 
 ```bash
-# Build for Valkey >= 8.1
-cargo build --release
-
-# Build for Valkey 8.0
-cargo build --release --features valkey_8_0
-
-# Unit tests (requires system allocator)
-cargo test --features enable-system-alloc
-
-# Load into Valkey
+cargo build --release                               # Valkey 8.1+
+cargo build --release --features valkey_8_0         # Valkey 8.0
+cargo test --features enable-system-alloc           # unit tests
 valkey-server --loadmodule ./target/release/libvalkey_bloom.so
-
-# Integration tests (requires running Valkey with module loaded)
-python3 -m pytest tests/ -v
+python3 -m pytest tests/ -v                         # integration (needs build.sh setup)
 ```
 
-Commands: BF.ADD, BF.MADD, BF.EXISTS, BF.MEXISTS, BF.CARD, BF.RESERVE, BF.INFO, BF.INSERT, BF.LOAD
+Commands: BF.ADD, BF.MADD, BF.EXISTS, BF.MEXISTS, BF.CARD, BF.RESERVE, BF.INFO, BF.INSERT, BF.LOAD.
 
-## Critical Rules
-
-1. **ValkeyAlloc is the global allocator** - the module uses `#[global_allocator]` with ValkeyAlloc so Valkey tracks all memory; unit tests need `--features enable-system-alloc` to swap in the system allocator
-2. **Seeds must be deterministic for replication** - BF.INSERT sends SEED and TIGHTENING as replication-only arguments to ensure replicas build identical filters
-3. **Respect bloom-memory-usage-limit** - size validation via `validate_size` must pass before creating or scaling; replicas bypass via `must_obey_client`
-4. **Feature flag for 8.0 compat** - `--features valkey_8_0` gates APIs unavailable on Valkey 8.0 (e.g., keyspace notifications)
-5. **Tests are non-negotiable** - unit tests via rstest + cargo test, integration tests via pytest with valkey-test-framework
-6. **CI runs ASAN builds** - address sanitizer catches memory issues; use `skip_for_asan` for tests incompatible with leak detection
-
-## Architecture
-
-| Topic | Reference |
-|-------|-----------|
-| BloomObject struct, scaling mechanism, FP tightening, memory limits, VALIDATESCALETO | [bloom-object](reference/architecture-bloom-object.md) |
-| BloomFilter struct, bloomfilter crate, seed handling, item add/check flow | [bloom-filter](reference/architecture-bloom-filter.md) |
-| RDB save/load, AOF rewrite, bincode encode/decode, copy callback, data type registration | [persistence](reference/architecture-persistence.md) |
-| Defrag callbacks, cursor-based incremental defrag, INFO bf metrics, atomic counters | [defrag-metrics](reference/architecture-defrag-metrics.md) |
-
-## Commands and Replication
-
-| Topic | Reference |
-|-------|-----------|
-| BF.ADD, BF.MADD, BF.EXISTS, BF.MEXISTS, BF.CARD, BF.INFO handlers | [command-handlers](reference/commands-command-handlers.md) |
-| BF.RESERVE, BF.INSERT, BF.LOAD, NOCREATE, VALIDATESCALETO, replication args | [bf-reserve-insert](reference/commands-bf-reserve-insert.md) |
-| Deterministic replication, must_obey_client, keyspace notifications | [replication](reference/commands-replication.md) |
-| All 7 configs, defaults, ranges, on_string_config_set, module_args_as_configuration | [module-configs](reference/commands-module-configs.md) |
-
-## Build and Contributing
-
-| Topic | Reference |
-|-------|-----------|
-| Cargo.toml, cdylib, dependencies, feature flags, ValkeyAlloc, build.sh | [build](reference/contributing-build.md) |
-| Unit tests (rstest, parameterized), integration test framework, test helpers | [testing](reference/contributing-testing.md) |
-| GitHub Actions CI jobs, matrix versions, ASAN/LeakSanitizer, release workflow | [ci-pipeline](reference/contributing-ci-pipeline.md) |
-| Directory layout, module registration, command metadata JSON, error types, adding new commands | [code-structure](reference/contributing-code-structure.md) |
+Configs: `bloom-capacity` (100), `bloom-expansion` (2), `bloom-fp-rate` ("0.01"), `bloom-tightening-ratio` ("0.5"), `bloom-memory-usage-limit` (128 MB), `bloom-use-random-seed` (true), `bloom-defrag-enabled` (true).

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/SKILL.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/SKILL.md
@@ -25,7 +25,7 @@ Targets valkey-bloom 1.0.1. Module registers itself as `bf` (not `bloom`). All R
 | BF.ADD / BF.MADD / BF.EXISTS / BF.MEXISTS / BF.CARD / BF.INFO handlers, auto-creation defaults, `handle_bloom_add` multi-mode, INFO field table, command flags and ACL | `reference/commands-command-handlers.md` |
 | BF.RESERVE / BF.INSERT argument parsing, TIGHTENING and SEED replication-internal args, VALIDATESCALETO check, NOCREATE, internal BF.LOAD, error summary | `reference/commands-bf-reserve-insert.md` |
 | Deterministic replication, three cases, synthetic BF.INSERT form, ReplicateArgs, must_obey_client (8.0 vs 8.1+), size-limit bypass, keyspace events | `reference/commands-replication.md` |
-| 7 module configs (defaults + ranges), string-as-f64 pattern, `on_string_config_set`, storage (AtomicI64 vs ValkeyGILGuard + Mutex<f64>), FIXED_SEED, BLOOM_MIN_SUPPORTED_VERSION, `module_args_as_configuration` | `reference/commands-module-configs.md` |
+| 7 module configs (defaults + ranges), string-as-f64 pattern, `on_string_config_set`, storage (`AtomicI64` vs `ValkeyGILGuard` + `Mutex<f64>`), FIXED_SEED, BLOOM_MIN_SUPPORTED_VERSION, `module_args_as_configuration` | `reference/commands-module-configs.md` |
 | Cargo setup (cdylib, `valkey_bloom`), feature flags (`enable-system-alloc`, `valkey_8_0`), ValkeyAlloc, `build.sh` env vars, build.sh vs CI differences | `reference/contributing-build.md` |
 | Unit tests (rstest seed parameterization), integration tests (pytest + valkey-test-framework), base class helpers, test inventory, ASAN skip, running tests | `reference/contributing-testing.md` |
 | CI jobs (ubuntu / macos / asan), matrix, LeakSanitizer detection scan, release-trigger workflow dispatching to valkey-bundle, debug tips | `reference/contributing-ci-pipeline.md` |

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/architecture-bloom-filter.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/architecture-bloom-filter.md
@@ -1,206 +1,90 @@
-# BloomFilter Struct and bloomfilter Crate
+# BloomFilter - sub-filter and bloomfilter crate integration
 
-Use when understanding the individual sub-filter implementation, how the bloomfilter crate is integrated, seed handling (random vs fixed), item add/check flow, or how filters are reconstructed from RDB data.
+Use when reasoning about the individual sub-filter, the `bloomfilter` crate, seed handling, or per-filter add/check.
 
-Source: `src/bloom/utils.rs`, `Cargo.toml`
+Source: `src/bloom/utils.rs`.
 
-## Contents
-
-- BloomFilter Struct (line 20)
-- The bloomfilter Crate (line 38)
-- Constructor Methods (line 52)
-- Seed Handling (line 95)
-- Item Add and Check Flow (line 121)
-- Memory Sizing (line 145)
-- Copy and Serialization Support (line 171)
-- Drop Implementation (line 185)
-
----
-
-## BloomFilter Struct
-
-Defined at line 566 of `src/bloom/utils.rs`. Each BloomFilter wraps a single instance of the external `bloomfilter` crate's `Bloom<[u8]>` type.
+## Struct
 
 ```rust
 #[derive(Serialize, Deserialize)]
 pub struct BloomFilter {
     #[serde(serialize_with = "serialize", deserialize_with = "deserialize_boxed_bloom")]
-    bloom: Box<bloomfilter::Bloom<[u8]>>,  // Bit vector + SipHash hasher
-    num_items: i64,                         // Items currently stored
-    capacity: i64,                          // Max items before parent scales
+    bloom: Box<bloomfilter::Bloom<[u8]>>,  // bit vec + SipHash keys
+    num_items: i64,
+    capacity: i64,
 }
 ```
 
-The `bloom` field uses custom serde helpers from the `bloomfilter` crate: `serialize` and `deserialize` (re-exported as `deserialize_boxed_bloom` to produce a `Box`). These handle the internal bit vector and hasher state during bincode serialization for AOF rewrite via BF.LOAD.
+`num_items` / `capacity` are `i64` even though item counts can't exceed u32::MAX in practice - the 128 MB memory cap hits far earlier. Serde wiring uses the crate's `serialize` and a local `deserialize_boxed_bloom` wrapper to produce a `Box<Bloom>`.
 
-The comment at line 559 notes the struct is approximately 200 bytes (not counting the heap-allocated bit vector). The source comment mentions `u32` for `num_items` and `capacity`, but the actual fields are `i64` - the 128MB per-object memory limit makes u32::MAX items unreachable regardless.
+## `bloomfilter` crate (3.0.1)
 
-## The bloomfilter Crate
+External crate providing:
 
-The module depends on `bloomfilter` version 3.0.1 (`Cargo.toml`). This external crate provides:
+- `Bloom<[u8]>` over a `Vec<u8>` bit vector.
+- SipHash-1-3, 32-byte seed -> two 64-bit SIP keys.
+- `new_for_fp_rate(cap, fp)` / `new_for_fp_rate_with_seed(cap, fp, &[u8;32])` - compute optimal bits and hash functions.
+- `set(&[u8])` / `check(&[u8])` - hash + bit ops.
+- `as_slice()` / `from_slice(&[u8])` - raw bitmap for RDB (the SipHash keys are embedded in the byte stream, so seed is preserved implicitly).
+- `to_bytes()` - full state for `COPY`.
+- `compute_bitmap_size(cap, fp)` - byte count without allocation.
+- `realloc_large_heap_allocated_objects(fn)` - defrag hook for the inner Vec.
 
-- **Bit vector storage**: `Bloom<[u8]>` stores the filter bits as a `Vec<u8>`
-- **SipHash hashing**: Uses SipHash-1-3 with a 32-byte seed to derive two 64-bit SIP keys
-- **Optimal sizing**: `new_for_fp_rate(capacity, fp_rate)` calculates the optimal number of bits and hash functions for the desired false positive rate
-- **Bitmap operations**: `set(item)` hashes and sets bits, `check(item)` hashes and tests bits
-- **Serde support**: `serialize`/`deserialize` functions for the `Bloom` struct, used by bincode
-- **Bitmap access**: `as_slice()` returns the raw bit vector as `&[u8]` for RDB persistence, `from_slice(bitmap)` reconstructs from raw bytes
-- **Size computation**: `compute_bitmap_size(capacity, fp_rate)` returns the byte count for the bit vector without allocating
-- **Seed access**: `seed()` returns the 32-byte seed, `to_bytes()` serializes the full state
-- **Realloc callback**: `realloc_large_heap_allocated_objects(callback)` supports custom reallocation of the internal Vec for defragmentation
+## Constructors
 
-## Constructor Methods
+| Method | Use |
+|--------|-----|
+| `with_fixed_seed(fp, cap, &seed)` | scale-out (subsequent filters inherit first filter's seed), replication (SEED arg), fixed-seed mode |
+| `with_random_seed(fp, cap)` | first filter only, when `bloom-use-random-seed=true` and no explicit seed |
+| `from_existing(bitmap, num_items, capacity)` | RDB load - reconstructs via `Bloom::from_slice`, recovers hasher state from the bitmap bytes |
 
-**`with_fixed_seed`** (line 585) - Creates a filter with a specific 32-byte seed:
+All three call `bloom_filter_incr_metrics_on_new_create`.
 
-```rust
-pub fn with_fixed_seed(fp_rate: f64, capacity: i64, fixed_seed: &[u8; 32]) -> BloomFilter {
-    let bloom = bloomfilter::Bloom::new_for_fp_rate_with_seed(
-        capacity as usize, fp_rate, fixed_seed,
-    ).expect("We expect bloomfilter::Bloom<[u8]> creation to succeed");
-    BloomFilter { bloom: Box::new(bloom), num_items: 0, capacity }
-}
-```
+## Seed handling
 
-Used for: scale-out (new sub-filters inherit the first filter's seed), replica creation (deterministic replication via `BF.INSERT ... SEED`), and fixed-seed mode.
+`FIXED_SEED` in `src/configs.rs` is a compile-time `[u8; 32]` constant. Seed policy is controlled by `bloom-use-random-seed` (default: true):
 
-**`with_random_seed`** (line 599) - Creates a filter with a crate-generated random seed:
+| Mode | First filter | Sub-filters | Replication (SEED arg) |
+|------|--------------|-------------|------------------------|
+| Random (default) | `with_random_seed` | `with_fixed_seed(self.seed())` | actual random seed |
+| Fixed (`no`) | `with_fixed_seed(FIXED_SEED)` | `with_fixed_seed(self.seed())` | `FIXED_SEED` |
 
-```rust
-pub fn with_random_seed(fp_rate: f64, capacity: i64) -> BloomFilter {
-    let bloom = Box::new(
-        bloomfilter::Bloom::new_for_fp_rate(capacity as usize, fp_rate)
-            .expect("We expect bloomfilter::Bloom<[u8]> creation to succeed"),
-    );
-    BloomFilter { bloom, num_items: 0, capacity }
-}
-```
+All sub-filters in an object share the first filter's seed. `BloomObject::seed()` delegates to `filters[0].seed()`.
 
-Used only for creating the very first filter of a BloomObject when `bloom-use-random-seed` is true and no explicit seed is provided.
+On RDB load, if `is_seed_random == false` and a restored filter's seed differs from the local `FIXED_SEED` constant, load fails with "Object in fixed seed mode, but seed does not match FIXED_SEED." - catches cross-build mismatches.
 
-**`from_existing`** (line 614) - Reconstructs from a raw bitmap during RDB load:
+## Add and check
 
 ```rust
-pub fn from_existing(bitmap: &[u8], num_items: i64, capacity: i64) -> BloomFilter {
-    let bloom = bloomfilter::Bloom::from_slice(bitmap)
-        .expect("We expect bloomfilter::Bloom<[u8]> creation to succeed");
-    BloomFilter { bloom: Box::new(bloom), num_items, capacity }
-}
+pub fn check(&self, item: &[u8]) -> bool { self.bloom.check(item) }
+pub fn set(&mut self, item: &[u8])        { self.bloom.set(item) }
 ```
 
-The `from_slice` method reconstructs the entire `Bloom` struct from the raw bytes, including the SipHash keys embedded in the bitmap header. RDB restore recovers the hasher state without explicitly saving seed data per filter.
+`set` does not check for existence. Dedup is the caller's job: `BloomObject::add_item` scans all filters before setting, so `num_items` is incremented only on genuinely new items.
 
-All three constructors call `bloom_filter_incr_metrics_on_new_create` to update global counters.
-
-## Seed Handling
-
-The 32-byte seed is the foundation for deterministic behavior. It flows through the system as follows:
-
-**FIXED_SEED constant** (line 68 of `src/configs.rs`):
-
-```rust
-pub const FIXED_SEED: [u8; 32] = [
-    89, 15, 245, 34, 234, 120, 17, 218, 167, 20, 216, 9, 59, 62, 123, 217,
-    29, 137, 138, 115, 62, 152, 136, 135, 48, 127, 151, 205, 40, 7, 51, 131,
-];
-```
-
-**Seed modes** controlled by `bloom-use-random-seed` config (default: true):
-
-| Mode | First Filter Creation | Sub-Filter Creation | Replication |
-|------|----------------------|--------------------|----|
-| Random seed | `with_random_seed` | `with_fixed_seed(self.seed())` | Sends actual seed via `SEED` arg |
-| Fixed seed | `with_fixed_seed(FIXED_SEED)` | `with_fixed_seed(self.seed())` | Sends FIXED_SEED via `SEED` arg |
-
-All sub-filters within a BloomObject always share the same seed as the first filter, regardless of seed mode. The `seed()` method on BloomObject delegates to the first filter's `seed()`.
-
-**RDB load seed validation** (line 123 of `data_type.rs`): When `is_seed_random` is false, each restored filter's seed is checked against `FIXED_SEED`. If they don't match, the restore fails with "Object in fixed seed mode, but seed does not match FIXED_SEED."
-
-**`is_seed_random` flag**: Stored in the BloomObject and persisted to RDB. Controls whether the fixed-seed validation is applied during restore. When true, any seed is accepted (since it was randomly generated and embedded in the bitmap).
-
-## Item Add and Check Flow
-
-**Check** (`check` method, line 681):
-
-```rust
-pub fn check(&self, item: &[u8]) -> bool {
-    self.bloom.check(item)
-}
-```
-
-Delegates directly to the crate. The crate hashes the item bytes with SipHash, derives bit positions, and tests each bit in the internal Vec.
-
-**Set** (`set` method, line 685):
-
-```rust
-pub fn set(&mut self, item: &[u8]) {
-    self.bloom.set(item)
-}
-```
-
-Delegates to the crate. Hashes the item and sets the corresponding bits. `set` does not check for existence - the caller (`BloomObject::add_item`) handles dedup by scanning all filters first.
-
-`BloomFilter` does not track whether individual items were already present. The `num_items` counter is incremented by the parent `BloomObject::add_item` only when a genuinely new item is added.
-
-## Memory Sizing
-
-**`number_of_bytes`** (line 668) - Actual memory of this filter:
+## Memory sizing
 
 ```rust
 pub fn number_of_bytes(&self) -> usize {
     size_of::<BloomFilter>()
-        + size_of::<bloomfilter::Bloom<[u8]>>()
-        + (self.bloom.len() / 8) as usize
+      + size_of::<bloomfilter::Bloom<[u8]>>()
+      + (self.bloom.len() / 8) as usize   // len() is bits
 }
-```
 
-Three components: the `BloomFilter` struct itself, the heap-allocated `Bloom<[u8]>` struct, and the bit vector bytes (`bloom.len()` returns bits, divided by 8).
-
-**`compute_size`** (line 675) - Projected size without allocation:
-
-```rust
 pub fn compute_size(capacity: i64, fp_rate: f64) -> usize {
     size_of::<BloomFilter>()
-        + size_of::<bloomfilter::Bloom<[u8]>>()
-        + bloomfilter::Bloom::<[u8]>::compute_bitmap_size(capacity as usize, fp_rate)
+      + size_of::<bloomfilter::Bloom<[u8]>>()
+      + bloomfilter::Bloom::<[u8]>::compute_bitmap_size(capacity as usize, fp_rate)
 }
 ```
 
-Used by `BloomObject::validate_size_before_create` and `validate_size_before_scaling` to check memory limits before allocating.
+`compute_size` drives `validate_size_before_create` / `validate_size_before_scaling` pre-allocation checks.
 
-## Copy and Serialization Support
+## `create_copy_from` (COPY command)
 
-**`create_copy_from`** (line 630) - For the `COPY` command:
+`BloomFilter::from_existing(&bf.bloom.to_bytes(), bf.num_items, bf.capacity)` - serializes then reconstructs. Produces an independent heap allocation.
 
-```rust
-pub fn create_copy_from(bf: &BloomFilter) -> BloomFilter {
-    BloomFilter::from_existing(&bf.bloom.to_bytes(), bf.num_items, bf.capacity)
-}
-```
+## Drop
 
-Serializes the bloom to bytes via `to_bytes()`, then reconstructs via `from_existing`. Produces a fully independent copy with its own heap allocation.
-
-**Serde integration**: The `#[serde]` attributes on the `bloom` field use the crate's `serialize` and a custom `deserialize_boxed_bloom` wrapper (line 576) that deserializes into a `Box<Bloom<[u8]>>`. This is used by bincode for the AOF rewrite path (BF.LOAD encoding).
-
-## Drop Implementation
-
-`BloomFilter` implements `Drop` (line 699) to decrement global metrics:
-
-```rust
-impl Drop for BloomFilter {
-    fn drop(&mut self) {
-        metrics::BLOOM_NUM_FILTERS_ACROSS_OBJECTS.fetch_sub(1, Ordering::Relaxed);
-        metrics::BLOOM_OBJECT_TOTAL_MEMORY_BYTES.fetch_sub(
-            self.number_of_bytes(), Ordering::Relaxed,
-        );
-        metrics::BLOOM_NUM_ITEMS_ACROSS_OBJECTS.fetch_sub(
-            self.num_items as u64, Ordering::Relaxed,
-        );
-        metrics::BLOOM_CAPACITY_ACROSS_OBJECTS.fetch_sub(
-            self.capacity as u64, Ordering::Relaxed,
-        );
-    }
-}
-```
-
-Decrements four counters: filter count, memory bytes, item count, and capacity. Combined with BloomObject's Drop (which handles object count and object-level overhead), all metrics stay accurate through the full lifecycle.
+Decrements four counters: `BLOOM_NUM_FILTERS_ACROSS_OBJECTS`, `BLOOM_OBJECT_TOTAL_MEMORY_BYTES` (by `number_of_bytes()`), `BLOOM_NUM_ITEMS_ACROSS_OBJECTS` (by `num_items`), `BLOOM_CAPACITY_ACROSS_OBJECTS` (by `capacity`). Paired with `BloomObject::Drop` (object count + overhead), keeps all seven metrics consistent through the lifecycle.

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/architecture-bloom-object.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/architecture-bloom-object.md
@@ -1,213 +1,89 @@
-# BloomObject Struct and Scaling Mechanism
+# BloomObject - scaling container
 
-Use when understanding the top-level bloom filter container, how sub-filters scale out, false positive tightening, memory limit enforcement, or the VALIDATESCALETO logic.
+Use when reasoning about the top-level bloom filter, scale-out, FP tightening, memory limits, or VALIDATESCALETO.
 
-Source: `src/bloom/utils.rs`
+Source: `src/bloom/utils.rs`.
 
-## Contents
-
-- BloomObject Struct (line 22)
-- Constructor Methods (line 39)
-- Scaling Mechanism (line 62)
-- FP Rate Tightening (line 84)
-- Non-Scaling Behavior (line 108)
-- Memory Limit Enforcement (line 119)
-- Maximum Filters and VALIDATESCALETO (line 150)
-- Item Operations (line 168)
-- Accessor Methods (line 183)
-- Drop Implementation (line 198)
-
----
-
-## BloomObject Struct
-
-Defined at line 92 of `src/bloom/utils.rs`. The top-level container stored as a Valkey data type (`bloomfltr`), holding one or more sub-filters in a chain.
+## Struct
 
 ```rust
 #[derive(Serialize, Deserialize)]
 pub struct BloomObject {
-    expansion: u32,                    // Scale factor per new filter (0 = non-scaling)
-    fp_rate: f64,                      // Target false positive rate for the object
-    tightening_ratio: f64,             // FP decay multiplier per scale-out (default 0.5)
-    is_seed_random: bool,              // Whether the seed was randomly generated
-    filters: Vec<Box<BloomFilter>>,    // Chain of sub-filters
-}
-```
-
-`expansion` doubles as a non-scaling indicator: when set to 0, scaling is disabled and only one filter is allowed.
-
-## Constructor Methods
-
-Three constructors exist:
-
-**`new_reserved`** - Creates a fresh BloomObject. Called by `BF.RESERVE` and `BF.INSERT` (when creating). Accepts `fp_rate`, `tightening_ratio`, `capacity`, `expansion`, a seed tuple `(Option<[u8; 32]>, bool)`, and `validate_size_limit`. The seed tuple allows passing either a fixed seed or `None` for random. Validates size before creation when `validate_size_limit` is true.
-
-```rust
-pub fn new_reserved(
+    expansion: u32,                 // 0 = non-scaling (single filter, NONSCALING keyword sets this)
     fp_rate: f64,
     tightening_ratio: f64,
-    capacity: i64,
-    expansion: u32,
-    seed: (Option<[u8; 32]>, bool),
-    validate_size_limit: bool,
-) -> Result<BloomObject, BloomError>
-```
-
-**`from_existing`** - Reconstructs from RDB load or BF.LOAD restore. Takes all fields directly, no validation beyond what the caller performs.
-
-**`create_copy_from`** - Deep copy for the `COPY` command. Iterates all filters and calls `BloomFilter::create_copy_from` on each.
-
-All three constructors call `bloom_object_incr_metrics_on_new_create` to update global atomic counters.
-
-## Scaling Mechanism
-
-Scaling happens inside `add_item` (line 308) when the last filter reaches capacity. The full sequence:
-
-1. **Check existence**: Scan all filters via `item_exists`. If the item is already present in any filter, return 0 (no-op).
-
-2. **Try the last filter**: If `num_items < capacity` on the last filter, add the item there.
-
-3. **Non-scaling check**: If `expansion == 0`, return `NonScalingFilterFull`.
-
-4. **Filter count check**: If `num_filters == BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX` (i32::MAX), return `MaxNumScalingFilters`.
-
-5. **Calculate new FP rate**: `fp_rate * tightening_ratio^num_filters`. Must stay above `f64::MIN_POSITIVE` or return `FalsePositiveReachesZero`.
-
-6. **Calculate new capacity**: `last_filter.capacity * expansion` via `checked_mul`. Overflow returns `BadCapacity`.
-
-7. **Validate size**: If `validate_size_limit` is true, call `validate_size_before_scaling` to check the total object size against `bloom-memory-usage-limit`.
-
-8. **Create new filter**: Use `BloomFilter::with_fixed_seed` with the same seed as the first filter (`self.seed()`). All sub-filters in an object share the same seed.
-
-9. **Add and push**: Set the item in the new filter, increment `num_items`, push to `self.filters`.
-
-## FP Rate Tightening
-
-The `calculate_fp_rate` function (line 385) computes the FP rate for the Nth filter:
-
-```rust
-pub fn calculate_fp_rate(
-    fp_rate: f64,
-    num_filters: i32,
-    tightening_ratio: f64,
-) -> Result<f64, BloomError> {
-    match fp_rate * tightening_ratio.powi(num_filters) {
-        x if x > f64::MIN_POSITIVE => Ok(x),
-        _ => Err(BloomError::FalsePositiveReachesZero),
-    }
+    is_seed_random: bool,
+    filters: Vec<Box<BloomFilter>>,
 }
 ```
 
-With default tightening ratio 0.5 and FP rate 0.01:
-- Filter 0: `0.01 * 0.5^0 = 0.01`
-- Filter 1: `0.01 * 0.5^1 = 0.005`
-- Filter 2: `0.01 * 0.5^2 = 0.0025`
+`expansion == 0` doubles as a non-scaling flag; the filter vec then always contains exactly one entry.
 
-Each successive filter uses a stricter FP rate. The union of independent bloom filters with geometrically decreasing FP rates converges to the original target, maintaining the configured FP rate as the object scales.
+## Constructors
 
-## Non-Scaling Behavior
+- `new_reserved(fp_rate, tightening_ratio, capacity, expansion, seed: (Option<[u8;32]>, bool), validate_size_limit)` - used by BF.RESERVE / BF.INSERT creation. Validates size when `validate_size_limit`.
+- `from_existing(...)` - RDB load / BF.LOAD reconstruction, no validation.
+- `create_copy_from(&BloomObject)` - deep copy for `COPY`; iterates filters, delegates to `BloomFilter::create_copy_from`.
 
-When `expansion == 0`, the bloom object operates as a single fixed-capacity filter:
+All three call `bloom_object_incr_metrics_on_new_create`.
 
-- `BF.RESERVE` with `NONSCALING` sets `expansion = 0` internally
-- `add_item` returns `BloomError::NonScalingFilterFull` when the single filter reaches capacity
-- The `filters` vec always contains exactly one entry
-- `VALIDATESCALETO` and `NONSCALING` cannot be combined - the module returns `NON_SCALING_AND_VALIDATE_SCALE_TO_IS_INVALID`
+## Scale-out sequence (`add_item`)
 
-The expansion range for scaling filters is 1 to `BLOOM_EXPANSION_MAX` (u32::MAX). The default expansion is 2, configured via `bloom-expansion`.
+1. `item_exists` across all filters - if present, return `Ok(0)`.
+2. If last filter has room (`num_items < capacity`), add there.
+3. `expansion == 0` -> `NonScalingFilterFull`.
+4. `num_filters == BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX` (`i32::MAX`) -> `MaxNumScalingFilters`.
+5. New FP rate = `fp_rate * tightening_ratio^num_filters`. Below `f64::MIN_POSITIVE` -> `FalsePositiveReachesZero`.
+6. New capacity = `last_filter.capacity * expansion` via `checked_mul`. Overflow -> `BadCapacity`.
+7. If `validate_size_limit`, call `validate_size_before_scaling`.
+8. Create new filter via `BloomFilter::with_fixed_seed(self.seed())` - **all sub-filters share the first filter's seed**.
+9. Set item, increment `num_items`, push.
 
-## Memory Limit Enforcement
+## FP tightening (`calculate_fp_rate`)
 
-Three validation functions enforce the `bloom-memory-usage-limit` config (default 128MB):
+`fp_rate * tightening_ratio.powi(num_filters)`, returns `FalsePositiveReachesZero` when `<= f64::MIN_POSITIVE`.
 
-**`validate_size`** (line 216) - Core check. Compares a byte count against `BLOOM_MEMORY_LIMIT_PER_OBJECT`:
+Default tightening 0.5, fp_rate 0.01: filter N uses `0.01 * 0.5^N`. Geometric decay keeps the union's aggregate FP rate close to the original target.
 
-```rust
-pub fn validate_size(bytes: usize) -> bool {
-    if bytes > configs::BLOOM_MEMORY_LIMIT_PER_OBJECT.load(Ordering::Relaxed) as usize {
-        return false;
-    }
-    true
-}
-```
+## Memory limit enforcement
 
-**`validate_size_before_create`** (line 208) - Called during `new_reserved`. Computes the projected size of a new BloomObject with one filter:
+Three helpers against `BLOOM_MEMORY_LIMIT_PER_OBJECT` (default 128 MB):
 
-```rust
-let bytes = size_of::<BloomObject>()
-    + size_of::<Box<BloomFilter>>()
-    + BloomFilter::compute_size(capacity, fp_rate);
-```
+| Function | Called by | Check |
+|----------|-----------|-------|
+| `validate_size(bytes)` | all three below | `bytes <= limit` |
+| `validate_size_before_create(capacity, fp_rate)` | `new_reserved` | projected size of `BloomObject + one filter` |
+| `validate_size_before_scaling(&self, capacity, fp_rate)` | `add_item` scale-out | `self.memory_usage() + new filter size` |
 
-**`validate_size_before_scaling`** (line 200) - Called during `add_item` scale-out. Adds the projected new filter size to the current `memory_usage()`:
+All three are skipped when `must_obey_client` returns true (replica / AOF replay). Primary never lets replicas reject what it accepted.
 
-```rust
-let bytes = self.memory_usage() + BloomFilter::compute_size(capacity, fp_rate);
-```
+## VALIDATESCALETO and MAXSCALEDCAPACITY
 
-Size validation is skipped for replicated commands (when `must_obey_client` returns true). This prevents replicas from rejecting operations that the primary already accepted.
+`calculate_max_scaled_capacity` simulates scaling from `starting_capacity` multiplied by `expansion` each round, tracking cumulative filter memory with `next_power_of_two` (mimics `Vec` growth). Returns:
 
-## Maximum Filters and VALIDATESCALETO
+- `BF.INFO MAXSCALEDCAPACITY` (scale_to = -1) - total items reachable before memory or FP limit.
+- `BF.INSERT VALIDATESCALETO <n>` - checks target; errors are `ValidateScaleToExceedsMaxSize` or `ValidateScaleToFalsePositiveInvalid`.
 
-The maximum number of filters per object is `BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX`, set to `i32::MAX` (2,147,483,647). In practice, the 128MB memory limit is hit long before this.
+## Item operations
 
-The `calculate_max_scaled_capacity` function (line 500) simulates scaling to answer two questions:
+- `add_item` - `Ok(0)` dup, `Ok(1)` new, else `Err(BloomError)`.
+- `item_exists` - `self.filters.iter().any(|f| f.check(item))`.
+- `cardinality` / `capacity` - sum across filters.
+- `starting_capacity` - first filter's capacity (used by MAXSCALEDCAPACITY, not total).
 
-1. **BF.INFO MAXSCALEDCAPACITY**: How many total items can this object hold before hitting memory or FP limits? Called with `validate_scale_to = -1`.
+## Accessors
 
-2. **BF.INSERT VALIDATESCALETO**: Can this object scale to hold at least N total items? Called with the user-provided target.
+| Method | Returns | Note |
+|--------|---------|------|
+| `expansion()` | `u32` | 0 = non-scaling |
+| `fp_rate()` / `tightening_ratio()` | `f64` | |
+| `is_seed_random()` | `bool` | |
+| `num_filters()` | `usize` | |
+| `filters()` / `filters_mut()` | `&[/&mut] Vec<Box<BloomFilter>>` | mut used by defrag + decode |
+| `seed()` | `[u8; 32]` | first filter's seed (shared by all) |
+| `memory_usage()` | `usize` | object overhead + all filters |
+| `free_effort()` | `usize` | filter count (threshold for async free) |
 
-The simulation loop:
-- Starts with the initial capacity and iterates, multiplying by `expansion` each round
-- For each simulated filter, checks FP rate degradation and memory limits
-- Tracks `filters_memory_usage` cumulatively, computing vec capacity as `next_power_of_two` to match actual allocation behavior
-- Returns the total capacity reached, or an error if the target cannot be met
+## Drop
 
-Two errors are possible: `ValidateScaleToExceedsMaxSize` (memory limit) and `ValidateScaleToFalsePositiveInvalid` (FP rate reaches zero).
-
-## Item Operations
-
-**`add_item`** returns `Result<i64, BloomError>`:
-- `Ok(0)` - item already existed (checked across all filters)
-- `Ok(1)` - item was added (to last filter or a new scaled-out filter)
-- `Err(...)` - non-scaling full, max filters, size limit, capacity overflow
-
-**`item_exists`** checks all filters: `self.filters.iter().any(|filter| filter.check(item))`.
-
-**`cardinality`** sums `num_items` across all filters.
-
-**`capacity`** sums `capacity` across all filters.
-
-**`starting_capacity`** returns the first filter's capacity (the initial size before scaling).
-
-## Accessor Methods
-
-| Method | Returns | Notes |
-|--------|---------|-------|
-| `expansion()` | `u32` | 0 for non-scaling |
-| `fp_rate()` | `f64` | Object-level target rate |
-| `tightening_ratio()` | `f64` | Decay multiplier per filter |
-| `is_seed_random()` | `bool` | Random vs fixed seed mode |
-| `num_filters()` | `usize` | Current filter count |
-| `filters()` | `&Vec<Box<BloomFilter>>` | Immutable filter access |
-| `filters_mut()` | `&mut Vec<Box<BloomFilter>>` | Mutable access (defrag, decode) |
-| `seed()` | `[u8; 32]` | First filter's seed (shared by all) |
-| `memory_usage()` | `usize` | Total bytes including all filters |
-| `free_effort()` | `usize` | Filter count (for async free threshold) |
-
-## Drop Implementation
-
-`BloomObject` implements `Drop` (line 690) to decrement global metrics:
-
-```rust
-impl Drop for BloomObject {
-    fn drop(&mut self) {
-        metrics::BLOOM_OBJECT_TOTAL_MEMORY_BYTES.fetch_sub(
-            self.bloom_object_memory_usage(), Ordering::Relaxed,
-        );
-        metrics::BLOOM_NUM_OBJECTS.fetch_sub(1, Ordering::Relaxed);
-    }
-}
-```
-
-Decrements the object-level overhead only. Each `BloomFilter` in the vec has its own `Drop` that decrements filter-level metrics separately.
+Decrements `BLOOM_OBJECT_TOTAL_MEMORY_BYTES` by `bloom_object_memory_usage()` and `BLOOM_NUM_OBJECTS` by 1. Each `BloomFilter` has its own `Drop` that handles per-filter metrics separately.

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/architecture-defrag-metrics.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/architecture-defrag-metrics.md
@@ -1,93 +1,51 @@
-# Defragmentation and INFO Metrics
+# Defragmentation and INFO metrics
 
-Use when understanding bloom filter defragmentation callbacks, cursor-based incremental defrag, the DEFRAG_BLOOM_FILTER swap placeholder, bloom-defrag-enabled config, INFO bf sections, or atomic counter tracking.
+Use when reasoning about active defrag callbacks, cursor-incremental defrag, `bloom-defrag-enabled`, INFO bf sections, or atomic counter tracking.
 
-Source: `src/wrapper/bloom_callback.rs`, `src/metrics.rs`
+Source: `src/wrapper/bloom_callback.rs`, `src/metrics.rs`.
 
-## Contents
+## Defrag callback
 
-- Defrag Overview (line 21)
-- 5-Layer Defrag Order (line 37)
-- Cursor-Based Incremental Defrag (line 59)
-- DEFRAG_BLOOM_FILTER Swap Placeholder (line 88)
-- Bit Vector Defrag Callback (line 110)
-- bloom-defrag-enabled Config (line 133)
-- INFO bf Sections (line 147)
-- Atomic Counter Tracking (line 170)
-- Memory Usage Callback (line 199)
+`bloom_defrag` is wired as the data type's defrag callback, invoked by Valkey's `activedefrag` path. Returns `0` complete, `1` incomplete (resume next call).
 
----
+Gate: first check is `configs::BLOOM_DEFRAG.load(Relaxed)`. If false, returns 0 immediately. `activedefrag` server-wide must also be on.
 
-## Defrag Overview
+## 5-layer defrag order
 
-The `bloom_defrag` function (line 214 of `bloom_callback.rs`) is the data type defrag callback, invoked by Valkey's active defragmentation when `activedefrag yes` is set. It defragments every heap allocation owned by a BloomObject to reduce memory fragmentation.
+Per filter, in a loop (steps 1-3):
 
-The function signature:
+1. **`BloomFilter` box** - remove from vec, pass pointer to `defrag.alloc()`, re-box result.
+2. **Inner `Box<Bloom<[u8]>>`** - swap out via `mem::replace` with a placeholder (see below), `defrag.alloc()`.
+3. **Bit vector `Vec<u8>`** - via `realloc_large_heap_allocated_objects(external_vec_defrag)` on the inner `Bloom`.
 
-```rust
-pub unsafe extern "C" fn bloom_defrag(
-    defrag_ctx: *mut RedisModuleDefragCtx,
-    _from_key: *mut RedisModuleString,
-    value: *mut *mut c_void,
-) -> i32
-```
+After all filters (steps 4-5):
 
-Returns 0 for complete defragmentation, 1 for incomplete (will resume on next call).
+4. **`Vec<Box<BloomFilter>>` backing array** - convert to boxed slice, `defrag.alloc()`, reconstruct with `Vec::from_raw_parts` preserving length and capacity.
+5. **`BloomObject` top-level** - `defrag.alloc()` via the `value` double pointer.
 
-## 5-Layer Defrag Order
+Each `defrag.alloc()` either returns a new pointer (moved) or null (already in good place).
 
-Each BloomObject has five levels of heap allocation, defragmented in this order:
+**Known source bug**: the Vec defrag (step 4) increments `BLOOM_DEFRAG_HITS` in both branches - the null branch should increment `BLOOM_DEFRAG_MISSES`. Slightly inflates the hit counter.
 
-**Per filter (steps 1-3, in a loop):**
+## Cursor-incremental
 
-1. **BloomFilter struct** - The boxed `BloomFilter` allocation itself. Removed from the vec, passed to `defrag.alloc()`, re-boxed from the result.
-
-2. **Inner Bloom struct** - The `Box<bloomfilter::Bloom<[u8]>>` inside each BloomFilter. Swapped out via `mem::replace` with a temporary placeholder, then passed to `defrag.alloc()`.
-
-3. **Bit vector** - The `Vec<u8>` inside the crate's `Bloom` struct. Defragmented via the `realloc_large_heap_allocated_objects` callback pattern using `external_vec_defrag`.
-
-**After all filters (steps 4-5):**
-
-4. **Filters Vec** - The `Vec<Box<BloomFilter>>` itself (the backing array). Converted to a boxed slice, passed to `defrag.alloc()`, then reconstructed with `Vec::from_raw_parts` preserving the original length and capacity.
-
-5. **BloomObject** - The top-level struct allocation. Passed to `defrag.alloc()` via the `value` double pointer.
-
-Each `defrag.alloc()` call either returns a new pointer (the allocation was moved to reduce fragmentation) or null (the allocation was already in a good location). Both outcomes are tracked in metrics.
-
-The Vec defrag in step 4 (line 308 of `bloom_callback.rs`) increments `BLOOM_DEFRAG_HITS` in both the hit and miss branches - the else branch should increment `BLOOM_DEFRAG_MISSES`. Known source bug that slightly inflates the hit counter.
-
-## Cursor-Based Incremental Defrag
-
-Large BloomObjects with many sub-filters could block the server if defragmented in one shot. The callback uses Valkey's cursor mechanism to yield between filters:
+Large objects yield mid-defrag to avoid blocking:
 
 ```rust
 let mut cursor = defrag.get_cursor().unwrap_or(0);
-
 while !defrag.should_stop_defrag() && cursor < num_filters as u64 {
-    // Defrag filter at index `cursor`
-    // ...
+    // defrag filter at `cursor`
     cursor += 1;
 }
-
 defrag.set_cursor(cursor);
-
-if cursor < num_filters as u64 {
-    return 1;  // Incomplete - resume next time
-}
+if cursor < num_filters as u64 { return 1; }  // resume later
 ```
 
-The cursor tracks which filter index to resume from. On each invocation:
-- If `get_cursor` returns a value, resume from that index
-- If it returns `None` (first time or previously completed), start from 0
-- `should_stop_defrag()` checks if enough time has been spent
-- Return 1 if not all filters were processed, causing Valkey to re-invoke later
-- Return 0 after completing all filters plus the Vec and BloomObject defrag
+Steps 4-5 run only after all filters are processed.
 
-Steps 4 and 5 (Vec and BloomObject defrag) only run after all filters are processed.
+## DEFRAG_BLOOM_FILTER swap placeholder
 
-## DEFRAG_BLOOM_FILTER Swap Placeholder
-
-During inner Bloom struct defragmentation, the code needs to temporarily move the `Bloom<[u8]>` out of the BloomFilter. A global static placeholder is used for this swap:
+The inner `Bloom<[u8]>` must temporarily leave the `BloomFilter` during its own defrag. A global placeholder stands in:
 
 ```rust
 lazy_static! {
@@ -96,117 +54,61 @@ lazy_static! {
 }
 ```
 
-The swap sequence for each filter:
+Swap sequence per filter:
 
-1. Lock the mutex and take the placeholder out: `temporary_bloom.take()`
-2. Swap the real Bloom out of the BloomFilter using `mem::replace`, putting the placeholder in its place
-3. Attempt to defrag the real Bloom via `defrag.alloc()`
-4. Defrag the bit vector via `realloc_large_heap_allocated_objects`
-5. Swap the defragmented Bloom back into the BloomFilter
-6. Put the placeholder back into the static: `*temporary_bloom = Some(placeholder_bloom)`
+1. `temporary_bloom.take()` to extract placeholder.
+2. `mem::replace` the real Bloom out, placeholder in.
+3. `defrag.alloc()` on the real Bloom.
+4. Vec-defrag via `realloc_large_heap_allocated_objects`.
+5. Put real Bloom back.
+6. Restore placeholder into the static.
 
-Avoids leaving a null or invalid pointer in the BloomFilter during defrag. The placeholder is a minimal `Bloom::new(1, 1)` - capacity 1, 1 item - using negligible memory.
+Avoids leaving a null/invalid pointer visible. `Bloom::new(1, 1)` is minimal memory.
 
-## Bit Vector Defrag Callback
+## `external_vec_defrag`
 
-The `external_vec_defrag` function (line 167 of `bloom_callback.rs`) defragments the raw bit vector inside the bloomfilter crate's `Bloom` struct:
+Passed as the callback to `realloc_large_heap_allocated_objects`. Pattern: take `Vec<u8>`, `into_boxed_slice` for a stable pointer, `defrag.alloc()`, then reconstruct via `Vec::from_raw_parts(ptr, len, capacity)` preserving original len/capacity. Non-null branch increments `BLOOM_DEFRAG_HITS`; null branch `BLOOM_DEFRAG_MISSES`.
 
-```rust
-fn external_vec_defrag(vec: Vec<u8>) -> Vec<u8> {
-    let defrag = Defrag::new(core::ptr::null_mut());
-    let len = vec.len();
-    let capacity = vec.capacity();
-    let vec_ptr = Box::into_raw(vec.into_boxed_slice()) as *mut c_void;
-    let defragged_filters_ptr = unsafe { defrag.alloc(vec_ptr) };
-    if !defragged_filters_ptr.is_null() {
-        metrics::BLOOM_DEFRAG_HITS.fetch_add(1, Ordering::Relaxed);
-        unsafe { Vec::from_raw_parts(defragged_filters_ptr as *mut u8, len, capacity) }
-    } else {
-        metrics::BLOOM_DEFRAG_MISSES.fetch_add(1, Ordering::Relaxed);
-        unsafe { Vec::from_raw_parts(vec_ptr as *mut u8, len, capacity) }
-    }
-}
-```
+## Config
 
-This function is passed as a callback to `realloc_large_heap_allocated_objects` on the bloomfilter crate's `Bloom` struct. The crate takes ownership of the Vec, passes it to this callback, and uses the returned Vec. The callback converts the Vec to a boxed slice to get a stable pointer, attempts defrag, and reconstructs with the original length and capacity.
+`bloom-defrag-enabled` (bool, default `true`). Stored as `AtomicBool BLOOM_DEFRAG`. Runtime-toggleable via `CONFIG SET`.
 
-## bloom-defrag-enabled Config
+## INFO bf sections
 
-The `bloom-defrag-enabled` configuration (default: true) controls whether defrag runs:
+Emitted by `bloom_info_handler` in `src/metrics.rs` via `ctx.builder().add_section(...).field(...).build_section()`:
 
-```rust
-if !configs::BLOOM_DEFRAG.load(Ordering::Relaxed) {
-    return 0;
-}
-```
+**`bloom_core_metrics`**
 
-First check in `bloom_defrag`. When disabled, the callback returns 0 immediately (indicating complete - no work needed). The config is an `AtomicBool` changeable at runtime via `CONFIG SET bloom-defrag-enabled yes|no`.
-
-Valkey's `activedefrag` must also be enabled for the callback to be invoked at all. `bloom-defrag-enabled` is an additional module-level toggle.
-
-## INFO bf Sections
-
-The `bloom_info_handler` function in `src/metrics.rs` (line 15) populates two sections in the `INFO bf` output:
-
-**Section: bloom_core_metrics**
-
-| Field | Counter | Description |
-|-------|---------|-------------|
-| `bloom_total_memory_bytes` | `BLOOM_OBJECT_TOTAL_MEMORY_BYTES` | Aggregate memory across all bloom objects |
-| `bloom_num_objects` | `BLOOM_NUM_OBJECTS` | Total bloom object count |
-| `bloom_num_filters_across_objects` | `BLOOM_NUM_FILTERS_ACROSS_OBJECTS` | Total sub-filter count |
-| `bloom_num_items_across_objects` | `BLOOM_NUM_ITEMS_ACROSS_OBJECTS` | Total items stored |
-| `bloom_capacity_across_objects` | `BLOOM_CAPACITY_ACROSS_OBJECTS` | Total capacity |
-
-**Section: bloom_defrag_metrics**
-
-| Field | Counter | Description |
-|-------|---------|-------------|
-| `bloom_defrag_hits` | `BLOOM_DEFRAG_HITS` | Allocations that were moved |
-| `bloom_defrag_misses` | `BLOOM_DEFRAG_MISSES` | Allocations already in good location |
-
-The handler uses the `InfoContext` builder pattern: `ctx.builder().add_section("name").field("key", value).build_section()`.
-
-## Atomic Counter Tracking
-
-Seven global `AtomicU64`/`AtomicUsize` counters in `src/metrics.rs` are maintained throughout the object lifecycle:
-
-**Incremented on creation:**
-
-| Event | Counters Updated |
-|-------|-----------------|
-| BloomObject created | `BLOOM_NUM_OBJECTS +1`, `BLOOM_OBJECT_TOTAL_MEMORY_BYTES +object_overhead` |
-| BloomFilter created | `BLOOM_NUM_FILTERS_ACROSS_OBJECTS +1`, `BLOOM_OBJECT_TOTAL_MEMORY_BYTES +filter_bytes`, `BLOOM_CAPACITY_ACROSS_OBJECTS +capacity` |
-| Item added | `BLOOM_NUM_ITEMS_ACROSS_OBJECTS +1` |
-| Scale-out | Memory bytes updated for vec capacity change |
-
-**Decremented on drop:**
-
-| Event | Counters Updated |
-|-------|-----------------|
-| BloomObject dropped | `BLOOM_NUM_OBJECTS -1`, `BLOOM_OBJECT_TOTAL_MEMORY_BYTES -object_overhead` |
-| BloomFilter dropped | `BLOOM_NUM_FILTERS_ACROSS_OBJECTS -1`, `BLOOM_OBJECT_TOTAL_MEMORY_BYTES -filter_bytes`, `BLOOM_NUM_ITEMS_ACROSS_OBJECTS -num_items`, `BLOOM_CAPACITY_ACROSS_OBJECTS -capacity` |
-
-**Updated on defrag:**
-
-| Event | Counter |
+| Field | Counter |
 |-------|---------|
-| `defrag.alloc` returns non-null | `BLOOM_DEFRAG_HITS +1` |
-| `defrag.alloc` returns null | `BLOOM_DEFRAG_MISSES +1` |
+| `bloom_total_memory_bytes` | `BLOOM_OBJECT_TOTAL_MEMORY_BYTES` |
+| `bloom_num_objects` | `BLOOM_NUM_OBJECTS` |
+| `bloom_num_filters_across_objects` | `BLOOM_NUM_FILTERS_ACROSS_OBJECTS` |
+| `bloom_num_items_across_objects` | `BLOOM_NUM_ITEMS_ACROSS_OBJECTS` |
+| `bloom_capacity_across_objects` | `BLOOM_CAPACITY_ACROSS_OBJECTS` |
 
-All counters use `Ordering::Relaxed` since exact precision is not required for metrics - eventual consistency across threads is acceptable.
+**`bloom_defrag_metrics`**
 
-## Memory Usage Callback
+| Field | Counter |
+|-------|---------|
+| `bloom_defrag_hits` | `BLOOM_DEFRAG_HITS` |
+| `bloom_defrag_misses` | `BLOOM_DEFRAG_MISSES` |
 
-The `bloom_mem_usage` function (line 110 of `bloom_callback.rs`) reports per-key memory for the `MEMORY USAGE` command:
+## Atomic counter lifecycle
 
-```rust
-pub unsafe extern "C" fn bloom_mem_usage(value: *const c_void) -> usize {
-    let item = &*value.cast::<BloomObject>();
-    item.memory_usage()
-}
-```
+All seven counters are `AtomicU64`/`AtomicUsize` with `Ordering::Relaxed` (metrics don't need strict ordering).
 
-Delegates to `BloomObject::memory_usage()`, which sums: the object struct overhead (`compute_size` with vec capacity) plus `number_of_bytes()` for each filter.
+| Event | Updates |
+|-------|---------|
+| `BloomObject` created | `BLOOM_NUM_OBJECTS +1`, `BLOOM_OBJECT_TOTAL_MEMORY_BYTES += object overhead` |
+| `BloomFilter` created | `BLOOM_NUM_FILTERS_ACROSS_OBJECTS +1`, `BLOOM_OBJECT_TOTAL_MEMORY_BYTES += filter bytes`, `BLOOM_CAPACITY_ACROSS_OBJECTS += capacity` |
+| Item added | `BLOOM_NUM_ITEMS_ACROSS_OBJECTS +1` |
+| `BloomObject` dropped | `BLOOM_NUM_OBJECTS -1`, memory byte sub |
+| `BloomFilter` dropped | filter count sub, memory sub, item sub, capacity sub |
+| defrag alloc non-null | `BLOOM_DEFRAG_HITS +1` |
+| defrag alloc null | `BLOOM_DEFRAG_MISSES +1` (except Vec step - see bug above) |
 
-The `bloom_free_effort` callback (line 138) returns `self.filters.len()` - the filter count. Valkey uses this to decide whether to free the object asynchronously (higher effort = more likely async).
+## Memory usage and free effort
+
+- `bloom_mem_usage` -> `BloomObject::memory_usage()` - object overhead (incl. Vec capacity) + sum of each filter's `number_of_bytes`. Feeds `MEMORY USAGE`.
+- `bloom_free_effort` -> `self.filters.len()`. Valkey uses this as a threshold for async free (higher = more likely async).

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/architecture-persistence.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/architecture-persistence.md
@@ -1,223 +1,92 @@
-# Persistence - RDB, AOF, and Bincode Serialization
+# Persistence - RDB, AOF, bincode
 
-Use when understanding how bloom objects are saved to RDB, loaded from RDB, rewritten to AOF, serialized with bincode for BF.LOAD, or how the COPY callback works.
+Use when reasoning about RDB save/load, AOF rewrite, bincode serialization, or the COPY callback.
 
-Source: `src/wrapper/bloom_callback.rs`, `src/bloom/data_type.rs`, `src/bloom/utils.rs`
+Source: `src/wrapper/bloom_callback.rs`, `src/bloom/data_type.rs`, `src/bloom/utils.rs`.
 
-## Contents
+## Versions
 
-- Version Constants (line 21)
-- RDB Save Format (line 29)
-- RDB Load and Validation (line 64)
-- AOF Rewrite via BF.LOAD (line 104)
-- Bincode Encode (line 125)
-- Bincode Decode (line 147)
-- Copy Callback (line 171)
-- Auxiliary Data (line 190)
-- Data Type Registration (line 204)
+- `BLOOM_TYPE_ENCODING_VERSION = 1` - RDB `encver` passed to `ValkeyType::new`. Load rejects `encver > 1`.
+- `BLOOM_OBJECT_VERSION = 1` - byte-prefix on bincode streams from `encode_object`. Bump when `BloomObject` struct layout changes.
 
----
+Both live in `src/bloom/data_type.rs`.
 
-## Version Constants
-
-Two version constants control serialization compatibility:
-
-**`BLOOM_TYPE_ENCODING_VERSION`** (line 16 of `data_type.rs`): Set to `1`. The RDB encoding version passed to `ValkeyType::new`. During RDB load, if the file's `encver` exceeds this value, the load is rejected with a warning.
-
-**`BLOOM_OBJECT_VERSION`** (line 13 of `data_type.rs`): Set to `1`. The bincode serialization version prepended to the byte stream in `encode_object`. Must be incremented when the `BloomObject` struct changes.
-
-## RDB Save Format
-
-The `bloom_rdb_save` function (line 27 of `bloom_callback.rs`) writes each BloomObject field-by-field:
+## RDB save format (`bloom_rdb_save`)
 
 ```
 [num_filters: u64]
 [expansion: u64]
 [fp_rate: f64]
 [tightening_ratio: f64]
-[is_seed_random: u64]    // 1 = true, 0 = false
---- per filter (repeated num_filters times) ---
+[is_seed_random: u64]   // 1 = true, 0 = false
+--- per filter ---
 [capacity: u64]
-[num_items: u64]          // ONLY for the last filter
-[bitmap: string_buffer]   // raw bit vector bytes from bloom.as_slice()
+[num_items: u64]        // ONLY for the last filter
+[bitmap: string_buffer] // raw bits from bloom.as_slice()
 ```
 
-The `num_items` optimization: only the last filter's `num_items` is stored. For all previous filters, `num_items` is assumed equal to `capacity` (they are full - that's why scaling created the next filter). Saves space in RDB for objects with many sub-filters.
+**num_items optimization**: only the last filter stores it; prior filters are assumed full (`num_items = capacity`). That's how scaling got there.
 
-The bitmap is written via `RedisModule_SaveStringBuffer` as raw bytes. The bitmap includes the SipHash keys embedded by the bloomfilter crate, so seed information is preserved implicitly without a separate seed field in RDB.
+Bitmap bytes carry the SipHash keys (embedded by the crate's serialization), so no separate seed field is needed per filter in RDB.
 
-Key implementation detail from `bloom_rdb_save`:
+## RDB load (`load_from_rdb` - `ValkeyDataType` trait)
 
-```rust
-let mut filter_list_iter = filter_list.iter().peekable();
-while let Some(filter) = filter_list_iter.next() {
-    raw::save_unsigned(rdb, filter.capacity() as u64);
-    if filter_list_iter.peek().is_none() {
-        // Only save num_items for the last filter
-        raw::save_unsigned(rdb, filter.num_items() as u64);
-    }
-    let bitmap = bloom.as_slice();
-    RedisModule_SaveStringBuffer(rdb, bitmap.as_ptr(), bitmap.len());
-}
-```
+1. `encver > BLOOM_TYPE_ENCODING_VERSION` -> log + return `None`.
+2. Read header: `num_filters`, `expansion`, `fp_rate`, `tightening_ratio`, `is_seed_random`.
+3. For each filter `i`:
+   - Read `capacity`.
+   - Compute this filter's FP rate via `calculate_fp_rate(fp_rate, i, tightening_ratio)`. Degrades to 0 -> abort.
+   - Project size via `BloomFilter::compute_size`; cumulative check against memory limit -> abort if over.
+   - Read `num_items` only when `i == num_filters - 1`; else `num_items = capacity`.
+   - Read bitmap via `load_string_buffer`.
+   - `BloomFilter::from_existing(bitmap, num_items, capacity)`.
+4. If `!is_seed_random`, each restored `filter.seed() != FIXED_SEED` aborts with "Object in fixed seed mode, but seed does not match FIXED_SEED." (catches cross-build mismatches - different `FIXED_SEED` at compile time would silently corrupt data).
+5. `BloomObject::from_existing(...)`. `filters` starts at `Vec::with_capacity(1)` to match normal-creation allocation growth.
 
-## RDB Load and Validation
+## AOF rewrite via BF.LOAD (`bloom_aof_rewrite`)
 
-The `load_from_rdb` function (line 58 of `data_type.rs`) implements the `ValkeyDataType` trait. It performs extensive validation during restore:
+Emits a synthetic `BF.LOAD <key> <bincode_bytes>` using format string `"sb"` (`s`=ValkeyString key, `b`=binary buffer). The receiver decodes via `decode_object`.
 
-**Step 1 - Version check**:
+AOF uses one-shot bincode (larger payload, simpler) - RDB writes fields individually (smaller, faster to stream). Important: **AOF emits BF.LOAD, replication emits synthetic BF.INSERT** (see `commands-replication.md`). Different paths.
 
-```rust
-if encver > BLOOM_TYPE_ENCODING_VERSION {
-    log_warning("Cannot load bloomfltr data type of version {encver}...");
-    return None;
-}
-```
-
-**Step 2 - Read header fields**: `num_filters`, `expansion`, `fp_rate`, `tightening_ratio`, `is_seed_random` (converted from u64 to bool).
-
-**Step 3 - Reconstruct filters** in a loop from 0 to `num_filters`:
-
-For each filter:
-1. Read `capacity`
-2. Calculate the expected FP rate for this filter index: `calculate_fp_rate(fp_rate, i, tightening_ratio)`. If FP degrades to zero, abort.
-3. Compute projected filter size via `BloomFilter::compute_size(capacity, fp_rate)` and validate cumulative object size against the memory limit. If exceeded, abort with "Object larger than the allowed memory limit."
-4. Read `num_items` - only for the last filter (`i == num_filters - 1`). For all others, set `num_items = capacity`.
-5. Read the bitmap via `load_string_buffer`
-6. Reconstruct: `BloomFilter::from_existing(bitmap, num_items, capacity)`
-
-**Step 4 - Fixed seed validation** (line 123):
-
-```rust
-if !is_seed_random && filter.seed() != configs::FIXED_SEED {
-    log_warning("Object in fixed seed mode, but seed does not match FIXED_SEED.");
-    return None;
-}
-```
-
-Catches the case where a fixed-seed object was created on a node with a different `FIXED_SEED` constant, preventing silent data corruption.
-
-**Step 5 - Assemble**: `BloomObject::from_existing(expansion, fp_rate, tightening_ratio, is_seed_random, filters)`.
-
-The `filters` vec is initialized with `Vec::with_capacity(1)` to match the same expansion pattern as normal creation (capacity starts at 1, then grows as elements are pushed).
-
-## AOF Rewrite via BF.LOAD
-
-The `bloom_aof_rewrite` function (line 67 of `bloom_callback.rs`) emits a `BF.LOAD` command containing the entire BloomObject as a bincode-serialized blob:
-
-```rust
-let hex = match filter.encode_object() {
-    Ok(val) => val,
-    Err(err) => {
-        log_io_error(aof, ValkeyLogLevel::Warning, err.as_str());
-        return;
-    }
-};
-let cmd = CString::new("BF.LOAD").unwrap();
-let fmt = CString::new("sb").unwrap();
-RedisModule_EmitAOF(aof, cmd.as_ptr(), fmt.as_ptr(), key, hex.as_ptr(), hex.len());
-```
-
-The format string `"sb"` means: `s` = RedisModuleString (the key), `b` = binary buffer (the serialized bytes). The `BF.LOAD` command handler on the receiving end calls `decode_object` to reconstruct the BloomObject.
-
-Unlike RDB save which writes fields individually, AOF rewrite serializes the entire struct in one shot via bincode. Simpler but produces a larger payload since it includes serde metadata.
-
-## Bincode Encode
-
-The `encode_object` method (line 372 of `utils.rs`) serializes a BloomObject for BF.LOAD:
+## Bincode encode / decode
 
 ```rust
 pub fn encode_object(&self) -> Result<Vec<u8>, BloomError> {
-    match bincode::serialize(self) {
-        Ok(vec) => {
-            let mut final_vec = Vec::with_capacity(1 + vec.len());
-            final_vec.push(BLOOM_OBJECT_VERSION);  // Version byte prefix
-            final_vec.extend(vec);
-            Ok(final_vec)
-        }
-        Err(_) => Err(BloomError::EncodeBloomFilterFailed),
-    }
+    // [BLOOM_OBJECT_VERSION byte] + bincode::serialize(self)
 }
 ```
 
-The version byte (`BLOOM_OBJECT_VERSION = 1`) is prepended before the bincode data. Future struct changes can be handled by version-specific deserialization logic.
+`decode_object(bytes, validate_size_limit)`:
 
-The `BloomObject` derives `Serialize` and `Deserialize`. The `BloomFilter`'s `bloom` field uses custom serde functions from the bloomfilter crate to handle the `Bloom<[u8]>` type.
+- `bytes[0]` = version. Empty -> `DecodeBloomFilterFailed`. Unknown -> `DecodeUnsupportedVersion`.
+- Version 1: bincode-deserialize `bytes[1..]` into `(u32, f64, f64, bool, Vec<Box<BloomFilter>>)` (the `BloomObject` field tuple).
+- Post-decode validation:
+  - `expansion` in `0..=BLOOM_EXPANSION_MAX`
+  - `fp_rate` in exclusive `(BLOOM_FP_RATE_MIN, BLOOM_FP_RATE_MAX)`
+  - `tightening_ratio` in exclusive `(BLOOM_TIGHTENING_RATIO_MIN, BLOOM_TIGHTENING_RATIO_MAX)`
+  - Filter count `< BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX` (`i32::MAX`)
+  - Total memory under limit iff `validate_size_limit`.
+- Metrics: per filter `bloom_filter_incr_metrics_on_new_create` + `BLOOM_NUM_ITEMS_ACROSS_OBJECTS`; then `bloom_object_incr_metrics_on_new_create`.
 
-## Bincode Decode
+## COPY callback (`bloom_copy`)
 
-The `decode_object` function (line 408 of `utils.rs`) handles BF.LOAD deserialization:
+`unsafe extern "C"` wrapper that delegates to `BloomObject::create_copy_from`. Each `BloomFilter` deep-copies via `create_copy_from` (serialize + reconstruct), giving fully independent heap allocations.
 
-```rust
-pub fn decode_object(
-    decoded_bytes: &[u8],
-    validate_size_limit: bool,
-) -> Result<BloomObject, BloomError>
-```
+## AUX data
 
-**Version dispatch**: Reads the first byte as the version number, then matches on it. Currently only version 1 is supported. Unknown versions return `DecodeUnsupportedVersion`. Empty input returns `DecodeBloomFilterFailed`.
+`bloom_aux_load` -> `bloom_rdb_aux_load` logs "Ignoring AUX fields during RDB load" at notice and returns `Status::Ok`. `aux_save` / `aux_save2` are `None` - the module has no out-of-keyspace data.
 
-**Version 1 deserialization**: Deserializes bytes[1..] via bincode into `(u32, f64, f64, bool, Vec<Box<BloomFilter>>)` - matching the BloomObject field order.
-
-**Validation** after deserialization:
-- Expansion range: `0..=BLOOM_EXPANSION_MAX`
-- FP rate: `(BLOOM_FP_RATE_MIN, BLOOM_FP_RATE_MAX)` exclusive
-- Tightening ratio: `(BLOOM_TIGHTENING_RATIO_MIN, BLOOM_TIGHTENING_RATIO_MAX)` exclusive
-- Filter count: less than `BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX`
-- Total memory: checked against `bloom-memory-usage-limit` when `validate_size_limit` is true
-
-**Metrics updates**: For each deserialized filter, `bloom_filter_incr_metrics_on_new_create` and `BLOOM_NUM_ITEMS_ACROSS_OBJECTS` are updated. Then `bloom_object_incr_metrics_on_new_create` is called for the object itself.
-
-## Copy Callback
-
-The `bloom_copy` function (line 117 of `bloom_callback.rs`) handles the Valkey `COPY` command:
-
-```rust
-pub unsafe extern "C" fn bloom_copy(
-    _from_key: *mut RedisModuleString,
-    _to_key: *mut RedisModuleString,
-    value: *const c_void,
-) -> *mut c_void {
-    let curr_item = &*value.cast::<BloomObject>();
-    let new_item = BloomObject::create_copy_from(curr_item);
-    let bb = Box::new(new_item);
-    Box::into_raw(bb).cast::<libc::c_void>()
-}
-```
-
-Delegates to `BloomObject::create_copy_from`, which deep-copies all filters via `BloomFilter::create_copy_from`. Each filter serializes its bloom to bytes and reconstructs, producing fully independent heap allocations.
-
-## Auxiliary Data
-
-The `bloom_aux_load` callback (line 94 of `bloom_callback.rs`) handles auxiliary (out-of-keyspace) data from RDB files:
-
-```rust
-pub unsafe extern "C" fn bloom_aux_load(
-    rdb: *mut raw::RedisModuleIO, _encver: c_int, _when: c_int,
-) -> c_int {
-    bloom::data_type::bloom_rdb_aux_load(rdb)
-}
-```
-
-The implementation in `data_type.rs` (line 156) logs at notice level "Ignoring AUX fields during RDB load" and returns `Status::Ok`. The `aux_save` and `aux_save2` callbacks are set to `None` since the module has no auxiliary data to persist.
-
-## Data Type Registration
-
-The `BLOOM_TYPE` static in `data_type.rs` (line 18) registers all callbacks:
+## Data type registration
 
 ```rust
 pub static BLOOM_TYPE: ValkeyType = ValkeyType::new(
-    "bloomfltr",
-    BLOOM_TYPE_ENCODING_VERSION,
+    "bloomfltr",                  // 9 chars - module type-name max
+    BLOOM_TYPE_ENCODING_VERSION,  // 1
     raw::RedisModuleTypeMethods { ... },
 );
 ```
 
-Type name is `"bloomfltr"` (9 characters, the Valkey maximum). Callbacks wired to implementations:
-- `rdb_save`, `rdb_load`, `aof_rewrite`, `digest` - persistence and integrity
-- `mem_usage`, `free`, `free_effort` - memory management
-- `copy`, `defrag`, `aux_load` - replication and maintenance
+Callbacks wired: `rdb_save`, `rdb_load`, `aof_rewrite`, `digest`, `mem_usage`, `free`, `free_effort`, `copy`, `defrag`, `aux_load`. Unwired (`None`): `unlink`, `mem_usage2`, `free_effort2`, `unlink2`, `copy2`, `aux_save`, `aux_save2`.
 
-The `digest` callback (line 130 of `bloom_callback.rs`) implements `DEBUG DIGEST` by hashing `expansion`, `fp_rate`, `tightening_ratio`, `is_seed_random`, and each filter's raw bitmap, `num_items`, and `capacity` via the `Digest` API. The `free` callback (line 104) drops the BloomObject box, triggering the `Drop` impls for both BloomObject and its BloomFilter children.
-
-Callbacks set to `None`: `unlink`, `mem_usage2`, `free_effort2`, `unlink2`, `copy2`, `aux_save`, `aux_save2`. The version 1 variants are used where both exist.
+`digest` feeds `DEBUG DIGEST-VALUE`: hashes `expansion`, `fp_rate`, `tightening_ratio`, `is_seed_random`, then each filter's raw bitmap, `num_items`, `capacity`. `free` drops the `BloomObject` box (triggers both `Drop` impls).

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/commands-bf-reserve-insert.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/commands-bf-reserve-insert.md
@@ -1,157 +1,111 @@
-# BF.RESERVE, BF.INSERT, and BF.LOAD
+# BF.RESERVE, BF.INSERT, BF.LOAD
 
-Use when understanding explicit bloom creation, complex argument parsing in BF.INSERT, replication-only arguments (TIGHTENING, SEED), VALIDATESCALETO validation, or the BF.LOAD AOF rewrite path.
+Use when reasoning about explicit creation, BF.INSERT argument parsing, replication-only args (SEED / TIGHTENING), VALIDATESCALETO, or the AOF-only BF.LOAD.
 
-Source: `src/bloom/command_handler.rs`
+Source: `src/bloom/command_handler.rs`.
 
 ## BF.RESERVE
 
-`bloom_filter_reserve` creates a bloom object with explicit parameters. Syntax: `BF.RESERVE key fp_rate capacity [EXPANSION exp | NONSCALING]`.
+`BF.RESERVE key fp_rate capacity [EXPANSION exp | NONSCALING]`. Arity 4 to 6 (`!(4..=6).contains(&argc)`).
 
-**Arity**: 4 to 6 args. The function checks `!(4..=6).contains(&argc)`.
+Parsing order and errors:
 
-**Argument parsing order**:
+- **key** - index 1.
+- **fp_rate** - f64, strict `(0, 1)`. Unparseable: `ERR bad error rate`. Out of range: `ERR (0 < error rate range < 1)`.
+- **capacity** - i64, `1..=i64::MAX`. Unparseable or out of range: `ERR bad capacity`. Zero specifically: `ERR (capacity should be larger than 0)`.
+- **Trailing arg** (`argc > 4`):
+  - argc 5 + `NONSCALING` -> `expansion = 0`.
+  - argc 6 + `EXPANSION <u32>` -> range `1..=u32::MAX`. Invalid: `ERR bad expansion`.
+  - Anything else: `ERR ERROR`.
 
-1. **key** - filter name at index 1
-2. **fp_rate** - parsed as f64, must satisfy `0 < fp_rate < 1` (exclusive on both ends). Two separate error paths: out-of-range values get `ERR (0 < error rate range < 1)`, unparseable strings get `ERR bad error rate`.
-3. **capacity** - parsed as i64, must be in `BLOOM_CAPACITY_MIN..=BLOOM_CAPACITY_MAX` (1 to i64::MAX). Zero specifically returns `ERR (capacity should be larger than 0)`. Other invalid values return `ERR bad capacity`.
-4. **Optional trailing argument** (argc > 4):
-   - `NONSCALING` (argc must be 5) - sets expansion to 0
-   - `EXPANSION <value>` (argc must be 6) - parsed as u32, range `BLOOM_EXPANSION_MIN..=BLOOM_EXPANSION_MAX` (1 to u32::MAX). Invalid values return `ERR bad expansion`.
-   - Anything else returns `ERR ERROR`
+Key check: existing bloom -> `ERR item exists`. Non-bloom type -> `WrongType`. BF.RESERVE never overwrites.
 
-**Key existence check**: If the key already exists with a bloom object, returns `ERR item exists`. BF.RESERVE never overwrites. Returns `WrongType` if the key holds a non-bloom type.
-
-**Object creation**: Uses current config values for tightening ratio and seed mode. Calls `BloomObject::new_reserved` with size validation gated on `!must_obey_client(ctx)`. After storing, replicates with `reserve_operation: true` and no items.
-
-**Default expansion**: When neither EXPANSION nor NONSCALING is provided (argc == 4), uses `configs::BLOOM_EXPANSION` (default 2).
+Creation: current config provides `tightening_ratio` and seed mode. `new_reserved` with size validation gated by `!must_obey_client(ctx)`. Replicates with `reserve_operation: true`, items empty. Default expansion when argc==4 is `BLOOM_EXPANSION` (2).
 
 ## BF.INSERT
 
-`bloom_filter_insert` is the most complex command handler. Syntax: `BF.INSERT key [ERROR fp] [CAPACITY cap] [EXPANSION exp] [NOCREATE] [NONSCALING] [TIGHTENING ratio] [SEED bytes] [VALIDATESCALETO cap] ITEMS item [item ...]`.
+`BF.INSERT key [ERROR fp] [CAPACITY cap] [EXPANSION exp] [NOCREATE] [NONSCALING] [TIGHTENING ratio] [SEED bytes] [VALIDATESCALETO cap] ITEMS item [item ...]`
 
-**Minimum arity**: 2 args (`BF.INSERT key`). Unlike BF.RESERVE, BF.INSERT can be called without items - it can create an empty bloom object.
+Minimum arity 2 - can create an empty bloom.
 
-**Default values**: All optional parameters start with current module config defaults (fp_rate, tightening_ratio, capacity, expansion, seed mode). Explicit arguments override these.
+Defaults come from current module config; explicit args override.
 
-## BF.INSERT Argument Parsing
+### Keyword table (case-insensitive, parsed in a `while idx < argc` loop)
 
-Arguments are parsed in a `while idx < argc` loop with case-insensitive keyword matching (via `to_uppercase()`):
+| Keyword | Value | Parsing / errors |
+|---------|-------|------------------|
+| `ERROR` | f64 `(0, 1)` | `ERR (0 < error rate range < 1)` |
+| `TIGHTENING` | f64 `(0, 1)` | replication-internal. `ERR bad tightening ratio` / `ERR (0 < tightening ratio range < 1)` |
+| `CAPACITY` | i64 `1..=i64::MAX` | zero -> `ERR (capacity should be larger than 0)` |
+| `SEED` | exactly 32 bytes | replication-internal. `try_into()` failure -> `ERR invalid seed` |
+| `NOCREATE` | none | sets flag |
+| `NONSCALING` | none | `expansion = 0` |
+| `EXPANSION` | u32 `1..=u32::MAX` | |
+| `VALIDATESCALETO` | i64 `1..=i64::MAX` | zero -> `ERR (capacity should be larger than 0)` |
+| `ITEMS` | (sentinel) | advances idx, sets `items_provided = true`, breaks loop |
 
-| Keyword | Expects Value | Parsing |
-|---------|--------------|---------|
-| `ERROR` | Yes | f64, range `(0, 1)` exclusive |
-| `TIGHTENING` | Yes | f64, range `(0, 1)` exclusive; replication-internal |
-| `CAPACITY` | Yes | i64, range `1..=i64::MAX`; zero returns `ERR (capacity should be larger than 0)` |
-| `SEED` | Yes | Exactly 32 bytes (raw `[u8; 32]`); replication-internal |
-| `NOCREATE` | No | Sets `nocreate = true` |
-| `NONSCALING` | No | Sets `expansion = 0` |
-| `EXPANSION` | Yes | u32, range `1..=u32::MAX` |
-| `VALIDATESCALETO` | Yes | i64, range `1..=i64::MAX`; zero returns `ERR (capacity should be larger than 0)` |
-| `ITEMS` | Starts items | Increments idx, sets `items_provided = true`, breaks loop |
+Unknown keyword: `ERR unknown argument received`. Value-expecting keywords check `idx >= (argc - 1)` -> `WrongArity`. `ITEMS` with no items: `WrongArity`.
 
-**ITEMS sentinel**: The `ITEMS` keyword breaks out of the option parsing loop. All remaining arguments after `ITEMS` are treated as items to add. If `ITEMS` is provided but no items follow (`idx == argc && items_provided`), returns `WrongArity`.
+### Replication-internal args
 
-**Unknown arguments**: Any unrecognized keyword returns `ERR unknown argument received`.
+Source comment on `TIGHTENING`:
 
-**Value-expecting keywords**: Each checks `idx >= (argc - 1)` to ensure a value follows. Missing values return `WrongArity`.
+> This argument is only supported on replicated commands since primary nodes replicate bloom objects deterministically using every global bloom config/property.
 
-## Replication-Only Arguments
+Same applies to `SEED`. Both arrive only in the synthetic `BF.INSERT` the primary sends to replicas.
 
-**TIGHTENING** and **SEED** are documented in source comments as replication-internal:
+`SEED` parsing: raw bytes -> `[u8; 32]` via `try_into()`. `is_seed_random` is derived by comparing against `FIXED_SEED` - different -> random, equal -> fixed.
 
-```rust
-"TIGHTENING" => {
-    // Note: This argument is only supported on replicated commands since primary nodes
-    // replicate bloom objects deterministically using every global bloom config/property.
-```
+### VALIDATESCALETO check
 
-When the primary creates a bloom object (via BF.ADD, BF.RESERVE, or BF.INSERT), it replicates the creation as `BF.INSERT ... TIGHTENING <ratio> SEED <32bytes> ...`. This ensures replicas use the exact same tightening ratio and seed as the primary, regardless of the replica's local config values.
+Run post-parse, before creation. Not replicated.
 
-**SEED parsing**: The raw bytes from the ValkeyString are converted to `[u8; 32]` via `try_into()`. If the slice is not exactly 32 bytes, returns `ERR invalid seed`. The `is_seed_random` flag is derived by comparing against `FIXED_SEED` - if different, it is considered random.
+1. `expansion == 0` (NONSCALING also present) -> `ERR cannot use NONSCALING and VALIDATESCALETO options together`.
+2. Call `BloomObject::calculate_max_scaled_capacity(capacity, fp_rate, scale_to, tightening_ratio, expansion)`.
+3. Failures:
+   - FP degrades to zero: `ERR provided VALIDATESCALETO causes false positive to degrade to 0`.
+   - Memory limit: `ERR provided VALIDATESCALETO causes bloom object to exceed memory limit`.
 
-**TIGHTENING parsing**: Parsed as f64 with range `(0, 1)` exclusive. Out-of-range values return `ERR (0 < tightening ratio range < 1)`. Unparseable strings return `ERR bad tightening ratio`.
+### NOCREATE
 
-## VALIDATESCALETO Validation
+Key missing + `nocreate` -> `ERR not found`. Key existing + `nocreate` -> no effect, items added normally.
 
-`VALIDATESCALETO` is a user-facing argument that validates whether a bloom object can scale to a target capacity before creating it. It is a pre-creation check, not a runtime limit.
+### Existing vs new key
 
-After all arguments are parsed, if `validate_scale_to` is set:
+- **Existing** (`Some`): items added to existing bloom. Option args (CAPACITY, ERROR, etc.) **ignored**. Replication uses `reserve_operation: false`; verbatim only if at least one item was new. `ReplicateArgs` pulls from the **object's** properties, not the current command's overrides.
+- **New** (`None`, no NOCREATE): create with parsed params (or defaults). Size validation gated. `new_reserved` + `handle_bloom_add` with `multi: true` for items. `set_value`, replicate with `reserve_operation: true`.
 
-1. Check that `expansion != 0` - combining NONSCALING with VALIDATESCALETO returns `ERR cannot use NONSCALING and VALIDATESCALETO options together`.
+Response is always `ValkeyValue::Array` of integer add-results. Empty ITEMS on new key -> empty array.
 
-2. Call `BloomObject::calculate_max_scaled_capacity(capacity, fp_rate, scale_to, tightening_ratio, expansion)` which simulates filter scaling to determine if the target capacity is reachable.
+## BF.LOAD - internal, AOF-only
 
-3. Two failure modes from `calculate_max_scaled_capacity`:
-   - FP rate degrades to zero before reaching target: `ERR provided VALIDATESCALETO causes false positive to degrade to 0`
-   - Memory limit exceeded before reaching target: `ERR provided VALIDATESCALETO causes bloom object to exceed memory limit`
+`BF.LOAD key data`. Arity exactly 3. Flags: `write deny-oom` (note: no `fast`). ACL: `write bloom`.
 
-Not replicated - validated on the primary before object creation only.
+Key existence -> `BUSYKEY Target key name already exists.` (`utils::KEY_EXISTS`). Non-bloom type -> `WrongType`.
 
-## NOCREATE Behavior
+Data is the raw bytes from `BloomObject::encode_object`:
 
-When `nocreate = true` and the key does not exist, BF.INSERT returns `ERR not found` instead of creating a new bloom object. This is checked in the `None` branch of the key existence match:
+1. `decode_object(&data, validate_size_limit)` - byte 0 is version (must be 1), bincode-deserializes `bytes[1..]` into `(u32, f64, f64, bool, Vec<Box<BloomFilter>>)`.
+2. Validates expansion, fp_rate, tightening_ratio, filter count, total memory.
+3. Failure: `ERR bloom object decoding failed` or `ERR bloom object decoding failed. Unsupported version`.
 
-```rust
-None => {
-    if nocreate {
-        return Err(ValkeyError::Str(utils::NOT_FOUND));
-    }
-    // ... create new bloom
-}
-```
+Size validation gated by `!must_obey_client`. After decode, replicates with `reserve_operation: true` - **replica receives a synthetic BF.INSERT** with full properties + items (including the encoded data in items list). Replica ends up building the bloom via BF.INSERT, not replaying BF.LOAD.
 
-When the key exists, NOCREATE has no effect - items are added normally.
+## Error summary
 
-## BF.INSERT Object Creation vs Existing
-
-**Existing key** (`Some` branch): Items are added to the existing bloom. Option arguments like CAPACITY and ERROR are ignored for existing objects. Replication uses `reserve_operation: false` (verbatim replication only when at least one item was new). The bloom object's properties from creation time are used in `ReplicateArgs`, not the arguments from the current command.
-
-**New key** (`None` branch, no NOCREATE): Creates with the parsed parameters (or defaults). Size validation is gated by `!must_obey_client(ctx)`. After calling `BloomObject::new_reserved`, items are added via `handle_bloom_add` with `multi: true` (BF.INSERT always uses multi mode for items). After `set_value`, replicates with `reserve_operation: true`.
-
-The response is always a multi-result array since `handle_bloom_add` is called with `multi: true`, returning `ValkeyValue::Array` of integer results (1 for new, 0 for duplicate). When no ITEMS are provided and the key is new, the response is an empty array.
-
-## BF.LOAD
-
-`bloom_filter_load` is an internal command used by AOF rewrite, not intended for direct user invocation. Syntax: `BF.LOAD key data`.
-
-**Arity**: Exactly 3 args.
-
-**Command flags**: `write deny-oom` (no `fast` flag, unlike other write commands). ACL: `write bloom`.
-
-**Key check**: If the key already exists, returns `BUSYKEY Target key name already exists.` (the `utils::KEY_EXISTS` constant). Returns `WrongType` if the key holds a non-bloom type.
-
-**Deserialization path**: The data argument is the raw bytes from `BloomObject::encode_object`:
-
-1. Calls `BloomObject::decode_object(&hex, validate_size_limit)`
-2. `decode_object` reads byte 0 as the version (must be 1)
-3. Remaining bytes are bincode-deserialized into `(u32, f64, f64, bool, Vec<Box<BloomFilter>>)`
-4. Validates: expansion range (0 to u32::MAX), fp_rate range, tightening_ratio range, filter count (< i32::MAX), total memory size
-5. On failure: `ERR bloom object decoding failed` or `ERR bloom object decoding failed. Unsupported version`
-
-**Size validation**: Gated by `!must_obey_client(ctx)`, same as other write commands. Replicas skip size validation.
-
-**Replication**: After successful load, replicates with `reserve_operation: true`. The replicated form is a synthetic `BF.INSERT` with full bloom object properties (capacity, fp_rate, tightening_ratio, seed, expansion). The data argument is included in the replicated items list, so the replica creates the bloom structure via BF.INSERT rather than BF.LOAD.
-
-## Error Summary
-
-| Command | Error | Condition |
-|---------|-------|-----------|
-| BF.RESERVE | `ERR item exists` | Key already has a bloom object |
-| BF.RESERVE | `ERR bad error rate` | fp_rate not parseable as f64 |
-| BF.RESERVE | `ERR (0 < error rate range < 1)` | fp_rate out of range |
-| BF.RESERVE | `ERR bad capacity` | capacity not parseable |
-| BF.RESERVE | `ERR (capacity should be larger than 0)` | capacity == 0 |
-| BF.RESERVE | `ERR bad expansion` | expansion not parseable or out of range |
-| BF.RESERVE | `ERR ERROR` | Unknown trailing argument |
-| BF.INSERT | `ERR not found` | NOCREATE and key missing |
-| BF.INSERT | `ERR unknown argument received` | Unrecognized option keyword |
-| BF.INSERT | `ERR invalid seed` | SEED not exactly 32 bytes |
-| BF.INSERT | `ERR bad tightening ratio` | TIGHTENING not parseable as f64 |
-| BF.INSERT | `ERR (0 < tightening ratio range < 1)` | TIGHTENING out of range |
-| BF.INSERT | `ERR cannot use NONSCALING and VALIDATESCALETO options together` | Both specified |
-| BF.INSERT | `ERR provided VALIDATESCALETO causes false positive to degrade to 0` | Scale target unreachable (FP) |
-| BF.INSERT | `ERR provided VALIDATESCALETO causes bloom object to exceed memory limit` | Scale target unreachable (mem) |
-| BF.LOAD | `BUSYKEY Target key name already exists.` | Key already exists |
-| BF.LOAD | `ERR bloom object decoding failed` | Bincode deserialization failure |
-| BF.LOAD | `ERR bloom object decoding failed. Unsupported version` | Version byte != 1 |
+| Command | Error | When |
+|---------|-------|------|
+| BF.RESERVE | `ERR item exists` | key holds bloom |
+| BF.RESERVE | `ERR bad error rate` / `ERR (0 < error rate range < 1)` | fp_rate parse / range |
+| BF.RESERVE | `ERR bad capacity` / `ERR (capacity should be larger than 0)` | cap parse / zero |
+| BF.RESERVE | `ERR bad expansion` | expansion parse / range |
+| BF.RESERVE | `ERR ERROR` | unknown trailing arg |
+| BF.INSERT | `ERR not found` | NOCREATE + key missing |
+| BF.INSERT | `ERR unknown argument received` | unknown keyword |
+| BF.INSERT | `ERR invalid seed` | SEED not 32 bytes |
+| BF.INSERT | `ERR bad tightening ratio` / `ERR (0 < tightening ratio range < 1)` | TIGHTENING parse / range |
+| BF.INSERT | `ERR cannot use NONSCALING and VALIDATESCALETO options together` | both set |
+| BF.INSERT | `ERR provided VALIDATESCALETO causes false positive to degrade to 0` | scale sim FP zero |
+| BF.INSERT | `ERR provided VALIDATESCALETO causes bloom object to exceed memory limit` | scale sim memory |
+| BF.LOAD | `BUSYKEY Target key name already exists.` | key exists |
+| BF.LOAD | `ERR bloom object decoding failed` / `... Unsupported version` | bincode fail / version != 1 |

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/commands-command-handlers.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/commands-command-handlers.md
@@ -1,136 +1,89 @@
-# Command Handlers - BF.ADD, BF.MADD, BF.EXISTS, BF.MEXISTS, BF.CARD, BF.INFO
+# Command handlers - BF.ADD, BF.MADD, BF.EXISTS, BF.MEXISTS, BF.CARD, BF.INFO
 
-Use when understanding read and add command implementations, multi-item variants, auto-creation behavior, cardinality queries, or BF.INFO field introspection.
+Use when reasoning about read/add command implementations, multi-item variants, auto-creation, or BF.INFO field semantics.
 
-Source: `src/bloom/command_handler.rs`, `src/bloom/utils.rs`, `src/lib.rs`
+Source: `src/bloom/command_handler.rs`, `src/lib.rs`.
 
-## BF.ADD and BF.MADD
+## BF.ADD / BF.MADD - shared handler
 
-Both commands share the `bloom_filter_add_value` function, differentiated by a `multi: bool` parameter. The entry points in `lib.rs` are thin wrappers:
+Both go through `bloom_filter_add_value(ctx, args, multi: bool)`. `lib.rs` wrappers set `multi=false` for ADD and `multi=true` for MADD.
 
-```rust
-fn bloom_add_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
-    command_handler::bloom_filter_add_value(ctx, &args, false)  // single item
-}
-fn bloom_madd_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
-    command_handler::bloom_filter_add_value(ctx, &args, true)   // multi item
-}
-```
+Arity:
 
-**Arity checks**: BF.ADD requires exactly 3 args (`BF.ADD key item`). BF.MADD requires at least 3 (`BF.MADD key item [item ...]`). The check `(!multi && argc != 3) || argc < 3` enforces both.
+- `BF.ADD key item` - exactly 3.
+- `BF.MADD key item [item ...]` - at least 3.
 
-**Key opening**: Uses `ctx.open_key_writable(filter_name)` since these are mutative. Calls `get_value::<BloomObject>(&BLOOM_TYPE)` and returns `WrongType` on type mismatch.
+Key opened `writable` via `open_key_writable` + `get_value::<BloomObject>(&BLOOM_TYPE)` (returns `WrongType` on type mismatch). Size validation gated by `!must_obey_client(ctx)`.
 
-**Size validation**: Skipped on replicated commands via `!must_obey_client(ctx)`. Replicas must accept whatever the primary sends regardless of local memory limits.
+## Auto-creation
 
-## Auto-Creation Behavior
+When the key is `None`, BF.ADD / BF.MADD create with current module config:
 
-When the key does not exist (the `None` branch), BF.ADD and BF.MADD create a new bloom object using current module config defaults:
+- `fp_rate` from `BLOOM_FP_RATE_F64` (Mutex),
+- `tightening_ratio` from `BLOOM_TIGHTENING_F64` (Mutex),
+- `capacity` from `BLOOM_CAPACITY` (AtomicI64),
+- `expansion` from `BLOOM_EXPANSION` (AtomicI64, cast to u32),
+- seed `(None, true)` if `BLOOM_USE_RANDOM_SEED`, else `(Some(FIXED_SEED), false)`.
 
-- `fp_rate` from `BLOOM_FP_RATE_F64` (Mutex lock)
-- `tightening_ratio` from `BLOOM_TIGHTENING_F64` (Mutex lock)
-- `capacity` from `BLOOM_CAPACITY` (AtomicI64)
-- `expansion` from `BLOOM_EXPANSION` (AtomicI64, cast to u32)
-- Seed: random `(None, true)` if `BLOOM_USE_RANDOM_SEED` is true, else `(Some(FIXED_SEED), false)`
+After creation: `set_value(&BLOOM_TYPE, bloom)` + replicate with `reserve_operation: true`. Replication always uses synthetic BF.INSERT (see `commands-replication.md`).
 
-After creation, the new bloom object is stored with `filter_key.set_value(&BLOOM_TYPE, bloom)`. The replication call passes `reserve_operation: true` so the creation is replicated deterministically as a `BF.INSERT` with full properties.
+On existing keys, `reserve_operation: false`; verbatim replication fires only when at least one item was new (`add_succeeded == true`).
 
-When the key already exists (the `Some` branch), items are added to the existing bloom and replication passes `reserve_operation: false`, causing verbatim replication only when at least one item was new (`add_succeeded == true`).
+## `handle_bloom_add` (shared by ADD / MADD / INSERT)
 
-## handle_bloom_add Helper
+| `multi` | Behavior |
+|---------|----------|
+| `false` | `bf.add_item(item, validate_size_limit)`. Returns `ValkeyValue::Integer(0)` dup or `Integer(1)` new. Errors -> `ValkeyError::Str`. `add_succeeded` true on new. |
+| `true` | Iterate items. Each -> `Integer(0/1)` in a result Vec. First error -> push `ValkeyValue::StaticError` and `break` (remaining items skipped). `add_succeeded` true if any item returned 1. |
 
-This private function handles item insertion for BF.ADD, BF.MADD, and BF.INSERT. It branches on the `multi` parameter:
+`add_succeeded` also gates the `bloom.add` keyspace notification and verbatim replication.
 
-**Single mode** (`multi: false`): Calls `bf.add_item(item, validate_size_limit)` on the one item at `item_idx`. Returns `ValkeyValue::Integer(0)` for duplicate, `ValkeyValue::Integer(1)` for new. Sets `add_succeeded = true` only on new insertions. Errors propagate as `ValkeyError::Str`.
+## BF.EXISTS / BF.MEXISTS
 
-**Multi mode** (`multi: true`): Iterates from `item_idx` to `argc`, collecting results into a `Vec`. Each item gets `ValkeyValue::Integer(0|1)`. On error (e.g., non-scaling filter full, memory limit exceeded, max filters reached), the error is pushed as `ValkeyValue::StaticError` and iteration stops with `break` - remaining items are not processed.
+Shared `bloom_filter_exists(ctx, args, multi)`. Opened read-only via `open_key`. Missing key returns `Integer(0)` per item (not an error).
 
-The `add_succeeded` flag is set to true if any item returned 1. It controls whether a `bloom.add` keyspace notification fires and whether verbatim replication occurs.
-
-## BF.EXISTS and BF.MEXISTS
-
-Both share `bloom_filter_exists`, differentiated by `multi: bool`. The pattern mirrors add but is read-only:
-
-```rust
-let filter_key = ctx.open_key(filter_name);  // read-only open
-```
-
-**Single mode**: Returns `ValkeyValue::Integer(1)` if found, `0` otherwise. Non-existent keys return `0` (not an error).
-
-**Multi mode**: Collects results into a `Vec<ValkeyValue>`. Each item independently returns 0 or 1.
-
-The standalone `handle_item_exists` function calls `val.item_exists(item)`, which runs `self.filters.iter().any(|filter| filter.check(item))` - scanning all sub-filters in the bloom object. Existence checks search every filter in a scaled bloom, not just the last one.
-
-**Key behavior**: When the key does not exist at all, the function returns `ValkeyValue::Integer(0)` for each item rather than an error. This matches Valkey convention where checking membership on a non-existent set returns 0.
+`handle_item_exists` -> `val.item_exists(item)` -> `filters.iter().any(|f| f.check(item))`. Scans **all** sub-filters - scaled blooms must check every filter, not just the last.
 
 ## BF.CARD
 
-`bloom_filter_card` is the simplest command. Requires exactly 2 args (`BF.CARD key`).
-
-```rust
-match value {
-    Some(val) => Ok(ValkeyValue::Integer(val.cardinality())),
-    None => Ok(ValkeyValue::Integer(0)),
-}
-```
-
-`cardinality()` in `utils.rs` sums `num_items` across all sub-filters in the bloom object. Like BF.EXISTS, a non-existent key returns 0 rather than an error. Opens the key read-only with `ctx.open_key`.
+Arity exactly 2. Read-only open. `Some(val)` -> `Integer(val.cardinality())` (sum of `num_items` across filters). `None` -> `Integer(0)`.
 
 ## BF.INFO
 
-`bloom_filter_info` handles two modes based on argument count:
+Arity 2 or 3 (`!(2..=3).contains(&argc)` check). Read-only open. **Unlike BF.EXISTS / BF.CARD, missing key returns `ERR not found` (`utils::NOT_FOUND`)** - only read command that errors on missing keys.
 
-- `BF.INFO key` (argc == 2) - returns all fields
-- `BF.INFO key <field>` (argc == 3) - returns a single field
+### Field queries (argc == 3)
 
-Unlike BF.CARD and BF.EXISTS, a non-existent key returns `ERR not found` (`utils::NOT_FOUND`). The only read command that errors on missing keys.
+Field name matched case-insensitively:
 
-Arity: exactly 2 or 3 args via `!(2..=3).contains(&argc)`. Opens key read-only.
+| Field | Returns | Notes |
+|-------|---------|-------|
+| `CAPACITY` | `val.capacity()` | sum across filters |
+| `SIZE` | `val.memory_usage() as i64` | |
+| `FILTERS` | `val.num_filters() as i64` | |
+| `ITEMS` | `val.cardinality()` | |
+| `ERROR` | `val.fp_rate()` (Float) | |
+| `EXPANSION` | `val.expansion() as i64` or `Null` if 0 | |
+| `TIGHTENING` | `val.tightening_ratio()` | scaling filters only |
+| `MAXSCALEDCAPACITY` | computed | scaling filters only |
 
-## BF.INFO Field Queries
+`MAXSCALEDCAPACITY` and `TIGHTENING` on non-scaling filters return `ERR invalid information value`. Unknown field name also returns `invalid information value`.
 
-When a specific field is requested (argc == 3), the field name is matched case-insensitively:
+`MAXSCALEDCAPACITY` calls `calculate_max_scaled_capacity` with `val.starting_capacity()` (first filter's capacity) and `scale_to = -1`.
 
-| Field | Return Value | Notes |
-|-------|-------------|-------|
-| `CAPACITY` | `val.capacity()` | Sum across all sub-filters |
-| `SIZE` | `val.memory_usage() as i64` | Total bytes including all allocations |
-| `FILTERS` | `val.num_filters() as i64` | Number of sub-filters |
-| `ITEMS` | `val.cardinality()` | Total items across all sub-filters |
-| `ERROR` | `val.fp_rate()` | Configured false positive rate (Float) |
-| `TIGHTENING` | `val.tightening_ratio()` | Only available when `expansion > 0` |
-| `EXPANSION` | `val.expansion() as i64` | Returns `Null` when expansion == 0 (non-scaling) |
-| `MAXSCALEDCAPACITY` | calculated | Only available when `expansion > 0` |
+### Full output (argc == 2)
 
-**MAXSCALEDCAPACITY** calls `BloomObject::calculate_max_scaled_capacity` with `val.starting_capacity()` (first filter's capacity, not the total) and `scale_to: -1` (meaning no target limit), simulating scale-out until memory or FP rate limits are reached. Only valid for scaling filters.
-
-**TIGHTENING** and **MAXSCALEDCAPACITY** return `ERR invalid information value` when queried on non-scaling filters (expansion == 0). The catch-all `_ =>` branch returns the same error for unknown field names.
-
-## BF.INFO Full Output
-
-When called without a field (argc == 2), returns an interleaved array of label/value pairs:
+Interleaved label/value array:
 
 ```
-Capacity: <total capacity>
-Size: <memory bytes>
-Number of filters: <count>
-Number of items inserted: <cardinality>
-Error rate: <fp_rate>
-Expansion rate: <expansion or null>
+Capacity / Size / Number of filters / Number of items inserted / Error rate / Expansion rate
 ```
 
-For scaling filters (expansion > 0), two additional fields are appended:
+For scaling filters, appends `Tightening ratio` and `Max scaled capacity`. Non-scaling: returns `Null` for Expansion rate and omits the two scaling fields. `Max scaled capacity` uses `starting_capacity()`, not total.
 
-```
-Tightening ratio: <ratio>
-Max scaled capacity: <max_capacity>
-```
+## Command registration
 
-The max scaled capacity calculation also uses `val.starting_capacity()` (first filter's capacity), not the total. Non-scaling filters omit the tightening and max capacity fields entirely and return `Null` for expansion rate.
-
-## Command Registration
-
-All commands are registered in the `valkey_module!` macro in `lib.rs`:
+From the `valkey_module!` commands block:
 
 | Command | Flags | ACL |
 |---------|-------|-----|
@@ -141,4 +94,4 @@ All commands are registered in the `valkey_module!` macro in `lib.rs`:
 | BF.CARD | `readonly fast` | `fast read bloom` |
 | BF.INFO | `readonly fast` | `fast read bloom` |
 
-All commands use key arguments `1, 1, 1` (first-key=1, last-key=1, key-step=1). All mutative commands include the `bloom` ACL category defined in the module's `acl_categories` block.
+Key spec `1, 1, 1` (first=1, last=1, step=1). All commands tagged with the custom `bloom` ACL category from `acl_categories`.

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/commands-module-configs.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/commands-module-configs.md
@@ -1,133 +1,80 @@
-# Module Configuration Options
+# Module configs
 
-Use when understanding bloom module config defaults, ranges, types, the custom string-to-f64 config handler, or the module_args_as_configuration pattern.
+Use when reasoning about bloom-* config defaults, ranges, the string-as-f64 pattern, or `module_args_as_configuration`.
 
-Source: `src/configs.rs`, `src/lib.rs` (valkey_module! configurations block)
+Source: `src/configs.rs`, `src/lib.rs` (`valkey_module!` configurations block).
 
-## Configuration Table
+## Config table
 
-| Config | Type | Default | Min | Max | Purpose |
-|--------|------|---------|-----|-----|---------|
-| `bloom-capacity` | i64 | 100 | 1 | i64::MAX | Default items per sub-filter |
-| `bloom-expansion` | i64 | 2 | 0 | u32::MAX | Scale factor (0 = non-scaling) |
-| `bloom-fp-rate` | string | "0.01" | (0 | 1) | Default false positive rate |
-| `bloom-tightening-ratio` | string | "0.5" | (0 | 1) | FP decay per scale-out |
-| `bloom-memory-usage-limit` | i64 | 128MB | 0 | i64::MAX | Max bytes per bloom object |
-| `bloom-use-random-seed` | bool | true | - | - | Random vs fixed seed mode |
-| `bloom-defrag-enabled` | bool | true | - | - | Enable defragmentation |
+| Config | Type | Default | Range | Purpose |
+|--------|------|---------|-------|---------|
+| `bloom-capacity` | i64 | 100 | `1..=i64::MAX` | Default initial capacity (auto-created blooms) |
+| `bloom-expansion` | i64 | 2 | `0..=u32::MAX` | Scale factor; 0 = non-scaling |
+| `bloom-fp-rate` | string | `"0.01"` | exclusive `(0, 1)` | Default FP rate |
+| `bloom-tightening-ratio` | string | `"0.5"` | exclusive `(0, 1)` | FP decay per scale-out |
+| `bloom-memory-usage-limit` | i64 | `128 * 1024 * 1024` | `0..=i64::MAX` | Max bytes per bloom object |
+| `bloom-use-random-seed` | bool | true | - | Random vs `FIXED_SEED` |
+| `bloom-defrag-enabled` | bool | true | - | Enable incremental defrag |
 
-All configs use `ConfigurationFlags::DEFAULT` and have no custom validation callback except for the two string configs (fp-rate and tightening-ratio).
+All use `ConfigurationFlags::DEFAULT`. Only the string configs have a custom validator (`on_string_config_set`). Runtime-settable via `CONFIG SET bf.<name> <value>`.
 
-## Integer Configs
+## Integer / bool configs - storage
 
-**bloom-capacity** - Default initial capacity for auto-created bloom objects. Used by BF.ADD, BF.MADD, and BF.INSERT when creating a new bloom without explicit CAPACITY. Range: 1 to i64::MAX (effectively unlimited). Stored in `BLOOM_CAPACITY: AtomicI64`. Defined as `BLOOM_CAPACITY_DEFAULT = 100`.
-
-**bloom-expansion** - Default expansion factor for scaling. When a sub-filter fills, the next one gets `capacity * expansion` items. Set to 0 for non-scaling behavior. Registration range is 0 to `BLOOM_EXPANSION_MAX as i64` (u32::MAX cast to i64 in the macro). Stored in `BLOOM_EXPANSION: AtomicI64`. Defined as `BLOOM_EXPANSION_DEFAULT = 2`.
-
-The config registration uses `0` as the min (allowing non-scaling), while the command-level `EXPANSION` argument enforces `BLOOM_EXPANSION_MIN` (1) as the floor. The value 0 is only reachable via the config or the `NONSCALING` keyword.
-
-**bloom-memory-usage-limit** - Per-object memory cap in bytes. Default is `128 * 1024 * 1024` (128MB). The `validate_size` function rejects objects whose `memory_usage()` exceeds this value. Write operations that would exceed the limit return `ERR operation exceeds bloom object memory limit`. Stored in `BLOOM_MEMORY_LIMIT_PER_OBJECT: AtomicI64`. Range: 0 to i64::MAX. Setting to 0 effectively blocks all bloom object creation since any object will have size > 0.
-
-## String Configs
-
-**bloom-fp-rate** - Target false positive rate for new bloom objects. Stored as a ValkeyString (`BLOOM_FP_RATE: ValkeyGILGuard<ValkeyString>`) for the config system, with a parallel `BLOOM_FP_RATE_F64: Mutex<f64>` for runtime use. Default: `"0.01"` (1% false positive rate). Range: exclusive (0, 1) - must be strictly greater than `BLOOM_FP_RATE_MIN` (0.0) and strictly less than `BLOOM_FP_RATE_MAX` (1.0).
-
-**bloom-tightening-ratio** - Controls how the FP rate decreases per scale-out. Each new sub-filter uses `fp_rate * tightening_ratio^N` where N is the filter index. Default: `"0.5"`. Range: exclusive (0, 1) using `BLOOM_TIGHTENING_RATIO_MIN` (0.0) and `BLOOM_TIGHTENING_RATIO_MAX` (1.0). Stored as `BLOOM_TIGHTENING_RATIO: ValkeyGILGuard<ValkeyString>` with parallel `BLOOM_TIGHTENING_F64: Mutex<f64>`.
-
-Both string configs exist because the Valkey module configuration system does not natively support f64 types. The string representation is the external interface; the `Mutex<f64>` is the internal working value.
-
-## Boolean Configs
-
-**bloom-use-random-seed** - When true (default), each new bloom object gets a unique random 32-byte seed. When false, all objects use `FIXED_SEED`. Stored in `BLOOM_USE_RANDOM_SEED: AtomicBool`. `AtomicBool::default()` initializes to false, but the config system applies the default value `true` on module load.
-
-**bloom-defrag-enabled** - Enables cursor-based incremental defragmentation. Default true. Stored in `BLOOM_DEFRAG: AtomicBool` initialized to `AtomicBool::new(BLOOM_DEFRAG_DEFAULT)` (true).
-
-## Custom String Config Handler
-
-The `on_string_config_set` function handles validation for both `bloom-fp-rate` and `bloom-tightening-ratio`:
+`AtomicI64` / `AtomicBool` with `Ordering::Relaxed` reads throughout:
 
 ```rust
-pub fn on_string_config_set(
-    config_ctx: &ConfigurationContext,
-    name: &str,
-    val: &'static ValkeyGILGuard<ValkeyString>,
-) -> Result<(), ValkeyError> {
-    let v = val.get(config_ctx);
-    let value_str = v.to_string_lossy();
-    let value = match value_str.parse::<f64>() {
-        Ok(v) => v,
-        Err(_) => return Err(ValkeyError::Str("Invalid floating-point value")),
-    };
-    match name {
-        "bloom-fp-rate" => { /* validate range, update BLOOM_FP_RATE_F64 */ }
-        "bloom-tightening-ratio" => { /* validate range, update BLOOM_TIGHTENING_F64 */ }
-        _ => Err(ValkeyError::Str("Unknown configuration parameter")),
-    }
-}
+pub static ref BLOOM_CAPACITY:        AtomicI64  = AtomicI64::new(BLOOM_CAPACITY_DEFAULT);
+pub static ref BLOOM_EXPANSION:       AtomicI64  = AtomicI64::new(BLOOM_EXPANSION_DEFAULT);
+pub static ref BLOOM_MEMORY_LIMIT_PER_OBJECT: AtomicI64 = ...;
+pub static ref BLOOM_USE_RANDOM_SEED: AtomicBool = AtomicBool::default();  // overridden at load to true
+pub static ref BLOOM_DEFRAG:          AtomicBool = AtomicBool::new(BLOOM_DEFRAG_DEFAULT);
 ```
 
-The handler performs three steps:
+Note: `bloom-expansion` register-range allows 0 (non-scaling), while command-level `EXPANSION` arg floor is `BLOOM_EXPANSION_MIN` (1). Zero is reachable only via config or `NONSCALING` keyword.
 
-1. **Extract string value**: Gets the ValkeyString from the GIL guard, converts via `to_string_lossy()`
-2. **Parse to f64**: Returns `"Invalid floating-point value"` on failure
-3. **Validate range**: For `bloom-fp-rate`, out-of-range returns `ERR (0 < error rate range < 1)`. For `bloom-tightening-ratio`, out-of-range returns `ERR (0 < tightening ratio range < 1)`. On success, updates the corresponding `Mutex<f64>` static.
+`bloom-memory-usage-limit = 0` blocks all bloom creation (any object has size > 0).
 
-This callback is registered in the `valkey_module!` macro via `Some(Box::new(configs::on_string_config_set))` as the last parameter of each string config entry.
+## String-as-f64 configs
 
-## Config Storage Pattern
+Valkey module config system has no native f64 type. Both `bloom-fp-rate` and `bloom-tightening-ratio` use:
 
-The module uses two storage mechanisms from `lazy_static!`:
-
-**AtomicI64 / AtomicBool** for integer and boolean configs:
+- **External storage**: `ValkeyGILGuard<ValkeyString>` - what CONFIG SET/GET sees.
+- **Internal cache**: `Mutex<f64>` - what command handlers read to avoid repeated string parsing.
 
 ```rust
-pub static ref BLOOM_CAPACITY: AtomicI64 = AtomicI64::new(BLOOM_CAPACITY_DEFAULT);
-pub static ref BLOOM_USE_RANDOM_SEED: AtomicBool = AtomicBool::default();
+pub static ref BLOOM_FP_RATE:       ValkeyGILGuard<ValkeyString> = ValkeyGILGuard::new(...);
+pub static ref BLOOM_FP_RATE_F64:   Mutex<f64>                   = Mutex::new(0.01);
+pub static ref BLOOM_TIGHTENING_RATIO: ValkeyGILGuard<ValkeyString> = ...;
+pub static ref BLOOM_TIGHTENING_F64:   Mutex<f64>                   = Mutex::new(0.5);
 ```
 
-These are read with `Ordering::Relaxed` throughout the codebase. The valkey-module SDK handles the CONFIG SET/GET plumbing automatically.
+`on_string_config_set(ctx, name, val)`:
 
-**ValkeyGILGuard + Mutex** for float-as-string configs:
+1. `to_string_lossy()`, `parse::<f64>()`. Parse error -> `"Invalid floating-point value"`.
+2. Range check:
+   - `bloom-fp-rate` out of range -> `ERR (0 < error rate range < 1)`.
+   - `bloom-tightening-ratio` out of range -> `ERR (0 < tightening ratio range < 1)`.
+3. Update the corresponding `Mutex<f64>`.
+
+Registered via `Some(Box::new(configs::on_string_config_set))` as the last parameter of each string config entry in `valkey_module!`.
+
+## `module_args_as_configuration`
 
 ```rust
-pub static ref BLOOM_FP_RATE: ValkeyGILGuard<ValkeyString> =
-    ValkeyGILGuard::new(ValkeyString::create(None, BLOOM_FP_RATE_DEFAULT));
-pub static ref BLOOM_FP_RATE_F64: Mutex<f64> = Mutex::new(0.01);
+configurations: [ ..., module_args_as_configuration: true ]
 ```
 
-The `ValkeyGILGuard<ValkeyString>` is the config system's storage. The `Mutex<f64>` is kept in sync by `on_string_config_set` and used by command handlers to avoid repeated string parsing.
-
-## module_args_as_configuration
-
-The `valkey_module!` macro includes:
-
-```rust
-configurations: [
-    // ...
-    module_args_as_configuration: true,
-]
-```
-
-Tells the valkey-module SDK to interpret module load arguments as configuration parameters. For example:
+Makes module load arguments flow through the config system:
 
 ```
 valkey-server --loadmodule ./libvalkey_bloom.so bloom-capacity 1000 bloom-fp-rate 0.001
 ```
 
-The arguments are automatically mapped to the registered configs, eliminating the need for custom `_args` parsing in the `initialize` function. The init function signature accepts `_args: &[ValkeyString]` but does not use them.
+No custom `_args` parsing needed in `initialize` - `_args: &[ValkeyString]` is unused.
 
-## Fixed Seed Constant
+## Other module constants (in `src/configs.rs`)
 
-```rust
-pub const FIXED_SEED: [u8; 32] = [
-    89, 15, 245, 34, 234, 120, 17, 218, 167, 20, 216, 9, 59, 62, 123, 217,
-    29, 137, 138, 115, 62, 152, 136, 135, 48, 127, 151, 205, 40, 7, 51, 131,
-];
-```
-
-Used when `bloom-use-random-seed` is false. Also used as the comparison baseline in BF.INSERT's SEED parsing to determine `is_seed_random`.
-
-## Other Constants
-
-- `BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX: i32 = i32::MAX` - hard cap on sub-filter count per bloom object, checked in `add_item` and `decode_object`
-- `BLOOM_MIN_SUPPORTED_VERSION: &[i64; 3] = &[8, 0, 0]` - minimum Valkey server version, checked in `initialize`
+- `FIXED_SEED: [u8; 32]` - used when `bloom-use-random-seed=false`, also the `is_seed_random` comparison baseline for BF.INSERT SEED parsing.
+- `BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX: i32 = i32::MAX` - hard cap, checked in `add_item` and `decode_object`.
+- `BLOOM_MIN_SUPPORTED_VERSION: &[i64; 3] = &[8, 0, 0]` - checked in `initialize`; below returns `Status::Err`.
+- Range constants: `BLOOM_EXPANSION_MAX` (u32::MAX), `BLOOM_FP_RATE_MIN`/`MAX` (0.0 / 1.0), `BLOOM_TIGHTENING_RATIO_MIN`/`MAX` (0.0 / 1.0).

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/commands-replication.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/commands-replication.md
@@ -1,80 +1,38 @@
-# Deterministic Replication Strategy
+# Deterministic replication
 
-Use when understanding how bloom objects replicate to replicas, why creation uses BF.INSERT with SEED/TIGHTENING, how size limits are bypassed on replicas, or how keyspace notifications fire.
+Use when reasoning about how primary sends bloom state to replicas, SEED/TIGHTENING as replication-internal args, size limit bypass, or keyspace notifications.
 
-Source: `src/bloom/command_handler.rs` (replicate_and_notify_events, ReplicateArgs), `src/wrapper/mod.rs` (must_obey_client)
+Source: `src/bloom/command_handler.rs` (`replicate_and_notify_events`, `ReplicateArgs`), `src/wrapper/mod.rs` (`must_obey_client`).
 
-## Overview
+## Why not verbatim
 
-The valkey-bloom module uses deterministic replication rather than verbatim replication for object creation. When a primary creates a bloom object, it must ensure the replica creates an identical object - same capacity, fp_rate, tightening_ratio, expansion, and critically the same hash seed. Without the seed, the replica's bloom filter would produce different hash results and diverge.
+Verbatim BF.ADD would diverge on replicas - each would pick its own random seed. Primary must ship the exact seed plus capacity / fp_rate / tightening_ratio / expansion so the replica's bloom is bit-for-bit identical in hash behavior.
 
-All mutative commands call `replicate_and_notify_events` after their operation completes. This function handles both replication to replicas and keyspace event notifications.
+Every mutative command calls `replicate_and_notify_events(add_operation, reserve_operation, ...)` after its work. That function dispatches replication and keyspace events.
 
-## Three Replication Cases
+## Three cases
 
-The `replicate_and_notify_events` function receives two boolean flags:
+| `reserve_operation` | `add_operation` | Action |
+|:-:|:-:|---|
+| true | * | synthetic `BF.INSERT` with full object properties (see below) |
+| false | true | `ctx.replicate_verbatim()` - replays the original command |
+| false | false | no-op (pure duplicate add, or empty INSERT on existing key) |
 
-- `add_operation: bool` - true when at least one item was successfully added
-- `reserve_operation: bool` - true when a new bloom object was created
-
-These flags produce three distinct replication behaviors:
-
-1. **Reserve (creation)**: `reserve_operation == true` - replicates as a synthetic `BF.INSERT`
-2. **Add-only (no creation)**: `reserve_operation == false && add_operation == true` - replicates verbatim
-3. **No-op**: both false - no replication at all
-
-## Reserve Replication
-
-When `reserve_operation` is true, the function constructs a synthetic `BF.INSERT` command with every property needed to recreate the bloom object identically:
+## Synthetic BF.INSERT form
 
 ```
-BF.INSERT <key> CAPACITY <cap> ERROR <fp> TIGHTENING <ratio> SEED <32bytes>
-    [EXPANSION <exp> | NONSCALING] [ITEMS <item1> <item2> ...]
+BF.INSERT <key> CAPACITY <cap> ERROR <fp> TIGHTENING <ratio> SEED <32 bytes>
+          [EXPANSION <exp> | NONSCALING] [ITEMS <item> ...]
 ```
 
-The construction in code:
+- `expansion == 0` appends `NONSCALING`, else `EXPANSION <value>`.
+- `ITEMS` present only if items were supplied (BF.RESERVE replication omits the entire ITEMS clause).
 
-```rust
-let mut cmd = vec![
-    key_name,
-    &capacity_str, &capacity_val,    // CAPACITY <cap>
-    &fp_rate_str, &fp_rate_val,      // ERROR <fp>
-    &tightening_str, &tightening_val, // TIGHTENING <ratio>
-    &seed_str, &seed_val,            // SEED <32bytes>
-];
-```
+Why BF.INSERT: it's the only command that accepts CAPACITY + ERROR + TIGHTENING + SEED + EXPANSION + NONSCALING + ITEMS. BF.RESERVE can't carry SEED / TIGHTENING. Funneling all creation through BF.INSERT unifies the replication path.
 
-**Expansion handling**: If `expansion == 0` (non-scaling), appends `NONSCALING`. Otherwise appends `EXPANSION <value>`.
+Called via `ctx.replicate("BF.INSERT", cmd.as_slice())` - also goes to AOF when AOF and replication are both enabled. (Note: AOF **rewrite** uses the different BF.LOAD path, see `architecture-persistence.md`.)
 
-**Items**: If items were provided (BF.ADD or BF.INSERT with items), appends `ITEMS` followed by the item arguments. For BF.RESERVE, items is empty and the ITEMS keyword is omitted entirely.
-
-**Why BF.INSERT**: BF.INSERT is the only command that accepts all of CAPACITY, ERROR, TIGHTENING, SEED, EXPANSION, NONSCALING, and ITEMS. BF.RESERVE cannot carry SEED or TIGHTENING. By funneling all creation through BF.INSERT, the replication path is unified.
-
-The call to `ctx.replicate("BF.INSERT", cmd.as_slice())` sends this synthetic command to replicas and the AOF.
-
-## Add-Only Replication
-
-When `reserve_operation` is false and `add_operation` is true, the command is replicated verbatim:
-
-```rust
-} else if add_operation {
-    ctx.replicate_verbatim();
-}
-```
-
-This covers cases where items are added to an existing bloom object. Since the object already exists on the replica (created by a prior reserve replication), the original command (BF.ADD, BF.MADD, or BF.INSERT) can be replayed as-is.
-
-## No-Op Case
-
-When both flags are false, no replication occurs. This happens when:
-
-- BF.ADD/BF.MADD adds an item that already exists (duplicate) - `add_succeeded` stays false
-- BF.INSERT with no items on an existing key
-- BF.INSERT where all items were duplicates on an existing key
-
-No replication is needed because nothing changed.
-
-## ReplicateArgs Structure
+## `ReplicateArgs`
 
 ```rust
 struct ReplicateArgs<'a> {
@@ -87,81 +45,58 @@ struct ReplicateArgs<'a> {
 }
 ```
 
-Populated from the **bloom object's actual properties**, not the command arguments. The distinction matters because BF.ADD and BF.MADD do not accept these parameters as arguments - they read them from the created bloom object. For BF.INSERT on an existing object, the object's original properties are used, not the command's override arguments.
+Populated from the **actual bloom object**, not the command's input args. Matters because:
 
-The `items` field is a slice of the original input arguments starting at the item index position, so the exact user-supplied items are forwarded to replicas.
+- BF.ADD / BF.MADD accept no property args - properties are read from the newly created (or existing) bloom.
+- BF.INSERT on an existing object ignores its own CAPACITY/ERROR/... overrides for replication and uses the object's creation-time values.
 
-## must_obey_client
+## `must_obey_client`
 
-The `must_obey_client` function in `src/wrapper/mod.rs` determines whether the current command is arriving from a primary or AOF replay and should not be rejected:
+In `src/wrapper/mod.rs`, detects whether the current command came from primary-to-replica replication or AOF replay. Two impls gated by feature flag:
 
-**Valkey 8.1+** (default, no feature flag):
+| Build | Impl |
+|-------|------|
+| default (Valkey 8.1+) | `ValkeyModule_MustObeyClient` via `valkey_module::raw` - returns 1 when command is from primary / AOF client |
+| `--features valkey_8_0` | `ctx.get_flags().contains(ContextFlags::REPLICATED)` - best-effort fallback using `GetContextFlags` (less precise) |
 
-```rust
-let ctx_raw = ctx.get_raw() as *mut valkey_module::ValkeyModuleCtx;
-let status = unsafe { valkey_module::raw::ValkeyModule_MustObeyClient.unwrap()(ctx_raw) };
-```
+Compile-time - no runtime toggle.
 
-Uses the `ValkeyModule_MustObeyClient` API from the `valkey_module::raw` bindings. Returns 1 when the command comes from the primary or AOF client. Panics on unexpected return values.
+## Size limit bypass on replicas
 
-**Valkey 8.0** (feature `valkey_8_0`):
-
-```rust
-ctx.get_flags().contains(valkey_module::ContextFlags::REPLICATED)
-```
-
-Falls back to checking `ContextFlags::REPLICATED` via the `GetContextFlags` API. A best-effort approximation since the flag-based approach is less precise than the dedicated API.
-
-The feature flag is compile-time: `cargo build --features valkey_8_0`. Without the flag, the 8.1+ path is used.
-
-## Size Limit Bypass on Replicas
-
-Every mutative command handler checks:
+Every mutative handler:
 
 ```rust
 let validate_size_limit = !must_obey_client(ctx);
 ```
 
-When `must_obey_client` returns true (replica receiving from primary, or AOF replay), `validate_size_limit` is false. This means:
+When true (replica / AOF replay), passed as `false` to:
 
-- `BloomObject::new_reserved` skips `validate_size_before_create`
-- `BloomObject::add_item` skips `validate_size_before_scaling`
-- `BloomObject::decode_object` (BF.LOAD path) skips memory size validation
+- `BloomObject::new_reserved` - skips `validate_size_before_create`.
+- `BloomObject::add_item` - skips `validate_size_before_scaling`.
+- `BloomObject::decode_object` (BF.LOAD) - skips total-size check.
 
-Replicas never reject operations that the primary accepted. If the primary's `bloom-memory-usage-limit` allowed a bloom object, the replica must accept it even if the replica has a different (lower) memory limit configured.
+Replicas never reject what the primary accepted. A lower `bloom-memory-usage-limit` on a replica is irrelevant to replication.
 
-The size limit is enforced only on user-initiated commands on the primary node.
-
-## Keyspace Notifications
-
-Two events are published after replication, defined as constants in `utils.rs`:
+## Keyspace notifications
 
 ```rust
-pub const ADD_EVENT: &str = "bloom.add";
+pub const ADD_EVENT:     &str = "bloom.add";
 pub const RESERVE_EVENT: &str = "bloom.reserve";
 ```
 
-Notification logic in `replicate_and_notify_events`:
+Fired in `replicate_and_notify_events`:
 
-```rust
-if add_operation {
-    ctx.notify_keyspace_event(NotifyEvent::GENERIC, "bloom.add", key_name);
-}
-if reserve_operation {
-    ctx.notify_keyspace_event(NotifyEvent::GENERIC, "bloom.reserve", key_name);
-}
-```
+- `add_operation` true -> `notify_keyspace_event(GENERIC, "bloom.add", key)`.
+- `reserve_operation` true -> `notify_keyspace_event(GENERIC, "bloom.reserve", key)`.
 
-Both events can fire in the same call - when BF.ADD or BF.INSERT creates a new object and adds items, both `bloom.reserve` and `bloom.add` are emitted. The events use `NotifyEvent::GENERIC` category. Keyspace notifications fire independently of the replication path - both checks run regardless of which replication branch was taken.
+Both can fire in the same call (BF.ADD / BF.INSERT that creates and adds). Independent of the replication branch taken.
 
-## Replication in Each Command
+## Per-command replication summary
 
-| Command | Creation | Add-Only | Notes |
+| Command | Creation | Add-only | Notes |
 |---------|----------|----------|-------|
-| BF.ADD | BF.INSERT with full props + items | Verbatim | Auto-creates if key missing |
-| BF.MADD | BF.INSERT with full props + items | Verbatim | Auto-creates if key missing |
-| BF.RESERVE | BF.INSERT with full props, no items | Never | Creation-only, no items to add |
-| BF.INSERT | BF.INSERT with full props + items | Verbatim | Explicit creation or add |
-| BF.LOAD | BF.INSERT with full props | Never | AOF rewrite path, creation-only |
-
-All creation paths use the same `replicate_and_notify_events` function. The replicated BF.INSERT always includes SEED and TIGHTENING, ensuring the replica's bloom object is bit-for-bit identical in hash behavior.
+| BF.ADD | synthetic BF.INSERT + items | verbatim | auto-create on missing key |
+| BF.MADD | synthetic BF.INSERT + items | verbatim | auto-create on missing key |
+| BF.RESERVE | synthetic BF.INSERT (no items) | never | creation-only |
+| BF.INSERT | synthetic BF.INSERT + items | verbatim | explicit flow |
+| BF.LOAD | synthetic BF.INSERT + data-as-item | never | AOF-rewrite-fed command; replica rebuilds via BF.INSERT, not BF.LOAD |

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/contributing-build.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/contributing-build.md
@@ -1,181 +1,79 @@
-# Build System
+# Build system
 
-Use when building valkey-bloom from source, understanding Cargo configuration, feature flags, build.sh usage, or troubleshooting build issues.
+Use when building valkey-bloom, understanding feature flags, or working with `build.sh`.
 
-Source: `Cargo.toml`, `build.sh`, `src/lib.rs`
+Source: `Cargo.toml`, `build.sh`.
 
-## Crate Configuration
+## Shape
 
-The crate produces a C-compatible dynamic library loaded by the Valkey server at runtime:
+- `crate-type = ["cdylib"]`, lib name `valkey_bloom` (output `libvalkey_bloom.so` / `.dylib`).
+- Crate version `99.99.99-dev`, `MODULE_VERSION = 999999` - both placeholder, rewritten at release.
+- Dev profile: `debug = 2`, `opt-level = 0`. Release profile uses Cargo defaults.
+- Module name registered to Valkey is `"bf"` (not `"bloom"`).
 
-```toml
-[package]
-name = "valkey-bloom"
-version = "99.99.99-dev"
-edition = "2021"
-license = "BSD-3-Clause"
-
-[lib]
-crate-type = ["cdylib"]
-name = "valkey_bloom"
-```
-
-The `cdylib` crate type produces a `.so` on Linux or `.dylib` on macOS. The library name `valkey_bloom` maps to output files `libvalkey_bloom.so` / `libvalkey_bloom.dylib`.
-
-The Cargo version (`99.99.99-dev`) is a placeholder replaced during release. The MODULE_VERSION constant in `src/lib.rs` is `999999` (an i32 for the module API), also replaced at release time.
-
-The dev profile enables full debug info (`debug = 2`), debug assertions, and no optimization (`opt-level = 0`). No `[profile.release]` is defined, so the release profile uses Cargo defaults (opt-level 3, no debug).
-
-## Dependencies
-
-Runtime dependencies:
-
-| Crate | Version | Purpose |
-|-------|---------|---------|
-| `valkey-module` | 0.1.5 | Valkey Module API bindings (with `min-valkey-compatibility-version-8-0` and `min-redis-compatibility-version-7-2` features) |
-| `valkey-module-macros` | 0 | Proc macros for `#[info_command_handler]` |
-| `linkme` | 0 | Distributed slice registration for macros |
-| `bloomfilter` | 3.0.1 | Core bloom filter implementation (with `serde` feature for serialization) |
-| `lazy_static` | 1.4.0 | Static initialization of configs and metrics |
-| `libc` | 0.2 | C types for FFI callbacks |
-| `serde` | 1.0 | Serialization framework (with `derive` feature) |
-| `bincode` | 1.3 | Binary encoding for BF.LOAD / AOF rewrite |
-
-Dev-only dependencies (used in unit tests):
-
-| Crate | Version | Purpose |
-|-------|---------|---------|
-| `rand` | 0.8 | Random string generation for test items |
-| `rstest` | 0.23.0 | Parameterized test cases (random vs fixed seed) |
-
-## Feature Flags
+## Feature flags
 
 ```toml
 [features]
 default = ["min-valkey-compatibility-version-8-0"]
-enable-system-alloc = ["valkey-module/enable-system-alloc"]
+enable-system-alloc        = ["valkey-module/enable-system-alloc"]
 min-valkey-compatibility-version-8-0 = []
-valkey_8_0 = []
-use-redismodule-api = []
+valkey_8_0                 = []
+use-redismodule-api        = []   # empty stub, prevents build errors if passed
 ```
 
-**default** - Enables `min-valkey-compatibility-version-8-0`. This is always on for standard builds.
+| Flag | Why |
+|------|-----|
+| `enable-system-alloc` | **Required for `cargo test`** - ValkeyAlloc needs a running server. Integration tests load into a real server and use ValkeyAlloc normally. |
+| `valkey_8_0` | Swaps `must_obey_client` from `ValkeyModule_MustObeyClient` to `ContextFlags::REPLICATED` fallback. Compile-time only. |
 
-**enable-system-alloc** - Switches from Valkey's allocator to the system allocator. Required for unit tests because ValkeyAlloc is unavailable outside of a running Valkey server. Always pass `--features enable-system-alloc` when running `cargo test`.
-
-**valkey_8_0** - Enables compatibility with Valkey 8.0. By default the module targets Valkey 8.1+ and uses the `ValkeyModule_MustObeyClient` API. When this flag is set, the module falls back to checking `ContextFlags::REPLICATED` instead (see `reference/commands/replication.md`). Pass this flag when building for Valkey 8.0:
-
-```bash
-cargo build --release --features valkey_8_0
-```
-
-**use-redismodule-api** - Empty stub. Exists to prevent build errors if the feature is passed by tooling. Not functional.
-
-## ValkeyAlloc Global Allocator
-
-The module registers Valkey's allocator as the global Rust allocator via the `valkey_module!` macro:
+## Allocator
 
 ```rust
 valkey_module! {
     allocator: (valkey_module::alloc::ValkeyAlloc, valkey_module::alloc::ValkeyAlloc),
-    // ...
+    ...
 }
 ```
 
-All Rust heap allocations route through Valkey's `zmalloc`/`zfree`, enabling accurate memory tracking in `INFO MEMORY` and correct behavior with `maxmemory` eviction policies. See `reference/architecture/bloom-object.md` for how memory limits interact with ValkeyAlloc.
+All heap allocations flow through Valkey's `zmalloc`, surfacing in `INFO MEMORY` and `maxmemory` eviction. This is why unit tests need `enable-system-alloc` to escape the dependency on a running server.
 
-Because ValkeyAlloc requires a running Valkey server, unit tests must use `--features enable-system-alloc` to substitute the system allocator. Integration tests load the module into a real server and use ValkeyAlloc normally.
+## Dependencies worth knowing
 
-## Build Commands
+- `valkey-module 0.1.5` with features `min-valkey-compatibility-version-8-0` + `min-redis-compatibility-version-7-2`.
+- `bloomfilter 3.0.1` with `serde` - core filter impl.
+- `bincode 1.3` - BF.LOAD / AOF encoding.
+- `rstest 0.23.0` (dev) - parameterized seed tests.
 
-**Debug build** (fast compilation, debug symbols):
+## `build.sh` pipeline
 
-```bash
-cargo build
-```
+Driven by `SERVER_VERSION` env (`unstable` / `8.0` / `8.1` / `9.0`; defaults to `unstable` with warning). Steps:
 
-**Release build** (optimized, used for integration tests):
+1. `cargo fmt --check`.
+2. `cargo clippy --profile release --all-targets -- -D clippy::all` (note: **stricter than CI**, which omits `-D`).
+3. `cargo test --features enable-system-alloc`.
+4. `RUSTFLAGS="-D warnings" cargo build --release` (adds `--features valkey_8_0` when `SERVER_VERSION=8.0`).
+5. Clone / build valkey-server into `tests/build/binaries/<version>/`.
+6. Clone `valkey-test-framework` into `tests/build/valkeytestframework/`.
+7. `pip install -r requirements.txt` (installs `valkey`, `pytest==7.4.3`).
+8. `pytest tests/` (with `tee` + ASAN scan when `ASAN_BUILD` set).
 
-```bash
-cargo build --all --all-targets --release
-```
+`./build.sh clean` removes `target/`, `tests/build/`, `test-data/`.
 
-**Release build for Valkey 8.0** (build.sh uses RUSTFLAGS; CI does not):
+### Env vars
 
-```bash
-RUSTFLAGS="-D warnings" cargo build --all --all-targets --release --features valkey_8_0
-```
+| Var | Required | Meaning |
+|-----|----------|---------|
+| `SERVER_VERSION` | yes | `unstable` / `8.0` / `8.1` / `9.0` |
+| `ASAN_BUILD` | no | any value -> `make SANITIZER=address`, output piped through `tee`, grep for `LeakSanitizer: detected memory leaks` |
+| `TEST_PATTERN` | no | pytest `-k` expression; works for ASAN and normal builds |
 
-**Unit tests** (must use system allocator):
-
-```bash
-cargo test --features enable-system-alloc
-```
-
-**Format and lint checks** (build.sh adds `-D clippy::all`; CI does not):
-
-```bash
-cargo fmt --check
-cargo clippy --profile release --all-targets -- -D clippy::all   # build.sh
-cargo clippy --profile release --all-targets                      # CI
-```
-
-## build.sh Script
-
-The `build.sh` script automates the full pipeline locally: format checks, unit tests, server build, and integration tests.
-
-**Usage**:
-
-```bash
-# Full pipeline (set SERVER_VERSION first)
-export SERVER_VERSION=unstable   # or 8.0, 8.1, 9.0
-./build.sh
-
-# Clean build artifacts (removes target/, tests/build/, test-data/)
-./build.sh clean
-```
-
-**Environment variables**:
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `SERVER_VERSION` | Yes | Target Valkey version: `unstable`, `8.0`, `8.1`, or `9.0`. Defaults to `unstable` with a warning if unset |
-| `ASAN_BUILD` | No | When set (any value), builds Valkey server with `SANITIZER=address` and enables LeakSanitizer detection in test output |
-| `TEST_PATTERN` | No | pytest `-k` expression to run specific tests (e.g., `TEST_PATTERN=test_replication`). Works for both ASAN and normal builds |
-
-**Pipeline steps** (in order):
-
-1. `cargo fmt --check` and `cargo clippy --profile release --all-targets -- -D clippy::all` - format and lint checks
-2. `cargo test --features enable-system-alloc` - unit tests
-3. `RUSTFLAGS="-D warnings" cargo build --release` - release build (adds `--features valkey_8_0` if SERVER_VERSION is 8.0)
-4. Clone and build valkey-server from source (cached in `tests/build/binaries/<version>/`)
-5. Clone valkey-test-framework into `tests/build/valkeytestframework/`
-6. `pip install -r requirements.txt` - install Python test dependencies (`valkey`, `pytest==7.4.3`)
-7. `pytest tests/` - run integration tests (with `--capture=sys` and `tee` for ASAN builds)
-
-When `ASAN_BUILD` is set, the script pipes test output through `tee` and scans for `LeakSanitizer: detected memory leaks`. If leaks are found, it reports the offending tests and exits with code 1.
-
-## build.sh vs CI Differences
-
-The build.sh script and GitHub Actions CI have minor differences:
+## build.sh vs CI differences
 
 | Aspect | build.sh | CI |
-|--------|----------|-----|
-| clippy flags | `-- -D clippy::all` | no `-D` flag |
-| RUSTFLAGS | `RUSTFLAGS="-D warnings"` on all builds | not set |
-| ASAN server build | `make -j SANITIZER=address` | adds `SERVER_CFLAGS='-Werror' BUILD_TLS=module` |
-| ASAN test filter | runs all tests | `-m "not skip_for_asan"` to exclude defrag tests |
-| Server versions | unstable, 8.0, 8.1, 9.0 | unstable, 8.0, 8.1 |
-
-## Output Artifacts
-
-| Platform | Path |
-|----------|------|
-| Linux | `target/release/libvalkey_bloom.so` |
-| macOS | `target/release/libvalkey_bloom.dylib` |
-
-Load the module in Valkey:
-
-```
-loadmodule /path/to/libvalkey_bloom.so
-```
+|--------|----------|----|
+| clippy | `-- -D clippy::all` | no `-D` |
+| RUSTFLAGS | `-D warnings` always | unset |
+| ASAN server make | `make -j SANITIZER=address` | adds `SERVER_CFLAGS='-Werror' BUILD_TLS=module` |
+| ASAN test filter | all tests | `-m "not skip_for_asan"` |
+| Server matrix | unstable, 8.0, 8.1, 9.0 | unstable, 8.0, 8.1 |

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/contributing-ci-pipeline.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/contributing-ci-pipeline.md
@@ -1,164 +1,103 @@
-# CI Pipeline
+# CI pipeline
 
-Use when debugging CI failures, understanding the CI matrix, adding new CI jobs, or working with the release workflow.
+Use when debugging CI failures, extending the matrix, or understanding the release-trigger workflow.
 
-Source: `.github/workflows/ci.yml`, `.github/workflows/trigger-bloom-release.yml`
+Source: `.github/workflows/ci.yml`, `.github/workflows/trigger-bloom-release.yml`.
 
-## CI Overview
+## Jobs
 
-The CI pipeline runs on every push and pull request. It has three jobs:
+Triggered on push and PR. `fail-fast: false` on all.
 
-| Job | Runner | Matrix | Purpose |
-|-----|--------|--------|---------|
-| `build-ubuntu-latest` | ubuntu-latest | unstable, 8.0, 8.1 | Full pipeline: lint, build, unit tests, integration tests |
-| `build-macos-latest` | macos-latest | none | Lint, build, unit tests only (no integration tests) |
-| `asan-build` | ubuntu-latest | unstable, 8.0, 8.1 | Full pipeline with AddressSanitizer and LeakSanitizer |
+| Job | Runner | Matrix | Coverage |
+|-----|--------|--------|----------|
+| `build-ubuntu-latest` | ubuntu-latest | unstable, 8.0, 8.1 | lint + build + unit + integration |
+| `build-macos-latest` | macos-latest | none | lint + build + unit (no integration - no server binary built on macOS) |
+| `asan-build` | ubuntu-latest | unstable, 8.0, 8.1 | full pipeline with AddressSanitizer + LeakSanitizer scan |
 
-All jobs use `fail-fast: false` so one matrix entry failing does not cancel others.
+Global env: `CARGO_TERM_COLOR`, `VALKEY_REPO_URL`, `TEST_FRAMEWORK_REPO`, `TEST_FRAMEWORK_DIR`.
 
-Global environment variables set on all jobs: `CARGO_TERM_COLOR=always`, `VALKEY_REPO_URL`, `TEST_FRAMEWORK_REPO`, `TEST_FRAMEWORK_DIR`.
+## Ubuntu pipeline (outline)
 
-## build-ubuntu-latest Job
+1. `actions/checkout@v4`.
+2. Export `SERVER_VERSION=<matrix>` into `$GITHUB_ENV`.
+3. `cargo fmt --check` + `cargo clippy --profile release --all-targets` (no `-D clippy::all`, unlike build.sh).
+4. `cargo build --all --all-targets --release` - adds `--features valkey_8_0` when `SERVER_VERSION=8.0`. No `RUSTFLAGS` (unlike build.sh).
+5. `cargo test --features enable-system-alloc`.
+6. Clone + build `valkey-io/valkey` at the target version; binary into `tests/build/binaries/<version>/`.
+7. Clone `valkey-io/valkey-test-framework`, copy `src/` into `tests/build/valkeytestframework/`.
+8. `actions/setup-python@v3` (3.8), `pip install -r requirements.txt`.
+9. Export `MODULE_PATH=$(realpath target/release/libvalkey_bloom.so)`.
+10. `python -m pytest --cache-clear -v tests/`.
 
-This is the primary CI job. It runs the complete pipeline for each server version in the matrix.
+## macOS pipeline
 
-**Steps in order**:
+Checkout + format/lint + release build + `cargo test --features enable-system-alloc`. No integration tests, no matrix.
 
-1. **Checkout** - `actions/checkout@v4`
+## ASAN pipeline - differences
 
-2. **Set SERVER_VERSION** - writes `SERVER_VERSION=<matrix.server_version>` to `$GITHUB_ENV` so integration tests use the correct server binary.
-
-3. **Format and lint checks** (note: no `-D clippy::all` unlike build.sh):
-   ```bash
-   cargo fmt --check
-   cargo clippy --profile release --all-targets
-   ```
-
-4. **Release build** - conditional on server version (no `RUSTFLAGS` unlike build.sh):
-   ```bash
-   # For 8.0:
-   cargo build --all --all-targets --release --features valkey_8_0
-   # For unstable and 8.1:
-   cargo build --all --all-targets --release
-   ```
-
-5. **Unit tests**:
-   ```bash
-   cargo test --features enable-system-alloc
-   ```
-
-6. **Build valkey-server** - clones `valkey-io/valkey` at the target version, builds with `make -j`, copies the binary to `tests/build/binaries/<version>/valkey-server`
-
-7. **Set up test framework** - clones `valkey-io/valkey-test-framework`, copies `src/` contents to `tests/build/valkeytestframework/`
-
-8. **Python setup** - Python 3.8 via `actions/setup-python@v3`, upgrades pip, installs `requirements.txt`
-
-9. **Set MODULE_PATH** - sets the environment variable via `realpath target/release/libvalkey_bloom.so` into `$GITHUB_ENV`
-
-10. **Integration tests**:
-    ```bash
-    python -m pytest --cache-clear -v "tests/"
-    ```
-
-## build-macos-latest Job
-
-A lighter job that validates compilation and unit tests on macOS. No server version matrix - runs once.
-
-**Steps**:
-
-1. Checkout
-2. Format and lint checks (`cargo fmt --check`, `cargo clippy --profile release --all-targets`)
-3. Release build (`cargo build --all --all-targets --release`)
-4. Unit tests (`cargo test --features enable-system-alloc`)
-
-Integration tests are skipped because the CI does not build a macOS valkey-server binary.
-
-## asan-build Job
-
-Runs the full pipeline with AddressSanitizer enabled on the Valkey server binary. Uses the same matrix as the Ubuntu job (unstable, 8.0, 8.1).
-
-**Key differences from the standard Ubuntu job**:
-
-The Valkey server is built with sanitizer flags (note `SERVER_CFLAGS` and `BUILD_TLS` are CI-only - build.sh uses just `SANITIZER=address`):
+Server built with sanitizer + TLS module:
 
 ```bash
 make distclean
 make -j SANITIZER=address SERVER_CFLAGS='-Werror' BUILD_TLS=module
 ```
 
-Integration tests run with `--capture=sys`, pipe output through `tee`, and filter out ASAN-incompatible tests:
+(`SERVER_CFLAGS='-Werror'` and `BUILD_TLS=module` are CI-only; `build.sh` uses bare `SANITIZER=address`.)
+
+Integration run:
 
 ```bash
 python -m pytest --capture=sys --cache-clear -v "tests/" \
     -m "not skip_for_asan" 2>&1 | tee test_output.tmp
 ```
 
-The `-m "not skip_for_asan"` filter excludes tests marked with `@pytest.mark.skip_for_asan`. Currently, the `TestBloomDefrag` class in `test_bloom_defrag.py` is the only test excluded because `activedefrag` cannot be enabled on ASAN server builds.
+The module itself builds as a standard release binary - ASAN instruments the server process only. Because module allocations go through ValkeyAlloc (instrumented), leaks in module code still show up.
 
-After tests complete, the output is scanned for LeakSanitizer reports (see next section).
+### LeakSanitizer detection
 
-The bloom module itself is built as a standard release binary without ASAN instrumentation. ASAN coverage applies to the Valkey server process. Memory leaks in the module are detected because the module's allocations (via ValkeyAlloc) flow through the server's instrumented allocator.
-
-## LeakSanitizer Detection
-
-After the ASAN integration tests finish, the CI scans `test_output.tmp` for memory leak reports:
+After pytest, scans `test_output.tmp`:
 
 ```bash
 if grep -q "LeakSanitizer: detected memory leaks" test_output.tmp; then
-    LEAKING_TESTS=$(grep -B 2 "LeakSanitizer: detected memory leaks" test_output.tmp | \
-                    grep -v "LeakSanitizer" | grep ".*\.py::")
-    LEAK_COUNT=$(echo "$LEAKING_TESTS" | wc -l)
+    LEAKING_TESTS=$(grep -B 2 "LeakSanitizer: detected memory leaks" test_output.tmp \
+                    | grep -v "LeakSanitizer" | grep ".*\.py::")
     echo "$LEAKING_TESTS" | while read -r line; do
         echo "::error::Test with leak: $line"
     done
     rm test_output.tmp
     exit 1
 fi
-rm test_output.tmp
 ```
 
-If any leaks are detected, the job fails with GitHub Actions error annotations listing the specific test names and a count. The `build.sh` script contains equivalent logic for local ASAN builds.
+Emits GitHub Actions `::error::` annotations listing offending tests. `build.sh` has equivalent local logic.
 
-To skip a test in ASAN builds, mark it at the class or method level:
+Skip incompatible tests at class or method level:
 
 ```python
-@pytest.mark.skip_for_asan(reason="Explanation of why this test is ASAN-incompatible")
-class TestSomething(ValkeyBloomTestCaseBase):
-    pass
+@pytest.mark.skip_for_asan(reason="activedefrag not available on ASAN server")
+class TestBloomDefrag(ValkeyBloomTestCaseBase):
+    ...
 ```
 
-## Release Trigger Workflow
+## Release trigger (`trigger-bloom-release.yml`)
 
-The `trigger-bloom-release.yml` workflow runs when a GitHub release is published or via manual `workflow_dispatch`.
+Triggers: `release: types: [published]` (auto) or `workflow_dispatch` with `version` input (manual).
 
-**Trigger conditions**:
+Flow:
 
-- `release: types: [published]` - automatic on new release
-- `workflow_dispatch` with `version` input (required) - manual trigger
+1. Resolve version from `github.event.release.tag_name` or `inputs.version`.
+2. `peter-evans/repository-dispatch@v3` sends to `valkey-io/valkey-bundle`:
+   ```yaml
+   event-type: bloom-release
+   client-payload: { "version": "<tag>", "component": "bloom" }
+   ```
 
-**What it does**:
+Uses `secrets.EXTENSION_PAT` for cross-repo dispatch. The bundle repo's listener updates its bloom component reference.
 
-1. Determines the version from the release tag (`github.event.release.tag_name`) or the manual input (`inputs.version`)
-2. Sends a `repository-dispatch` event to `valkey-io/valkey-bundle` with:
-   - `event-type: bloom-release`
-   - `client-payload: { "version": "<tag>", "component": "bloom" }`
+## Debug tips
 
-This triggers the downstream valkey-bundle repository to update its bloom component reference.
-
-The workflow uses a `secrets.EXTENSION_PAT` token for cross-repository dispatch via the `peter-evans/repository-dispatch@v3` action.
-
-## Debugging CI Failures
-
-**Lint failures** - Run locally with build.sh (stricter than CI due to `-D clippy::all`):
-```bash
-cargo fmt --check
-cargo clippy --profile release --all-targets -- -D clippy::all
-```
-
-**Build failures for 8.0** - ensure the `valkey_8_0` feature flag is used. The `must_obey_client` wrapper in `src/wrapper/mod.rs` has conditional compilation (`#[cfg(feature = "valkey_8_0")]` vs `#[cfg(not(feature = "valkey_8_0"))]`).
-
-**Integration test failures** - check which server version and seed mode failed. Every test runs twice (random-seed and fixed-seed) via `conftest.py`. A failure in only one mode usually indicates a seed-dependent bug.
-
-**ASAN leak reports** - the leak is in the Valkey server process. Check if the leak originates from module code (bloom allocations) or server internals. Module allocations use ValkeyAlloc, so leaks show up under `zmalloc` in the stack trace.
-
-**Flaky FP-rate tests** - correctness tests use a margin above the configured FP rate. If a test fails intermittently, the margin may need adjustment for the specific capacity/expansion combination. See `reference/architecture/bloom-object.md` for FP tightening details.
+- **Lint failures** - run locally with `build.sh` (stricter `-D clippy::all`).
+- **8.0 build** - ensure `valkey_8_0` feature. `must_obey_client` in `src/wrapper/mod.rs` branches on `#[cfg(feature = "valkey_8_0")]`.
+- **Integration failure in one seed mode only** - likely a seed-dependent bug. Every test runs both random-seed and fixed-seed via `conftest.py`.
+- **ASAN leaks** - allocations flow through ValkeyAlloc, so module leaks trace through `zmalloc`.
+- **Flaky FP rate tests** - correctness margin may be too tight for that capacity/expansion combo.

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/contributing-code-structure.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/contributing-code-structure.md
@@ -1,278 +1,146 @@
-# Code Structure
+# Code structure
 
-Use when navigating the codebase, adding new commands, understanding module registration, or working with error handling patterns.
+Use when navigating the codebase, adding a new command, or understanding module registration and error handling.
 
-Source: `src/lib.rs`, `src/bloom/mod.rs`, `src/bloom/command_handler.rs`, `src/bloom/utils.rs`, `src/commands/*.json`
+Source: `src/lib.rs`, `src/bloom/*`, `src/wrapper/*`, `src/commands/*.json`.
 
-## Contents
-
-- Directory Layout (line 21)
-- Module Registration (line 48)
-- Command Registration Pattern (line 85)
-- Command Metadata JSON (line 122)
-- ACL Category (line 157)
-- Module Configurations (line 167)
-- Error Types and Handling (line 188)
-- Replication Pattern (line 229)
-- Adding a New Command (line 243)
-
----
-
-## Directory Layout
+## Directory layout
 
 ```
 src/
-  lib.rs                  # Entry point: valkey_module! macro, command wrappers, initialize/deinitialize
-  configs.rs              # Configuration constants, defaults, lazy_static config statics, config set handler
-  metrics.rs              # Atomic counters for INFO metrics (objects, memory, filters, items, capacity, defrag)
+  lib.rs                  # valkey_module! macro, command wrappers, initialize/deinitialize
+  configs.rs              # FIXED_SEED, range consts, lazy_static config statics, on_string_config_set
+  metrics.rs              # AtomicU64/usize counters for INFO bf
   bloom/
-    mod.rs                # Re-exports: command_handler, data_type, utils
-    command_handler.rs    # Command implementations (BF.ADD, BF.EXISTS, BF.RESERVE, BF.INSERT, etc.)
-    data_type.rs          # ValkeyType registration ("bloomfltr"), RDB load/save trait, encoding version
-    utils.rs              # BloomObject/BloomFilter structs, error types, error strings, unit tests
+    mod.rs                # re-exports command_handler, data_type, utils
+    command_handler.rs    # all BF.* command impls
+    data_type.rs          # BLOOM_TYPE ("bloomfltr"), RDB load, version constants
+    utils.rs              # BloomObject, BloomFilter, BloomError, error strings, unit tests
   wrapper/
-    mod.rs                # must_obey_client() - version-aware check for replicated commands
-    bloom_callback.rs     # Unsafe extern "C" callbacks: RDB save/load, AOF rewrite, free, copy, defrag, digest
+    mod.rs                # must_obey_client - 8.0 vs 8.1+ feature-gated
+    bloom_callback.rs     # unsafe extern "C" callbacks: RDB save/load, AOF rewrite, free, copy, defrag, digest
   commands/
-    bf.add.json           # Command metadata for BF.ADD
-    bf.card.json          # Command metadata for BF.CARD
-    bf.exists.json        # Command metadata for BF.EXISTS
-    bf.info.json          # Command metadata for BF.INFO
-    bf.insert.json        # Command metadata for BF.INSERT
-    bf.load.json          # Command metadata for BF.LOAD (internal, used for AOF rewrite)
-    bf.madd.json          # Command metadata for BF.MADD
-    bf.mexists.json       # Command metadata for BF.MEXISTS
-    bf.reserve.json       # Command metadata for BF.RESERVE
+    bf.{add,card,exists,info,insert,load,madd,mexists,reserve}.json  # COMMAND DOCS metadata (9 files)
 ```
 
-## Module Registration
-
-The `valkey_module!` macro in `src/lib.rs` registers the module with Valkey:
+## Module registration
 
 ```rust
 valkey_module! {
-    name: MODULE_NAME,              // "bf"
-    version: MODULE_VERSION,        // 999999 (dev), set during release
+    name:     MODULE_NAME,        // "bf"
+    version:  MODULE_VERSION,     // 999999 on dev, rewritten at release
     allocator: (ValkeyAlloc, ValkeyAlloc),
-    data_types: [BLOOM_TYPE],       // "bloomfltr" from data_type.rs
-    init: initialize,
-    deinit: deinitialize,
-    acl_categories: ["bloom"]
-    commands: [ /* 9 commands */ ],
-    configurations: [ /* i64, string, bool, enum sections */ ],
+    data_types: [BLOOM_TYPE],     // "bloomfltr"
+    init:     initialize,
+    deinit:   deinitialize,
+    acl_categories: ["bloom"],
+    commands: [ /* 9 */ ],
+    configurations: [ /* i64 / string / bool sections + module_args_as_configuration: true */ ],
 }
 ```
 
-Also registered: `MODULE_RELEASE_STAGE` (a constant set to `"dev"` on unstable, changed to `"rc1"`...`"rcN"` and finally `"ga"` during release), and `module_args_as_configuration: true` which allows passing configs as module load arguments.
+`MODULE_RELEASE_STAGE` is also registered: `"dev"` on unstable, flipped through `"rc1"..`"rcN"`, finally `"ga"` at release.
 
-The `initialize` function runs on module load. It sets `HANDLE_IO_ERRORS` for graceful RDB error handling and validates the server version against `configs::BLOOM_MIN_SUPPORTED_VERSION` (8.0.0):
+### initialize
 
 ```rust
 fn initialize(ctx: &Context, _args: &[ValkeyString]) -> Status {
     ctx.set_module_options(ModuleOptions::HANDLE_IO_ERRORS);
     let ver = ctx.get_server_version().expect("Unable to get server version!");
-    if !valid_server_version(ver) {
-        // Log warning and return Err - minimum is 8.0.0
-        Status::Err
-    } else {
-        Status::Ok
-    }
+    if !valid_server_version(ver) { Status::Err } else { Status::Ok }
 }
 ```
 
-The `deinitialize` function is a no-op returning `Status::Ok`.
+`BLOOM_MIN_SUPPORTED_VERSION = &[8, 0, 0]`. `deinitialize` is a no-op.
 
-## Command Registration Pattern
+## Command registration pattern
 
-Each command is registered in the `commands` array of `valkey_module!` with this format:
+One entry per command:
 
 ```rust
 ["BF.ADD", bloom_add_command, "write fast deny-oom", 1, 1, 1, "fast write bloom"],
 ```
 
-The fields are: command name, handler function, flags, first key, last key, step, ACL categories.
+Fields: name, handler, flags, first-key, last-key, step, ACL categories.
 
-Command flags used in this module:
+Flags used: `write`, `readonly`, `fast`, `deny-oom`. **BF.LOAD is the only command without `fast`** - `"write deny-oom"` - since it deserializes an entire bloom.
 
-| Flag | Meaning |
-|------|---------|
-| `write` | Command modifies data |
-| `readonly` | Command only reads data |
-| `fast` | O(1) or O(log N) complexity |
-| `deny-oom` | Reject when server is over maxmemory |
-
-BF.LOAD uses `"write deny-oom"` without `fast` - the only command without the fast flag since it deserializes an entire bloom object.
-
-Each wrapper function in `lib.rs` is a thin dispatcher to `command_handler.rs`:
+Wrapper functions in `lib.rs` are thin dispatchers to `command_handler::`, using a `multi: bool` parameter for ADD/MADD and EXISTS/MEXISTS (one shared handler each):
 
 ```rust
-fn bloom_add_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
-    command_handler::bloom_filter_add_value(ctx, &args, false)
-}
-
-fn bloom_madd_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
-    command_handler::bloom_filter_add_value(ctx, &args, true)
-}
+fn bloom_add_command  (ctx, args) { command_handler::bloom_filter_add_value(ctx, &args, false) }
+fn bloom_madd_command (ctx, args) { command_handler::bloom_filter_add_value(ctx, &args, true)  }
 ```
 
-The `multi` boolean distinguishes single-item from multi-item variants. The same pattern applies to EXISTS/MEXISTS.
+`#[info_command_handler]` macro on `info_handler` registers the INFO section handler delegating to `metrics::bloom_info_handler`.
 
-An `#[info_command_handler]` macro on `info_handler` registers the custom INFO section handler that delegates to `metrics::bloom_info_handler`.
+## Command JSON metadata (`src/commands/bf.*.json`)
 
-## Command Metadata JSON
-
-Each command has a JSON file in `src/commands/` that describes its schema for `COMMAND DOCS`. Example from `bf.add.json`:
+One file per command, fed to `COMMAND DOCS`. Shape:
 
 ```json
 {
-    "BF.ADD": {
-        "summary": "Add a single item to a bloom filter...",
-        "complexity": "O(N), where N is the number of hash functions...",
-        "group": "bloom",
-        "module_since": "1.0.0",
-        "arity": 3,
-        "acl_categories": ["FAST", "WRITE", "BLOOM"],
-        "arguments": [
-            { "name": "key", "type": "key", "key_spec_index": 0 },
-            { "name": "value", "type": "string" }
-        ]
-    }
+  "BF.ADD": {
+    "summary":       "...",
+    "complexity":    "O(N), N = hash functions",
+    "group":         "bloom",
+    "module_since":  "1.0.0",
+    "arity":         3,
+    "acl_categories": ["FAST", "WRITE", "BLOOM"],
+    "arguments":     [ { "name": "key", "type": "key", "key_spec_index": 0 }, ... ]
+  }
 }
 ```
 
-**Key fields**:
+| Field | Use |
+|-------|-----|
+| `arity` | positive = fixed, negative = minimum (e.g. `-2` for variadic) |
+| `arguments[].optional: true` | keyword arg |
+| `arguments[].multiple: true` | repeatable |
 
-| Field | Description |
-|-------|-------------|
-| `summary` | One-line description shown in `COMMAND DOCS` |
-| `complexity` | Big-O complexity string |
-| `group` | Command group - always `"bloom"` |
-| `module_since` | Module version that introduced the command |
-| `arity` | Fixed arity (positive) or minimum arity (negative, e.g., `-2` for variadic) |
-| `acl_categories` | ACL categories for access control |
-| `arguments` | Array of argument descriptors with `name`, `type`, and optional `token`, `optional`, `multiple` |
+## ACL category
 
-For variadic commands like BF.INSERT, arguments with `"optional": true` denote keyword arguments, and `"multiple": true` indicates repeatable arguments.
+Custom category `"bloom"` registered via `acl_categories: ["bloom"]`. Every command includes it (e.g. `"fast write bloom"`). Grant via `ACL SETUSER <user> +@bloom` / `-@bloom`.
 
-## ACL Category
+## Error types
 
-The module registers a custom ACL category `"bloom"` in the `valkey_module!` macro:
-
-```rust
-acl_categories: ["bloom"]
-```
-
-All commands include `"bloom"` in their ACL categories string (e.g., `"fast write bloom"`). This allows operators to control access with `ACL SETUSER user +@bloom` or `-@bloom`. See `reference/commands/command-handlers.md` for the full command-to-flag mapping.
-
-## Module Configurations
-
-Configurations are registered in the `configurations` block of `valkey_module!`. Four types:
-
-**Integer configs** (`i64`):
-- `bloom-capacity` - default initial capacity (default: 100, range: 1 to i64::MAX)
-- `bloom-expansion` - default expansion factor (default: 2, range: 0 to u32::MAX). 0 means non-scaling
-- `bloom-memory-usage-limit` - max bytes per bloom object (default: 128MB, range: 0 to i64::MAX)
-
-**String configs** (stored as `ValkeyGILGuard<ValkeyString>`, parsed as `f64`):
-- `bloom-fp-rate` - default false positive rate (default: "0.01", range: exclusive (0, 1))
-- `bloom-tightening-ratio` - FP decay per scale-out (default: "0.5", range: exclusive (0, 1))
-
-String configs use a custom `on_string_config_set` handler in `configs.rs` that validates the range and updates a paired `Mutex<f64>` (`BLOOM_FP_RATE_F64`, `BLOOM_TIGHTENING_F64`) for fast access in command handlers.
-
-**Boolean configs**:
-- `bloom-use-random-seed` - use random vs fixed hash seed (default: true)
-- `bloom-defrag-enabled` - enable active defragmentation (default: true)
-
-All configs are runtime-modifiable via `CONFIG SET bf.<name> <value>` and readable via `CONFIG GET bf.<name>`. See `reference/commands/module-configs.md` for full config details.
-
-## Error Types and Handling
-
-Errors are defined in `src/bloom/utils.rs` as the `BloomError` enum:
+`BloomError` in `src/bloom/utils.rs`:
 
 ```rust
 pub enum BloomError {
-    NonScalingFilterFull,        // "ERR non scaling filter is full"
-    MaxNumScalingFilters,        // "ERR bloom object reached max number of filters"
-    ExceedsMaxBloomSize,         // "ERR operation exceeds bloom object memory limit"
-    EncodeBloomFilterFailed,     // "Failed to encode bloom object."
-    DecodeBloomFilterFailed,     // "ERR bloom object decoding failed"
-    DecodeUnsupportedVersion,    // "ERR bloom object decoding failed. Unsupported version"
-    ErrorRateRange,              // "ERR (0 < error rate range < 1)"
-    BadExpansion,                // "ERR bad expansion"
-    FalsePositiveReachesZero,    // "ERR false positive degrades to 0 on scale out"
-    BadCapacity,                 // "ERR bad capacity"
-    ValidateScaleToExceedsMaxSize,
-    ValidateScaleToFalsePositiveInvalid,
+    NonScalingFilterFull, MaxNumScalingFilters, ExceedsMaxBloomSize,
+    EncodeBloomFilterFailed, DecodeBloomFilterFailed, DecodeUnsupportedVersion,
+    ErrorRateRange, BadExpansion, FalsePositiveReachesZero, BadCapacity,
+    ValidateScaleToExceedsMaxSize, ValidateScaleToFalsePositiveInvalid,
 }
 ```
 
-Additional error string constants are defined at the top of `utils.rs` for argument validation: `NOT_FOUND`, `ITEM_EXISTS`, `INVALID_INFO_VALUE`, `INVALID_SEED`, `BAD_ERROR_RATE`, `BAD_TIGHTENING_RATIO`, `TIGHTENING_RATIO_RANGE`, `CAPACITY_LARGER_THAN_0`, `UNKNOWN_ARGUMENT`, `KEY_EXISTS`, and `NON_SCALING_AND_VALIDATE_SCALE_TO_IS_INVALID`.
+`as_str()` maps each to a `&'static str` (one of the `ERR ...` constants defined at the top of `utils.rs`: `NOT_FOUND`, `ITEM_EXISTS`, `INVALID_INFO_VALUE`, `INVALID_SEED`, `BAD_ERROR_RATE`, `BAD_TIGHTENING_RATIO`, `TIGHTENING_RATIO_RANGE`, `CAPACITY_LARGER_THAN_0`, `UNKNOWN_ARGUMENT`, `KEY_EXISTS`, `NON_SCALING_AND_VALIDATE_SCALE_TO_IS_INVALID`).
 
-Each variant maps to a static `&str` via `as_str()`. In command handlers, errors convert to `ValkeyError`:
+Translation to command returns:
 
 ```rust
-// For single-value returns:
-Err(ValkeyError::Str(utils::NOT_FOUND))
-
-// For multi-value returns (MADD, INSERT):
-result.push(ValkeyValue::StaticError(err.as_str()));
-
-// For arity errors:
+Err(ValkeyError::Str(utils::NOT_FOUND))            // single-value return
+result.push(ValkeyValue::StaticError(err.as_str())) // multi-value (MADD, INSERT)
 Err(ValkeyError::WrongArity)
-
-// For type mismatches:
 Err(ValkeyError::WrongType)
 ```
 
-The pattern: parse arguments with early returns on validation failure, open the key writable, check for type errors via `get_value::<BloomObject>(&BLOOM_TYPE)`, and proceed with the operation.
+Handler pattern: parse with early returns on validation failure -> `open_key_writable` / `open_key` -> `get_value::<BloomObject>(&BLOOM_TYPE)` (handles `WrongType`) -> operate -> replicate if mutative.
 
-## Replication Pattern
+## Replication (summary - full in `commands-replication.md`)
 
-Mutative commands use deterministic replication through `replicate_and_notify_events()` in `command_handler.rs`. See `reference/commands/replication.md` for full details.
+- Creation always replicates as a **synthetic BF.INSERT** with full properties (capacity, fp_rate, tightening_ratio, seed, expansion, items). SEED and TIGHTENING are replication-internal args.
+- Item addition on existing bloom: `ctx.replicate_verbatim()`.
+- Duplicate add (no new item): no replication.
+- `must_obey_client(ctx)` true (replica / AOF replay) -> size limit checks skipped.
+- Keyspace events: `bloom.reserve` on creation, `bloom.add` on any new-item insert. Both can fire in one call.
 
-**Bloom creation** is always replicated as `BF.INSERT` with exact properties from the primary (capacity, fp_rate, tightening_ratio, seed, expansion, items). This ensures the replica creates an identical bloom object regardless of its local config.
+## Adding a new command (checklist)
 
-**Item addition** to an existing bloom uses `ctx.replicate_verbatim()` - the original command is forwarded as-is.
-
-**No replication** occurs when an item already exists (add returns 0) since no state changed.
-
-The `must_obey_client` wrapper (in `src/wrapper/mod.rs`) detects replicated commands. On Valkey 8.1+, it uses `ValkeyModule_MustObeyClient`. On Valkey 8.0 (with `valkey_8_0` feature), it falls back to checking `ContextFlags::REPLICATED`. When a command is replicated, size limit validation is skipped to avoid rejecting data the primary already accepted.
-
-Keyspace notifications are published for both creation (`bloom.reserve`) and item addition (`bloom.add`) events.
-
-## Adding a New Command
-
-Step-by-step process for adding a hypothetical `BF.NEWCMD`:
-
-1. **Create command metadata** - add `src/commands/bf.newcmd.json`:
-   ```json
-   {
-       "BF.NEWCMD": {
-           "summary": "Description of the new command",
-           "complexity": "O(1)",
-           "group": "bloom",
-           "module_since": "1.1.0",
-           "arity": 3,
-           "acl_categories": ["FAST", "READ", "BLOOM"],
-           "arguments": [...]
-       }
-   }
-   ```
-
-2. **Implement the handler** - add a `pub fn bloom_filter_newcmd(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult` function in `src/bloom/command_handler.rs`. Follow the existing pattern: validate arity, parse arguments, open key, get typed value, perform operation, handle replication if mutative.
-
-3. **Add the wrapper** - in `src/lib.rs`, add a thin wrapper function:
-   ```rust
-   fn bloom_newcmd_command(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
-       command_handler::bloom_filter_newcmd(ctx, &args)
-   }
-   ```
-
-4. **Register the command** - add to the `commands` array in `valkey_module!`:
-   ```rust
-   ["BF.NEWCMD", bloom_newcmd_command, "readonly fast", 1, 1, 1, "fast read bloom"],
-   ```
-
-5. **Write tests** - add unit tests in `src/bloom/utils.rs` if the command involves new BloomObject logic. Add integration tests in a new or existing `tests/test_bloom_*.py` file.
-
-6. **Update test_basic** - add the new command name to the `bf_cmds` list in `test_bloom_basic.py::test_basic` so module loading validation includes it.
+1. `src/commands/bf.newcmd.json` - metadata with `summary`, `arity`, `acl_categories`, etc.
+2. Implement `pub fn bloom_filter_newcmd(ctx: &Context, input_args: &[ValkeyString]) -> ValkeyResult` in `src/bloom/command_handler.rs`. Follow the parse -> open -> type-check -> operate -> replicate pattern.
+3. Thin wrapper in `src/lib.rs`.
+4. Register in `valkey_module!` `commands` array with the right flags and ACL categories.
+5. Unit tests in `utils.rs`; integration tests in `tests/test_bloom_*.py`.
+6. Add the command name to the `bf_cmds` list in `test_bloom_basic.py::test_basic` (module-load sanity check).

--- a/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/contributing-testing.md
+++ b/skills/valkey-bloom-dev/skills/valkey-bloom-dev/reference/contributing-testing.md
@@ -1,24 +1,24 @@
 # Testing
 
-Use when writing or running unit tests, integration tests, understanding the test framework, or debugging test failures.
+Use when writing or running unit / integration tests, or understanding the seed parameterization pattern.
 
-Source: `src/bloom/utils.rs` (tests module), `tests/conftest.py`, `tests/valkey_bloom_test_case.py`, `tests/test_bloom_*.py`
+Source: `src/bloom/utils.rs` (`#[cfg(test)] mod tests`), `tests/conftest.py`, `tests/valkey_bloom_test_case.py`, `tests/test_bloom_*.py`.
 
-## Unit Tests Overview
+## Unit tests (Rust)
 
-Unit tests live in `src/bloom/utils.rs` inside a `#[cfg(test)] mod tests` block (approximately lines 722-1308). They test BloomObject and BloomFilter logic directly without a running Valkey server.
+Live in a `#[cfg(test)] mod tests` block in `src/bloom/utils.rs`. Exercise `BloomObject` / `BloomFilter` without a running server.
 
-Key test helpers defined in the unit test module:
+**Must run with `--features enable-system-alloc`** - ValkeyAlloc needs a running Valkey:
 
-- `random_prefix(len)` - generates a random alphanumeric string for unique item names
-- `add_items_till_capacity(bf, capacity, start_idx, prefix, expected_error)` - fills a bloom filter to a target capacity, tracking false positive count. Returns `(fp_count, last_idx)`
-- `check_items_exist(bf, start, end, expected, prefix)` - checks existence of items and counts mismatches. Returns `(error_count, num_operations)`
-- `fp_assert(error_count, num_ops, expected_fp_rate, margin)` - asserts that the actual false positive rate stays within the expected rate plus a margin
-- `verify_restored_items(original, restored, idx, fp_rate, margin, prefix)` - validates that a restored bloom object matches the original in properties, seed, bitmap, and item existence
+```bash
+cargo test --features enable-system-alloc
+cargo test --features enable-system-alloc test_scaling_filter
+cargo test --features enable-system-alloc -- --nocapture
+```
 
-## Parameterized Tests with rstest
+### rstest seed parameterization
 
-Most unit tests run twice - once with a random seed and once with a fixed seed - using the `rstest` crate:
+Most tests run twice (random + fixed seed) via `rstest`:
 
 ```rust
 #[rstest(
@@ -26,53 +26,28 @@ Most unit tests run twice - once with a random seed and once with a fixed seed -
     case::random_seed((None, true)),
     case::fixed_seed((Some(configs::FIXED_SEED), false))
 )]
-fn test_non_scaling_filter(seed: (Option<[u8; 32]>, bool)) {
-    // Test body runs for each case
-}
+fn test_non_scaling_filter(seed: (Option<[u8; 32]>, bool)) { ... }
 ```
 
-This pattern verifies that bloom filter behavior is correct regardless of seed mode. Tests parameterized this way:
+Parameterized tests (each runs twice): `test_non_scaling_filter`, `test_scaling_filter`.
 
-- `test_non_scaling_filter` - fills a non-scaling filter to capacity, validates FP rate, checks that adding beyond capacity returns `NonScalingFilterFull`, and verifies restore correctness
-- `test_scaling_filter` - scales through 5 filter expansions, validates capacity growth, FP rate, and restore correctness
+Non-parameterized (seed-irrelevant): `test_seed` (constant vs varying sip keys), `test_exceeded_size_limit`, `test_calculate_max_scaled_capacity` (rstest `#[case]`s for capacity/expansion/fp combos), `test_bf_encode_and_decode` (scaling vs non-scaling), `test_bf_decode_when_*_should_failed` (unsupported version / empty / oversized + invalid fp), `test_vec_capacity_matches_size_calculations`, `test_valid_server_version`.
 
-Non-parameterized tests:
+### Unit test helpers
 
-- `test_seed` - validates fixed seed produces constant sip keys, random seed produces varying keys
-- `test_exceeded_size_limit` - validates that allocations beyond the 128MB memory limit are rejected
-- `test_calculate_max_scaled_capacity` - parameterized with `#[rstest]` using `#[case]` attributes across 5 capacity/expansion/fp_rate combinations
-- `test_bf_encode_and_decode` - parameterized for scaling (expansion=2) and non-scaling (expansion=0)
-- `test_bf_decode_when_unsupported_version_should_failed` - corrupted version byte
-- `test_bf_decode_when_bytes_is_empty_should_failed` - empty input
-- `test_bf_decode_when_bytes_is_exceed_limit_should_failed` - oversized and invalid fp_rate
-- `test_vec_capacity_matches_size_calculations` - validates Vec capacity growth matches expectations
-- `test_valid_server_version` - validates version comparison logic against various Valkey versions
+Defined inside the test module:
 
-## Running Unit Tests
+- `random_prefix(len)` - unique item names
+- `add_items_till_capacity(bf, capacity, start_idx, prefix, expected_error)` -> `(fp_count, last_idx)`
+- `check_items_exist(bf, start, end, expected, prefix)` -> `(error_count, num_operations)`
+- `fp_assert(error_count, num_ops, expected_fp_rate, margin)`
+- `verify_restored_items(original, restored, idx, fp_rate, margin, prefix)` - validates restore round-trip (properties, seed, bitmap, item existence)
 
-```bash
-# Run all unit tests (system allocator required)
-cargo test --features enable-system-alloc
+## Integration tests (Python)
 
-# Run a specific test
-cargo test --features enable-system-alloc test_scaling_filter
+Pytest + `valkey-test-framework` (maintained in `valkey-io/valkey-test-framework`). `ValkeyTestCase` and `ReplicationTestCase` manage server lifecycle.
 
-# Run with output visible
-cargo test --features enable-system-alloc -- --nocapture
-```
-
-## Integration Test Framework
-
-Integration tests use Python's pytest with the `valkey-test-framework` - a framework maintained in `valkey-io/valkey-test-framework`. The framework provides `ValkeyTestCase` and `ReplicationTestCase` base classes that manage Valkey server lifecycle.
-
-Setup (handled by `build.sh` or CI):
-
-1. Build the module as a release `.so`/`.dylib`
-2. Clone and compile valkey-server for the target version
-3. Clone valkey-test-framework into `tests/build/valkeytestframework/`
-4. Install Python requirements (`pip install -r requirements.txt` - installs `valkey` and `pytest==7.4.3`)
-
-The `conftest.py` file adds `tests/build/` and `tests/build/valkeytestframework/` to `sys.path` and configures a pytest fixture that parameterizes all tests with `random-seed` and `fixed-seed` modes:
+`conftest.py` adds `tests/build/` and `tests/build/valkeytestframework/` to `sys.path` and defines the autouse parameterization:
 
 ```python
 @pytest.fixture(params=['random-seed', 'fixed-seed'])
@@ -80,99 +55,62 @@ def bloom_config_parameterization(request):
     return request.param
 ```
 
-Every integration test automatically runs twice - once with `bf.bloom-use-random-seed yes` and once with `no`.
+Every integration test runs twice - random-seed and fixed-seed - mirroring the unit tests.
 
-## Test Base Class Helpers
+### Base class helpers (`ValkeyBloomTestCaseBase` in `tests/valkey_bloom_test_case.py`)
 
-`ValkeyBloomTestCaseBase` (in `tests/valkey_bloom_test_case.py`) extends `ValkeyTestCase` with bloom-specific utilities:
+Extends `ValkeyTestCase`. Key fixtures: `setup_test` (starts Valkey + loads module + `enable-debug-command`; also supports external server via `VALKEY_EXTERNAL_SERVER=true` + `VALKEY_HOST`/`VALKEY_PORT`), `use_random_seed_fixture` (sets `use_random_seed` from the parameterization).
 
-**Server management**:
-- `setup_test` fixture - starts a Valkey server with the bloom module loaded and `enable-debug-command` enabled. Also supports external server mode via `VALKEY_EXTERNAL_SERVER=true` with `VALKEY_HOST` and `VALKEY_PORT` environment variables
-- `use_random_seed_fixture` - sets `use_random_seed` config based on the parameterization fixture
+Notable helpers:
 
-**Assertion helpers**:
-- `verify_error_response(client, cmd, expected_err)` - executes a command expecting a `ResponseError`, asserts the message matches
-- `verify_command_success_reply(client, cmd, expected)` - executes a command and asserts the result matches. For BF.M* and BF.INSERT commands, checks result length instead of exact values to avoid FP-related flakiness
-- `verify_bloom_filter_item_existence(client, key, value, should_exist)` - checks BF.EXISTS returns expected 0 or 1
-- `verify_server_key_count(client, expected)` - asserts DBSIZE matches
+- `verify_error_response`, `verify_command_success_reply`, `verify_bloom_filter_item_existence`, `verify_server_key_count`
+- `create_bloom_filters_and_add_items`, `add_items_till_capacity` (via MADD batches), `add_items_till_nonscaling_failure`, `check_items_exist` (MEXISTS batches), `fp_assert`
+- `validate_nonscaling_failure` - asserts BF.ADD, BF.MADD, BF.INSERT all return the expected error; multi-item commands stop at first error (2 result elements)
+- `validate_copied_bloom_correctness` - uses `DEBUG DIGEST-VALUE` to confirm COPY produces identical objects
+- `verify_bloom_metrics`, `parse_valkey_info`, `restart_external_server`
 
-**Bloom operation helpers**:
-- `create_bloom_filters_and_add_items(client, number_of_bf=5)` - creates N bloom filters named SAMPLE0..N-1 with one item each
-- `add_items_till_capacity(client, filter, capacity, start_idx, prefix, batch_size=1000)` - adds items via BF.MADD in batches until target capacity. Returns `(fp_count, last_idx)`
-- `add_items_till_nonscaling_failure(client, filter, start_idx, prefix)` - adds items until "non scaling filter is full" error. Returns the failing index
-- `check_items_exist(client, filter, start, end, expected, prefix, batch_size=1000)` - checks items via BF.MEXISTS in batches. Returns `(error_count, num_operations)`
-- `fp_assert(error_count, num_ops, expected_fp_rate, margin)` - asserts actual FP rate stays within bounds
-- `validate_nonscaling_failure(client, filter, prefix, idx)` - validates BF.ADD, BF.MADD, and BF.INSERT all return the expected error. Multi-item commands stop at the first error and return 2 elements
-- `validate_copied_bloom_correctness(client, filter, prefix, idx, fp_rate, margin, info_dict)` - validates COPY produces identical bloom objects using DEBUG DIGEST-VALUE comparison
-- `calculate_expected_capacity(initial, expansion, num_filters)` - computes total capacity across scaled filters
-- `generate_random_string(length=7)` - creates a random alphanumeric string
-
-**Metrics helpers**:
-- `verify_bloom_metrics(info, memory, objects, filters, items, capacity)` - parses INFO output and validates bloom metric values by prefix-matching metric names
-- `parse_valkey_info(section)` - parses an INFO command response into a Python dict
-- `restart_external_server(server, ...)` - restarts external Docker-based servers by finding the container by port
-
-## Test Parameterization
-
-Every test class that inherits from `ValkeyBloomTestCaseBase` automatically runs each test method twice (random-seed and fixed-seed) via the `bloom_config_parameterization` fixture from `conftest.py`.
-
-Replication tests inherit from `ReplicationTestCase` (from the test framework) and set up their own `use_random_seed_fixture` to achieve the same parameterization.
-
-Some tests are marked with `@pytest.mark.skip_for_asan` to exclude them from ASAN builds. Currently only `TestBloomDefrag` uses this marker because `activedefrag` cannot be enabled on ASAN server builds.
-
-## Test File Inventory
+### Test files
 
 | File | Tests | Coverage |
 |------|-------|----------|
-| `test_bloom_basic.py` | 17 | Core operations, COPY, MEMORY USAGE, too-large objects, maxmemory (above/below), module data type, object access, transactions, Lua, DEL/UNLINK/FLUSHALL, TTL, DEBUG, wrong type errors, config set (string/default), DUMP/RESTORE |
-| `test_bloom_command.py` | 3 | Command arity validation, error responses for all commands, behavioral edge cases |
-| `test_bloom_correctness.py` | 3 | FP rate validation for scaling and non-scaling filters, correctness after COPY |
-| `test_bloom_replication.py` | 2 | Replication behavior (write/read/delete/error commands), deterministic replication with non-default configs |
-| `test_bloom_save_and_restore.py` | 4 | RDB save/restore (basic, many filters), restore-failed for oversized bloom, non-bloom RDB compatibility |
-| `test_bloom_aofrewrite.py` | 2 | AOF rewrite for scaling and non-scaling filters, correctness after reload |
-| `test_bloom_metrics.py` | 4 | Basic command metrics, scaled bloomfilter metrics, copy metrics, save-and-restore metrics |
-| `test_bloom_keyspace.py` | 1 | Keyspace notifications for bloom.add and bloom.reserve events |
-| `test_bloom_acl_category.py` | 2 | ACL category "bloom" enforcement, allowed/denied command lists |
-| `test_bloom_defrag.py` | 1 | Active defragmentation hits/misses metrics (parametrized with capacity 1 and 200, marked skip_for_asan) |
-| `test_bloom_valkeypy_compatibility.py` | 5 | valkey-py client compatibility for BF.RESERVE, BF.ADD, BF.MADD, BF.EXISTS, BF.MEXISTS, BF.INFO, BF.INSERT, BF.CARD |
+| `test_bloom_basic.py` | 17 | core ops, COPY, MEMORY USAGE, maxmemory, type, transactions, Lua, DEL/UNLINK/FLUSHALL, TTL, DEBUG, wrong-type, CONFIG SET, DUMP/RESTORE |
+| `test_bloom_command.py` | 3 | arity and error responses across commands |
+| `test_bloom_correctness.py` | 3 | FP rate (scaling / non-scaling), correctness after COPY |
+| `test_bloom_replication.py` | 2 | write / read / delete / error + deterministic replication with non-default configs |
+| `test_bloom_save_and_restore.py` | 4 | RDB (basic, many filters), oversized bloom failure, non-bloom RDB compat |
+| `test_bloom_aofrewrite.py` | 2 | AOF rewrite (scaling + non-scaling), correctness after reload |
+| `test_bloom_metrics.py` | 4 | basic / scaled / copy / save-restore metrics |
+| `test_bloom_keyspace.py` | 1 | `bloom.add` / `bloom.reserve` events |
+| `test_bloom_acl_category.py` | 2 | `bloom` ACL category allow / deny |
+| `test_bloom_defrag.py` | 1 | defrag hits / misses, parameterized on capacity; **marked `skip_for_asan`** |
+| `test_bloom_valkeypy_compatibility.py` | 5 | valkey-py compatibility across BF.* |
 
-Total: 11 test files, 44 test methods, ~1782 lines of test code (excluding base class). Each test runs twice (random-seed and fixed-seed), so a full run executes 88 test instances per server version.
+11 files, 44 methods, ~1782 lines. Doubled by seed parameterization -> 88 instances per server version.
 
-## Running Integration Tests
+### ASAN
+
+`@pytest.mark.skip_for_asan(reason=...)` excludes tests under CI's `-m "not skip_for_asan"`. Only `TestBloomDefrag` uses it currently (`activedefrag` can't run under ASAN builds).
+
+### Running integration tests
 
 ```bash
-# Full suite via build.sh
+# Full suite (build.sh handles setup)
 export SERVER_VERSION=unstable
 ./build.sh
 
-# Manual pytest (after build.sh has set up server and framework)
+# Manual (after setup done)
 export MODULE_PATH=$(pwd)/target/release/libvalkey_bloom.so
 python3 -m pytest --cache-clear -v tests/
+python3 -m pytest -v tests/ -k "test_deterministic"
 
-# Run specific test file
-python3 -m pytest --cache-clear -v tests/test_bloom_replication.py
-
-# Run specific test by name pattern
-python3 -m pytest --cache-clear -v tests/ -k "test_deterministic"
-
-# With ASAN leak detection (via build.sh)
-export ASAN_BUILD=1
-export SERVER_VERSION=unstable
-./build.sh
-
-# Against an external server (e.g., Docker)
-export VALKEY_EXTERNAL_SERVER=true
-export VALKEY_HOST=localhost
-export VALKEY_PORT=6379
-python3 -m pytest --cache-clear -v tests/
+# External server (e.g. Docker)
+export VALKEY_EXTERNAL_SERVER=true VALKEY_HOST=localhost VALKEY_PORT=6379
+python3 -m pytest -v tests/
 ```
 
-## Writing New Tests
+## Writing new tests
 
-1. Create a new test class inheriting from `ValkeyBloomTestCaseBase` (or `ReplicationTestCase` for replication tests)
-2. The `setup_test` and `use_random_seed_fixture` fixtures are `autouse=True` - they run automatically
-3. Use `self.client` for the primary connection and `self.server` for server operations
-4. Use the batch helpers (`add_items_till_capacity`, `check_items_exist`) for correctness tests to keep tests fast
-5. Use `self.verify_error_response` for testing error paths
-6. For replication tests, call `self.setup_replication(num_replicas=1)` in the test method, then use `self.replicas[0].client` for replica operations
-7. If the test is incompatible with ASAN builds, mark the class with `@pytest.mark.skip_for_asan(reason="...")`
+1. Extend `ValkeyBloomTestCaseBase` (or `ReplicationTestCase`). Both autouse fixtures handle server + seed mode.
+2. Use batch helpers (`add_items_till_capacity`, `check_items_exist`) to keep runtime down.
+3. Replication: call `self.setup_replication(num_replicas=1)` inside the test; replica client via `self.replicas[0].client`.
+4. ASAN-incompatible -> `@pytest.mark.skip_for_asan(reason="...")`.


### PR DESCRIPTION
## Summary

- Per-file trim: 2244 -> 1219 lines (46% reduction across 12 reference files), all 79-146 lines each.
- Stripped all line-number citations (skill-writing-rules violation - they decay on every edit).
- Removed "Contents" TOCs at the top of every file.
- Cut Rust/Cargo baseline content that agents already know.
- Kept all Valkey-bloom-specific divergence and gotchas.

## Phase 4 validation (against `valkey-bloom` tag `1.0.1`)

Spot-checked in source, all verified:

- Config constants: `BLOOM_CAPACITY_DEFAULT=100`, `BLOOM_EXPANSION_DEFAULT=2`, `BLOOM_FP_RATE_DEFAULT="0.01"`, `TIGHTENING_RATIO_DEFAULT="0.5"`, `BLOOM_MEMORY_LIMIT_PER_OBJECT_DEFAULT=128 MB`, `BLOOM_USE_RANDOM_SEED_DEFAULT=true`, `BLOOM_DEFRAG_DEFAULT=true`.
- Module identity: `MODULE_NAME="bf"`, data type `"bloomfltr"`, `MODULE_VERSION=10001` at 1.0.1 (placeholder `999999` on unstable).
- Version distinction: `BLOOM_OBJECT_VERSION: u8 = 1` (bincode prefix) vs `BLOOM_TYPE_ENCODING_VERSION: i32 = 1` (RDB encver).
- Constants: `FIXED_SEED: [u8; 32]` exact bytes, `BLOOM_NUM_FILTERS_PER_OBJECT_LIMIT_MAX = i32::MAX`, `BLOOM_MIN_SUPPORTED_VERSION = &[8,0,0]`.
- Command flags: BF.LOAD uniquely `"write deny-oom"` (no `fast`).
- `must_obey_client` feature-gated: 8.0 uses `ContextFlags::REPLICATED`, 8.1+ uses `ValkeyModule_MustObeyClient`.
- Vec-defrag counter bug confirmed: step 4 of defrag increments `BLOOM_DEFRAG_HITS` in both branches (else branch should be `BLOOM_DEFRAG_MISSES`).
- RDB per-filter layout: `num_items` written only for the last filter (via `filter_list_iter.peek().is_none()`).

## Test plan

- [ ] Skill structure still has all 12 reference files.
- [ ] SKILL.md router table matches reference/ contents.
- [ ] No line-number citations remain in reference/*.md.
- [ ] Grep hazards section present in SKILL.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (no module/runtime code). Risk is limited to potential reviewer/agent confusion if any behavioral detail is misstated.
> 
> **Overview**
> Refreshes the `valkey-bloom-dev` skill docs, **bumping the skill version to `2.0.0`** and rewriting `SKILL.md` into a compact router + quick-start + "critical rules"/"grep hazards" sections aligned to valkey-bloom `1.0.1` (module name `bf`, persistence/replication gotchas, config defaults).
> 
> Across the reference markdown files, removes line-number citations/TOCs and aggressively trims/reshapes content into shorter, task-oriented pages while keeping the module-specific details for scaling, persistence (RDB/AOF + bincode versions), defrag/metrics, command parsing/replication behavior, configs, and build/CI/testing workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c55ccfed781719f464593da214e353e259d2672. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->