### PR TITLE
valkey-search-dev: trim rule violations, validate against 1.2.0

### DIFF
--- a/skills/valkey-search-dev/skills/valkey-search-dev/SKILL.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/SKILL.md
@@ -1,113 +1,87 @@
 ---
 name: valkey-search-dev
-description: "Use when contributing to valkey-io/valkey-search - C++ internals, HNSW/FLAT vector indexes, full-text/numeric/tag indexes, query engine, cluster coordinator, build. Not for FT.SEARCH in apps (valkey) or Valkey server internals (valkey-dev)."
-version: 1.0.0
+description: "Use when contributing to valkey-io/valkey-search source - C++20 module internals, HNSW/FLAT/numeric/tag/text indexes, query engine, cluster coordinator, VMSDK, build. Not for FT.SEARCH in apps (valkey) or Valkey server internals (valkey-dev)."
+version: 2.0.0
 argument-hint: "[subsystem or source file]"
 ---
 
-# Valkey Search Module - Contributor Reference
+# valkey-search contributor reference
 
-## Routing
+Targets valkey-search 1.2.0. Module registers as `"search"`; minimum Valkey server 9.0.1. C++20, ships as `libsearch.{so,dylib}`.
 
-- HNSW graph, ef_construction, ef_runtime, M parameter, ANN search -> Indexes (hnsw)
-- FLAT index, brute-force, exact KNN, block-size growth -> Indexes (flat)
-- Numeric range queries, BTreeNumeric, SegmentTree, EntriesFetcher -> Indexes (numeric)
-- Tag filtering, PatriciaTree, separator, prefix wildcard, case sensitivity -> Indexes (tag)
-- Full-text search, Rax trees, postings, stemming, proximity, phrase, fuzzy -> Indexes (text)
-- Module loading, ValkeySearch singleton, VMSDK, startup sequence -> Architecture (module-overview)
-- IndexSchema class, attributes, keyspace mutations, backfill, sequence numbers -> Architecture (index-schema)
-- SchemaManager, index CRUD, staging, FlushDB/SwapDB, RDB load -> Architecture (schema-manager)
-- Thread pools, TimeSlicedMRMWMutex, fork suspension, concurrency -> Architecture (thread-model)
-- Filter expressions, predicate AST, QueryOperations bitmask, safety limits -> Query (parsing)
-- Prefilter vs inline filtering, async dispatch, content resolution -> Query (execution)
-- FT.SEARCH handler, RETURN/LIMIT/SORTBY, response serialization -> Query (ft-search)
-- FT.AGGREGATE pipeline, GROUPBY/REDUCE, APPLY, expression engine -> Query (ft-aggregate)
-- gRPC coordinator, cluster topology, metadata sync, fingerprinting -> Cluster (coordinator)
-- RDB protobuf format, SafeRDB, FT.INTERNAL_UPDATE, replication staging -> Cluster (replication)
-- FT.INFO fanout, FT._DEBUG subcommands, metrics counters, latency samplers -> Cluster (metrics)
-- Building from source, CMake, Ninja, build.sh, dependencies -> Build (build)
-- Unit tests, integration tests, pytest, GoogleTest, stability tests -> Build (testing)
-- CI workflows, Docker CI, pre-built debs, debugging CI failures -> Build (ci-pipeline)
-- Directory layout, IndexBase hierarchy, adding features, VMSDK -> Build (code-structure)
-- Query engine overview, hybrid search, pre-filter architecture -> Query (execution)
-- Cluster-mode search, shard fanout, coordinator port -> Cluster (coordinator)
-- Adding new index types, RDB callbacks, command registration -> Build (code-structure)
-- Performance, contention checking, writer suspension, cron jobs -> Architecture (thread-model)
-- Vector similarity, VectorBase, embedding storage, distance metrics -> Indexes (hnsw)
-- Schema mutations, replication staging protocol, chunk streaming -> Cluster (replication)
-- Observability, adding metrics, latency sampling -> Cluster (metrics)
-- Expression engine, Record types, RecordSet, reducers -> Query (ft-aggregate)
-- Index architecture overview, shard design -> Architecture (module-overview)
-- Build with sanitizers, ASAN, TSAN, Valgrind -> Build (build)
+## Not this skill
 
-## Quick Start
+- Apps using FT.SEARCH / FT.AGGREGATE -> `valkey`.
+- Valkey server internals -> `valkey-dev`.
 
-    # Build
-    ./build.sh --configure
+## Route by work area
 
-    # Run all tests
-    ./build.sh --run-tests
+| Working on... | File |
+|---------------|------|
+| Module loading, `ValkeySearch` singleton, thread pools, VMSDK overview, command table, configs, INFO sections | `reference/architecture-module-overview.md` |
+| `IndexSchema` per-index state, attribute map, keyspace notifications, mutation pipeline, sequence numbers, backfill, `TimeSlicedMRMWMutex` quotas | `reference/architecture-index-schema.md` |
+| `SchemaManager` registry, CRUD, replication staging, FlushDB / SwapDB, RDB save/load, fingerprinting | `reference/architecture-schema-manager.md` |
+| Thread contexts, pool suspension across fork, writer resume policy, `TimeSlicedMRMWMutex`, `MainThreadAccessGuard`, thread-safety annotations | `reference/architecture-thread-model.md` |
+| HNSW graph index, `VectorHNSW`, hnswlib, M / ef_construction / ef_runtime, resize, inline filter, `PrefilterEvaluator`, mark-delete + re-add | `reference/indexes-hnsw.md` |
+| FLAT brute-force index, `VectorFlat`, in-place modify, physical remove, block-size growth | `reference/indexes-flat.md` |
+| Numeric index, BTree + SegmentTree, range queries, negated ranges, tracked vs untracked | `reference/indexes-numeric.md` |
+| Tag index, `PatriciaTree`, separator / case sensitivity, wildcard prefix, negated queries | `reference/indexes-tag.md` |
+| Full-text, `TextIndexSchema` vs `Text`, Rax prefix / optional suffix / stem trees, postings, proximity / phrase, lexer, fuzzy, per-word bucket locks | `reference/indexes-text.md` |
+| `FilterParser`, predicate AST, `TextPredicate` variants, `ComposedPredicate`, `Evaluator`, `QueryOperations` bitmask, safety limits | `reference/query-parsing.md` |
+| Search execution, prefilter vs inline (planner), async dispatch, content resolution, contention check, result trimming | `reference/query-execution.md` |
+| FT.SEARCH handler, parameter table, PARAMS substitution, response shape, SORTBY | `reference/query-ft-search.md` |
+| FT.AGGREGATE pipeline, GROUPBY / REDUCE / APPLY / SORTBY / LIMIT / FILTER, reducers, expression engine, `Record` / `RecordSet` | `reference/query-ft-aggregate.md` |
+| gRPC coordinator, service RPCs, port offset, client pool, `MetadataManager`, HighwayHash fingerprinting, cluster-bus broadcast, reconciliation, suspension guard | `reference/cluster-coordinator.md` |
+| RDB protobuf format, `SafeRDB`, iterator discipline, chunk streams for vectors, module type registration, `FT.INTERNAL_UPDATE`, replication staging | `reference/cluster-replication.md` |
+| `Metrics` singleton, counter groups, latency samplers, RDB restore progress, FT.INFO scopes + fanout, FT._DEBUG subcommands, pausepoints | `reference/cluster-metrics.md` |
+| CMake + `build.sh`, submodules, third-party, VMSDK layer, sanitizer builds, platform notes, troubleshooting | `reference/contributing-build.md` |
+| Unit tests (7 GoogleTest binaries), Python integration, stability / memtier, test infra, adding tests | `reference/contributing-testing.md` |
+| CI workflows (11), Docker build, pre-built `.deb` deps, clang-format gate, artifact upload, local CI repro | `reference/contributing-ci-pipeline.md` |
+| Directory layout, `IndexBase` interface, how to add an index type, command registration, VMSDK abstractions, key singletons, proto files | `reference/contributing-code-structure.md` |
 
-    # Run a single test suite
-    ./build.sh --run-tests=vector_test
+## Critical rules
 
-    # Load the module
-    valkey-server --loadmodule .build-release/libsearch.so
+1. **C++20 only** - GCC 12+ or Clang 16+.
+2. **Never call `ValkeyModule_*` directly.** Use the VMSDK wrapper layer.
+3. **`TimeSlicedMRMWMutex` for index-data access.** Reader/writer phases with 10:1 quota (10 ms read, 1 ms write). Writers yield to readers.
+4. **Fork discipline**: writer pool is suspended across fork (COW dirty-page control). Reader + utility resume immediately; writer resumes on `SUBEVENT_FORK_CHILD_DIED` or `max-worker-suspension-secs` timeout (default 60 s).
+5. **Protobuf RDB format.** Index metadata is proto-serialized; vectors stream as supplemental chunks via `RDBChunkInputStream` / `RDBChunkOutputStream` with `SafeRDB`.
+6. **gRPC coordinator for cluster fanout.** Port = `valkey_port + 20294` (special-cased for 6378 TLS). Never bypass the coordinator protocol.
+7. **`MainThreadAccessGuard<T>`** - wraps data that must only touch the main thread (`db_key_info_`, `backfill_job_`, `staged_db_to_index_schemas_`, etc.). Debug-asserts on misuse.
 
-    # Build with sanitizers
-    ./build.sh --configure --asan
-    ./build.sh --configure --tsan
+## Grep hazards
 
-## Critical Rules
+- **Module name is `"search"`, data type (dummy for aux RDB) is `"Vk-Search"`** (9 chars, Valkey max). `MODULE_RELEASE_STAGE` rotates `"dev"` -> `"rcN"` -> `"ga"` at release.
+- **`kCoordinatorPortOffset = 20294`** - default port 6379 yields 26673 ("COORD" on phone keypad). TLS port 6378 adds an extra +1 to avoid collision.
+- **Writer pool is suspended during fork, not reader/utility.** Don't reverse this. Copy-on-write dirty pages for vector mutations are the reason.
+- **`TextIndexSchema` (shared) vs `Text` (per-field)**. Full-text is inherently cross-field: one Rax tree indexes words from all text fields; field masks distinguish which fields. Max 64 text fields (`kMaxTextFieldsCount`), mask is `uint64_t`.
+- **`BTreeNumeric` + `SegmentTree` are kept in sync on every mutation.** Both updated per Add/Remove. SegmentTree is O(log n) range counting overlay. Don't update one without the other.
+- **Vec-defrag bug is in valkey-bloom, NOT here.** Don't transfer that grep pattern.
+- **`RDBSectionIter` / `SupplementalContentIter` / `SupplementalContentChunkIter` are move-only with strict consumption assertions.** Unknown section types must drain supplementals or the destructor fires an assertion.
+- **`FieldMask` struct is 16 bytes (enforced by `static_assert`).** `FieldMaskPredicate` is a `uint64_t` alias. These are distinct types.
+- **`shouldEmbedStringObject` / `embed-string-threshold` don't apply here** - those are Valkey server internals, not this module.
+- **`cancel::Token` is cooperative.** HNSW walks and fetcher iteration poll it; `CancelCondition` wraps it for `hnswlib::BaseCancellationFunctor`. `enable_partial_results=true` returns partial on cancel vs `CancelledError`.
+- **FLAT does physical removal (`removePoint`); HNSW only tombstones (`markDelete`).** Consequence: HNSW modify = mark-delete + re-add with `allow_replace_deleted_`; FLAT modify = in-place `memcpy` on hnswlib internals.
+- **`SearchIndexPartition` vs `InfoIndexPartition`** - both gRPC RPCs carry `IndexFingerprintVersion` for consistency. Don't confuse the response shapes.
+- **`FT.INTERNAL_UPDATE`** is cluster-internal, not user-facing. `skip-corrupted-internal-update-entries` config controls AOF-load behavior on parse failure.
+- **Stem tree expansion is gated by `stem_text_field_mask_`.** Only fields with stemming enabled get expanded variants.
+- **`kHashKey` for HighwayHash is a fixed 4x64-bit constant** in both `MetadataManager` and `SchemaManager` fingerprinting (same key, different usage levels).
+- **`FT._DEBUG` is gated by `vmsdk::config::IsDebugModeEnabled()`.** Off -> replies "ERR unknown command" (appears non-existent). On -> all args logged at WARNING.
+- **Pausepoints**: `vmsdk::debug::PausePoint("label")`. Never on main thread or while holding locks - tests block/release background threads. Not replicated.
 
-1. **C++17 codebase** - uses std::variant, std::optional, structured bindings throughout
-2. **VMSDK abstraction** - never call ValkeyModule_* directly; use the VMSDK wrapper layer
-3. **TimeSlicedMRMWMutex** - all index mutations must hold the correct lock; background threads yield to fork
-4. **Protobuf RDB format** - index metadata serializes via protobuf, not raw binary; see SafeRDB for backward compat
-5. **Tests are non-negotiable** - unit tests (GoogleTest) for internals, pytest integration tests for commands
-6. **gRPC coordinator** - cluster mode uses gRPC for metadata sync; never bypass the coordinator protocol
+## Quick-start
 
-## Architecture
+```bash
+./build.sh --configure                            # CMake + build (auto-detects)
+./build.sh --run-tests                            # all unit tests
+./build.sh --run-tests=vector_test                # one suite
+./build.sh --run-integration-tests                # Python integration
+./build.sh --configure --asan                     # AddressSanitizer
+./build.sh --configure --tsan                     # ThreadSanitizer
+./build.sh --format                               # clang-format
+valkey-server --loadmodule .build-release/libsearch.so
+```
 
-| Topic | Reference |
-|-------|-----------|
-| Module loading, ValkeySearch singleton, VMSDK, thread pools, config | [module-overview](reference/architecture-module-overview.md) |
-| IndexSchema class, attribute map, keyspace mutations, backfill | [index-schema](reference/architecture-index-schema.md) |
-| SchemaManager singleton, index CRUD, replication staging, RDB | [schema-manager](reference/architecture-schema-manager.md) |
-| Thread pools, TimeSlicedMRMWMutex, fork suspension, concurrency | [thread-model](reference/architecture-thread-model.md) |
+Commands: FT.CREATE, FT.DROPINDEX, FT.INFO, FT._LIST, FT.SEARCH, FT.AGGREGATE, FT._DEBUG, FT.INTERNAL_UPDATE.
 
-## Index Types
-
-| Topic | Reference |
-|-------|-----------|
-| HNSW graph index, VectorHNSW, hnswlib, ef/M params, inline filtering | [hnsw](reference/indexes-hnsw.md) |
-| FLAT brute-force index, VectorFlat, block-size growth, exact KNN | [flat](reference/indexes-flat.md) |
-| Numeric index, BTreeNumeric, SegmentTree overlay, range queries | [numeric](reference/indexes-numeric.md) |
-| Tag index, PatriciaTree storage, separator, prefix wildcard matching | [tag](reference/indexes-tag.md) |
-| Full-text search, Rax prefix/suffix trees, postings, stemming, fuzzy | [text](reference/indexes-text.md) |
-
-## Query Engine
-
-| Topic | Reference |
-|-------|-----------|
-| Filter expression parser, predicate AST, QueryOperations, safety limits | [parsing](reference/query-parsing.md) |
-| Search execution, prefilter vs inline, async dispatch, content resolution | [execution](reference/query-execution.md) |
-| FT.SEARCH handler, parameter parsing, RETURN/LIMIT/SORTBY, response format | [ft-search](reference/query-ft-search.md) |
-| FT.AGGREGATE pipeline, GROUPBY/REDUCE, APPLY, expression engine, Records | [ft-aggregate](reference/query-ft-aggregate.md) |
-
-## Cluster and Replication
-
-| Topic | Reference |
-|-------|-----------|
-| gRPC coordinator, cluster topology, MetadataManager, reconciliation | [coordinator](reference/cluster-coordinator.md) |
-| RDB protobuf format, SafeRDB, FT.INTERNAL_UPDATE, replication staging | [replication](reference/cluster-replication.md) |
-| FT.INFO fanout, FT._DEBUG subcommands, Metrics singleton, latency samplers | [metrics](reference/cluster-metrics.md) |
-
-## Build and Contributing
-
-| Topic | Reference |
-|-------|-----------|
-| CMake build system, Ninja, dependencies, build.sh options, sanitizers | [build](reference/contributing-build.md) |
-| Unit tests (GoogleTest), integration tests (pytest), stability tests | [testing](reference/contributing-testing.md) |
-| CI workflows, Docker-based CI, pre-built debs, debugging CI failures | [ci-pipeline](reference/contributing-ci-pipeline.md) |
-| Directory layout, IndexBase hierarchy, adding features, VMSDK layer | [code-structure](reference/contributing-code-structure.md) |
+Core configs: `reader-threads`, `writer-threads`, `utility-threads`, `hnsw-block-size`, `max-indexes`, `backfill-batch-size`, `use-coordinator` (startup-only), `prefiltering-threshold-ratio`, `max-term-expansions`, `tag-min-prefix-length`, `max-worker-suspension-secs`.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-index-schema.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-index-schema.md
@@ -122,7 +122,7 @@ struct BackfillJob {
     vmsdk::StopWatch stopwatch;
     bool paused_by_oom{false};
     bool IsScanDone() const { return scan_ctx.get() == nullptr; }
-    void MarkScanAsDone()   { scan_ctx.reset(); cursor.reset(); }
+    void MarkScanAsDone() { scan_ctx.reset(); cursor.reset(); }
 };
 ```
 
@@ -141,12 +141,12 @@ Reported progress: `GetBackfillPercent() = (scanned - in_queue) / db_size`. `bac
 
 Time-slices between read and write phases. Asymmetric quotas prioritize query latency over mutation throughput (10:1 read vs write).
 
-| Parameter | Value |
-|-----------|-------|
-| `read_quota_duration` | 10 ms |
-| `read_switch_grace_period` | 1 ms |
-| `write_quota_duration` | 1 ms |
-| `write_switch_grace_period` | 200 us |
+| Parameter | Value | Effect |
+|-----------|-------|--------|
+| `read_quota_duration` | 10 ms | max read phase when writers are waiting |
+| `read_switch_grace_period` | 1 ms | read inactivity before switching to write |
+| `write_quota_duration` | 1 ms | max write phase when readers are waiting |
+| `write_switch_grace_period` | 200 us | write inactivity before switching to read |
 
 Queries take `ReaderMutexLock`. Writers take `WriterMutexLock`. Multiple concurrent readers or multiple concurrent writers (on different keys) are allowed; `mutated_records_mutex_` arbitrates writers on the same key.
 

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-index-schema.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-index-schema.md
@@ -1,173 +1,117 @@
-# IndexSchema Class
+# IndexSchema
 
-Use when understanding per-index state, attribute management, keyspace mutation processing, backfill, or the mutation sequence number system.
+Use when reasoning about per-index state, attribute management, keyspace mutation processing, backfill, or mutation sequence numbers.
 
-Source: `src/index_schema.h`, `src/index_schema.cc`
+Source: `src/index_schema.{h,cc}`.
 
-## Contents
+## Shape
 
-- [Class Overview](#class-overview)
-- [Creation and Initialization](#creation-and-initialization)
-- [Attribute Map](#attribute-map)
-- [Keyspace Notification Handling](#keyspace-notification-handling)
-- [Mutation Processing Pipeline](#mutation-processing-pipeline)
-- [Mutation Sequence Numbers](#mutation-sequence-numbers)
-- [Backfill Job](#backfill-job)
-- [TimeSlicedMRMWMutex Usage](#timeslicedmrmwmutex-usage)
-- [Statistics and Info](#statistics-and-info)
+One `IndexSchema` per `FT.CREATE`. Inherits from `KeyspaceEventSubscription` (receives key-change events) and `std::enable_shared_from_this` (safe `shared_ptr` / `weak_ptr` for background tasks).
 
-## Class Overview
+Key owned state:
 
-`IndexSchema` is the central per-index object in valkey-search. One instance exists for each `FT.CREATE` index. It inherits from `KeyspaceEventSubscription` (to receive keyspace notifications) and `std::enable_shared_from_this` (to safely pass `shared_ptr`/`weak_ptr` to background tasks).
+| Field | Type | Role |
+|-------|------|------|
+| `name_` | string | index name |
+| `db_num_` | uint32_t | database number |
+| `attributes_` | `flat_hash_map<string, Attribute>` | alias -> `Attribute` (holds `IndexBase`) |
+| `attribute_data_type_` | `unique_ptr<AttributeDataType>` | Hash or JSON source |
+| `backfill_job_` | `MainThreadAccessGuard<optional<BackfillJob>>` | active backfill state |
+| `time_sliced_mutex_` | `TimeSlicedMRMWMutex` | read/write phase coordination |
+| `mutations_thread_pool_` | `ThreadPool*` | borrowed writer pool |
+| `tracked_mutated_records_` | `InternedStringHashMap<DocumentMutation>` | pending mutations by interned key |
+| `text_index_schema_` | `shared_ptr<TextIndexSchema>` | shared text state (language, punctuation, stop words) |
+| `stats_` | `Stats` | per-index counters |
 
-```
-IndexSchema
-  |-- KeyspaceEventSubscription   (receives key change events)
-  |-- enable_shared_from_this     (safe async references)
-```
-
-Key state owned by each IndexSchema:
-
-| Field | Type | Purpose |
-|-------|------|---------|
-| `name_` | string | Index name from FT.CREATE |
-| `db_num_` | uint32_t | Valkey database number |
-| `attributes_` | flat_hash_map<string, Attribute> | Field name to Attribute (holds IndexBase) |
-| `attribute_data_type_` | `unique_ptr<AttributeDataType>` | Hash or JSON data source |
-| `backfill_job_` | `MainThreadAccessGuard<optional<BackfillJob>>` | Active backfill scan state |
-| `time_sliced_mutex_` | TimeSlicedMRMWMutex | Read/write phase coordination |
-| `mutations_thread_pool_` | ThreadPool* | Writer pool reference (not owned) |
-| `tracked_mutated_records_` | `InternedStringHashMap<DocumentMutation>` | Pending mutations keyed by interned string |
-| `text_index_schema_` | `shared_ptr<TextIndexSchema>` | Shared text index state (language, punctuation, stop words) |
-| `stats_` | Stats | Per-index counters |
-
-## Creation and Initialization
-
-The static factory `IndexSchema::Create()` builds a new IndexSchema from a protobuf definition:
+## `Create()`
 
 ```cpp
 static absl::StatusOr<std::shared_ptr<IndexSchema>> Create(
-    ValkeyModuleCtx *ctx,
-    const data_model::IndexSchema &index_schema_proto,
+    ValkeyModuleCtx *ctx, const data_model::IndexSchema &proto,
     vmsdk::ThreadPool *mutations_thread_pool,
     bool skip_attributes, bool reload);
 ```
 
-Steps in `Create()`:
+Steps:
 
-1. **Validate data type** - determines Hash or JSON. JSON requires the JSON module to be loaded.
-2. **Count text fields** - enforces a maximum of 64 text fields per index (`kMaxTextFieldsCount`). This limit exists because text field tracking uses 64-bit bitmasks.
-3. **Construct** - calls private constructor which initializes the `TimeSlicedMRMWMutex` with options (10ms read quota, 1ms write quota, 200us write grace period).
-4. **Init** - `Init()` registers with `KeyspaceEventManager` for keyspace notifications and creates the `BackfillJob`.
-5. **Add indexes** - iterates protobuf attributes, calls `IndexFactory()` to create concrete index objects (Tag, Numeric, Text, VectorHNSW, VectorFlat), then `AddIndex()` to register each.
-6. **SkipInitialScan** - if the protobuf has `skip_initial_scan` set and this is not a reload, the backfill is immediately marked as done.
+1. Validate data type (Hash or JSON - JSON needs the JSON module loaded).
+2. Enforce `kMaxTextFieldsCount = 64` text fields per index (text-field tracking uses 64-bit bitmasks).
+3. Construct - initializes `TimeSlicedMRMWMutex` with 10 ms read / 1 ms write quota, 1 ms / 200 us grace periods.
+4. `Init()` - register with `KeyspaceEventManager`, create `BackfillJob`.
+5. `IndexFactory()` + `AddIndex()` per proto attribute (Tag, Numeric, Text, VectorHNSW, VectorFlat).
+6. `skip_initial_scan` on the proto (and not a reload) marks backfill done immediately.
 
-The constructor extracts key prefixes from the protobuf. If none are specified, an empty prefix `""` is used (matches all keys). Duplicate prefixes that are prefixes of each other are deduplicated.
+Prefix handling: if the proto has no prefixes, `""` is used (matches all). Overlapping prefixes that contain each other are deduplicated. RDB reload restores `document_cnt` from saved stats.
 
-For reload (RDB load), the constructor restores `document_cnt` from the saved protobuf stats.
+## Attributes
 
-## Attribute Map
+`attributes_` keyed by alias (query-facing name). Each `Attribute` holds: `alias`, `identifier` (Hash field or JSON path), `index` (`shared_ptr<IndexBase>`), `position` (into `attributes_indexed_data_size_`).
 
-Each field in an index is represented by an `Attribute` object stored in `attributes_`:
+`AddIndex()` inserts the attribute, grows the size-tracking vector, updates `identifier_to_alias_`, refreshes text bitmasks.
 
-```cpp
-absl::flat_hash_map<std::string, Attribute> attributes_;
-```
+### Text field bitmasks
 
-The map is keyed by attribute alias (the name used in queries). Each Attribute holds:
+| Mask | Use |
+|------|-----|
+| `all_text_field_mask_` | unqualified text queries |
+| `suffix_text_field_mask_` | fields with suffix trie enabled |
+| `stem_text_field_mask_` | fields with stemming enabled |
 
-- **alias** - query-facing name
-- **identifier** - the actual Hash field name or JSON path
-- **index** - `shared_ptr<IndexBase>` to the concrete index (VectorHNSW, Tag, etc.)
-- **position** - index into `attributes_indexed_data_size_` for size tracking
+`GetAllTextIdentifiers(with_suffix)`, `GetAllTextFieldMask(with_suffix)`, `GetTextIdentifiersByFieldMask()` avoid iteration at query time.
 
-`AddIndex()` inserts an attribute, grows `attributes_indexed_data_size_`, maps identifier to alias in `identifier_to_alias_`, and updates text field bitmasks.
+## Keyspace notifications
 
-Text field tracking uses 64-bit bitmasks:
+`OnKeyspaceNotification(ctx, type, event, key)` flow:
 
-| Bitmask | Purpose |
-|---------|---------|
-| `all_text_field_mask_` | All text fields - used for unqualified text queries |
-| `suffix_text_field_mask_` | Fields with suffix trie enabled |
-| `stem_text_field_mask_` | Fields with stemming enabled |
+1. `IsInCurrentDB(ctx)` filter.
+2. `ProcessKeyspaceNotification(ctx, key, false)`.
+3. Open key with `NOEFFECTS | READ`.
+4. `GetAttributeDataType().IsProperType()` - Hash/JSON match.
+5. Per attribute: `VectorExternalizer::Instance().GetRecord()`. Missing record on untracked key -> skip.
+6. `NormalizeStringRecord()` for string-type records.
+7. Counters: `ingest_hash_keys` / `ingest_json_keys`.
+8. `ProcessMutation()`.
 
-`GetAllTextIdentifiers(with_suffix)` and `GetAllTextFieldMask(with_suffix)` return these precomputed sets for query-time field resolution without iteration. `GetTextIdentifiersByFieldMask()` converts a bitmask back to identifier strings.
+Deleted keys (null `key_obj`): all attributes get `DeletionType::kRecord`. The same `ProcessKeyspaceNotification()` is called from the backfill scan callback with `from_backfill=true`.
 
-## Keyspace Notification Handling
-
-`OnKeyspaceNotification()` is called by `KeyspaceEventManager` when a subscribed key changes:
-
-```cpp
-void OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type,
-                            const char *event, ValkeyModuleString *key);
-```
-
-The flow:
-
-1. **DB check** - `IsInCurrentDB(ctx)` ensures the event is for this index's database.
-2. **Delegate** - calls `ProcessKeyspaceNotification(ctx, key, false)`.
-3. **Open key** - opens the key with `NOEFFECTS | READ` flags.
-4. **Type check** - `GetAttributeDataType().IsProperType()` verifies Hash vs JSON match.
-5. **Per-attribute extraction** - for each attribute, fetches the field value via `VectorExternalizer::Instance().GetRecord()`. If the record is missing and the key is not tracked, skips it.
-6. **Normalize** - string-type records go through `NormalizeStringRecord()`.
-7. **Metrics** - increments `ingest_hash_keys` or `ingest_json_keys`.
-8. **Process** - calls `ProcessMutation()` with the collected attribute data.
-
-For deleted keys (where `key_obj` is null), all attributes get `DeletionType::kRecord`.
-
-The same `ProcessKeyspaceNotification()` is called from the backfill scan callback with `from_backfill=true`.
-
-## Mutation Processing Pipeline
-
-Mutations flow through a multi-stage pipeline that separates main-thread bookkeeping from background index updates:
+## Mutation pipeline
 
 ### Main thread (`ProcessMutation`)
 
-1. **UpdateDbInfoKey** - updates `db_key_info_` map with attribute sizes, increments `schema_mutation_sequence_number_`, updates `document_cnt`.
-2. **Sync fallback** - if no writer thread pool, acquires `WriterMutexLock` on `time_sliced_mutex_` and calls `SyncProcessMutation()` directly.
-3. **Multi/exec batching** - if inside MULTI/EXEC, calls `EnqueueMultiMutation()` instead of immediate scheduling. The batch is flushed on the next FT.SEARCH via `ProcessMultiQueue()`.
-4. **Track** - `TrackMutatedRecord()` stores the mutation in `tracked_mutated_records_` (keyed by interned string). If the key already has a pending mutation, the new data merges into the existing entry.
-5. **Schedule** - `ScheduleMutation()` pushes a task to the writer thread pool. Backfill mutations use `Priority::kLow`, real-time mutations use `Priority::kHigh`.
-6. **Client blocking** - real user clients (not from backfill, not inside MULTI) get blocked until their mutation is visible. The `ShouldBlockClient()` function checks context flags.
+1. `UpdateDbInfoKey` - update `db_key_info_`, bump `schema_mutation_sequence_number_`, adjust `document_cnt`.
+2. If no writer pool: `WriterMutexLock(time_sliced_mutex_)` + `SyncProcessMutation()`.
+3. Inside MULTI/EXEC: `EnqueueMultiMutation()`; batch flushes on next FT.SEARCH via `ProcessMultiQueue()`.
+4. `TrackMutatedRecord()` into `tracked_mutated_records_` (interned-key); existing entries merge.
+5. `ScheduleMutation()` - writer pool task. Backfill = `Priority::kLow`; real-time = `Priority::kHigh`.
+6. Real user clients (not backfill, not inside MULTI) block via `ShouldBlockClient()` until mutation is visible.
 
 ### Writer thread (`ProcessSingleMutationAsync`)
 
-1. **Acquire write phase** - `WriterMutexLock lock(&time_sliced_mutex_)`.
-2. **Consume loop** - `ConsumeTrackedMutatedAttribute()` pops pending mutations for this key. Multiple mutations to the same key collapse.
-3. **SyncProcessMutation** - for each consumed mutation:
-   - Deletes existing text index data for the key via `TextIndexSchema::DeleteKeyData()`
-   - Calls `ProcessAttributeMutation()` per attribute
-   - If all attributes are deletes, removes from `index_key_info_`
-   - Commits text index data via `TextIndexSchema::CommitKeyData()`
-4. **ProcessAttributeMutation** - routes to `AddRecord`, `ModifyRecord`, or `RemoveRecord` on the concrete index, tracking success/failure/skip stats.
-5. **Stat update** - decrements `mutation_queue_size_`, samples queue delay.
+1. `WriterMutexLock(time_sliced_mutex_)`.
+2. `ConsumeTrackedMutatedAttribute()` - pop pending mutations for the key; multiple mutations to the same key collapse.
+3. Per consumed mutation in `SyncProcessMutation`:
+   - `TextIndexSchema::DeleteKeyData()`
+   - `ProcessAttributeMutation()` per attribute -> `AddRecord` / `ModifyRecord` / `RemoveRecord` on the concrete index (tracks success/failure/skip).
+   - All-delete case: drop from `index_key_info_`.
+   - `TextIndexSchema::CommitKeyData()`.
+4. Decrement `mutation_queue_size_`, sample queue delay.
 
-## Mutation Sequence Numbers
+## Mutation sequence numbers
 
-The mutation sequence number system provides consistency guarantees for queries that may race with in-flight mutations:
+`using MutationSequenceNumber = uint64_t;`
 
-```cpp
-using MutationSequenceNumber = uint64_t;
-```
-
-Two parallel maps track sequence numbers:
+Two parallel maps:
 
 | Map | Thread safety | Purpose |
 |-----|---------------|---------|
-| `db_key_info_` | Main thread only (`MainThreadAccessGuard`) | Assigned on main thread when mutation is received |
-| `index_key_info_` | `time_sliced_mutex_` (write phase) | Updated on writer thread after mutation completes |
+| `db_key_info_` | main thread only (`MainThreadAccessGuard`) | seq number assigned at notification |
+| `index_key_info_` | `time_sliced_mutex_` write phase | updated after the mutation completes |
 
-The flow:
+Query-side: `PerformKeyContentionCheck()` compares neighbor seq numbers against `db_key_info_`; mismatch means in-flight mutation - the query is enqueued to retry after the mutation completes.
 
-1. Main thread receives a mutation, increments `schema_mutation_sequence_number_`, stores in `db_key_info_[key].mutation_sequence_number_`.
-2. Writer thread processes the mutation, updates `index_key_info_[key].mutation_sequence_number_`.
-3. Queries call `PerformKeyContentionCheck()` to compare sequence numbers of neighbor results against `db_key_info_`. If they differ, the query result may be stale due to an in-flight mutation - the query is enqueued to retry after that mutation completes.
+`PopulateIndexMutationSequenceNumbers()` reads `index_key_info_` under the read phase (`ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_)`).
 
-`PopulateIndexMutationSequenceNumbers()` reads from `index_key_info_` during the read phase of the time-sliced mutex. It requires `ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_)`.
-
-## Backfill Job
-
-When an index is created, it must scan existing keys to populate the index. The `BackfillJob` struct manages this:
+## Backfill
 
 ```cpp
 struct BackfillJob {
@@ -178,54 +122,44 @@ struct BackfillJob {
     vmsdk::StopWatch stopwatch;
     bool paused_by_oom{false};
     bool IsScanDone() const { return scan_ctx.get() == nullptr; }
-    void MarkScanAsDone() { scan_ctx.reset(); cursor.reset(); }
+    void MarkScanAsDone()   { scan_ctx.reset(); cursor.reset(); }
 };
 ```
 
-`PerformBackfill()` is called from `SchemaManager::OnServerCronCallback()` on every cron tick:
+`PerformBackfill()` runs on every `SchemaManager::OnServerCronCallback`:
 
-1. **Check completion** - returns 0 if no backfill job or scan is done.
-2. **OOM check** - pauses if `VALKEYMODULE_CTX_FLAGS_OOM` is set.
-3. **DB size tracking** - monotonically increases `db_size` for accurate progress reporting.
-4. **Scan loop** - calls `ValkeyModule_Scan()` with `BackfillScanCallback` up to `batch_size` keys.
-5. **Callback** - for each scanned key, checks prefix match, then calls `ProcessKeyspaceNotification(ctx, keyname, true)`.
-6. **Completion** - when `ValkeyModule_Scan` returns 0, calls `MarkScanAsDone()` and logs duration.
+1. No-op if `IsScanDone()`.
+2. Pause if `VALKEYMODULE_CTX_FLAGS_OOM` is set.
+3. Track `db_size` monotonically for progress reporting.
+4. `ValkeyModule_Scan(BackfillScanCallback, batch_size)`.
+5. Callback: prefix check, then `ProcessKeyspaceNotification(ctx, keyname, /*from_backfill=*/true)`.
+6. Scan returns 0 -> `MarkScanAsDone()` + log duration.
 
-Progress is reported via `GetBackfillPercent()` which computes `(scanned - in_queue) / db_size`. The `backfill-batch-size` config controls keys processed per cron tick (default 10240).
+Reported progress: `GetBackfillPercent() = (scanned - in_queue) / db_size`. `backfill-batch-size` controls per-tick count (default 10240). `IsBackfillInProgress()` = scan active OR `backfill_inqueue_tasks > 0`.
 
-`IsBackfillInProgress()` returns true when the scan cursor is active OR there are still queued backfill tasks (`backfill_inqueue_tasks > 0`).
+## `TimeSlicedMRMWMutex` timing
 
-## TimeSlicedMRMWMutex Usage
+Time-slices between read and write phases. Asymmetric quotas prioritize query latency over mutation throughput (10:1 read vs write).
 
-Each IndexSchema owns a `vmsdk::TimeSlicedMRMWMutex` (`time_sliced_mutex_`) that coordinates concurrent reads (queries) and writes (mutations) to the index data:
+| Parameter | Value |
+|-----------|-------|
+| `read_quota_duration` | 10 ms |
+| `read_switch_grace_period` | 1 ms |
+| `write_quota_duration` | 1 ms |
+| `write_switch_grace_period` | 200 us |
 
-- **Read phase** - query threads acquire shared read access via `ReaderMutexLock`. Multiple queries execute concurrently during the read phase. Access to `index_key_info_` and index data structures is safe.
-- **Write phase** - writer threads acquire shared write access via `WriterMutexLock`. Multiple mutations execute concurrently during the write phase (on different keys). The `mutated_records_mutex_` provides exclusion between writers accessing the same key's tracked records.
+Queries take `ReaderMutexLock`. Writers take `WriterMutexLock`. Multiple concurrent readers or multiple concurrent writers (on different keys) are allowed; `mutated_records_mutex_` arbitrates writers on the same key.
 
-The mutex time-slices between phases with configurable quotas:
+## `Stats`
 
-| Parameter | Value | Effect |
-|-----------|-------|--------|
-| `read_quota_duration` | 10ms | Maximum read phase duration when writes are waiting |
-| `read_switch_grace_period` | 1ms | Inactivity before switching from read to write |
-| `write_quota_duration` | 1ms | Maximum write phase duration when reads are waiting |
-| `write_switch_grace_period` | 200us | Inactivity before switching from write to read |
-
-This asymmetry (10:1 read vs write quota) prioritizes query latency over mutation throughput.
-
-## Statistics and Info
-
-The `Stats` struct tracks per-index metrics with atomic counters:
+Atomic counters feeding `FT.INFO` and coordinator fanout via `GetInfoIndexPartitionData()`.
 
 | Counter | Type | Meaning |
 |---------|------|---------|
-| `subscription_add` | ResultCnt | Records added (success/failure/skipped) |
-| `subscription_modify` | ResultCnt | Records modified |
-| `subscription_remove` | ResultCnt | Records removed |
-| `document_cnt` | atomic<uint32_t> | Current indexed document count |
-| `backfill_inqueue_tasks` | atomic<uint32_t> | Backfill tasks waiting in writer pool |
-| `mutation_queue_size_` | uint64_t (mutex-guarded) | Mutations pending processing |
-| `mutations_queue_delay_` | Duration (mutex-guarded) | Sampled queue wait time |
+| `subscription_add` / `_modify` / `_remove` | `ResultCnt` | success / failure / skip |
+| `document_cnt` | `atomic<uint32_t>` | indexed documents |
+| `backfill_inqueue_tasks` | `atomic<uint32_t>` | pending backfill tasks |
+| `mutation_queue_size_` | `uint64_t` (mutex) | pending mutations |
+| `mutations_queue_delay_` | `Duration` (mutex) | sampled queue wait |
 
-`RespondWithInfo()` formats these for `FT.INFO` responses. `GetInfoIndexPartitionData()` aggregates stats into the `InfoIndexPartitionData` struct for coordinator fanout, including `num_docs`, `num_records`, `backfill_complete_percent`, `mutation_queue_size`, and `state`.
-</uint32_t></uint32_t>
+`InfoIndexPartitionData` fields: `num_docs`, `num_records`, `backfill_complete_percent`, `mutation_queue_size`, `state`.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-module-overview.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-module-overview.md
@@ -117,28 +117,30 @@ Eight commands, all under `@search` ACL category (`FT.INTERNAL_UPDATE` is intern
 
 Registered via the `vmsdk::config` builder pattern. Access via `CONFIG GET search.<param>` / `CONFIG SET search.<param> <value>`.
 
-| Config | Type | Default | Range |
-|--------|------|---------|-------|
-| `reader-threads` | Number | CPU cores | 1-1024 |
-| `writer-threads` | Number | CPU cores | 1-1024 |
-| `utility-threads` | Number | 1 | 1-1024 |
-| `max-worker-suspension-secs` | Number | 60 | 0-3600 |
-| `hnsw-block-size` | Number | 10240 | 0-UINT_MAX |
-| `query-string-bytes` | Number | 10240 | 1-UINT_MAX |
-| `max-indexes` | Number | 1000 | 1-10000000 |
-| `backfill-batch-size` | Number | 10240 | 1-INT32_MAX |
-| `use-coordinator` | Boolean | false | startup-only, hidden |
-| `log-level` | Enum | notice | warning..debug |
-| `skip-rdb-load` | Boolean | false | |
-| `hnsw-allow-replace-deleted` | Boolean | false | dev |
-| `search-result-background-cleanup` | Boolean | false | |
-| `high-priority-weight` | Number | 100 | 0-100 |
-| `enable-partial-results` | Boolean | true | default SOMESHARDS |
-| `enable-consistent-results` | Boolean | false | default CONSISTENT |
-| `max-term-expansions` | Number | 200 | 1-100000 |
-| `tag-min-prefix-length` | Number | 2 | 0-UINT_MAX |
-| `prefiltering-threshold-ratio` | String | "0.001" | 0.0-1.0 (dev) |
-| `max-nonvector-search-results-fetched` | Number | 100000 | 0-UINT32_MAX |
+| Config | Type | Default | Range | Purpose |
+|--------|------|---------|-------|---------|
+| `reader-threads` | Number | CPU cores | 1-1024 | FT.SEARCH / FT.AGGREGATE worker pool |
+| `writer-threads` | Number | CPU cores | 1-1024 | mutation-processing worker pool |
+| `utility-threads` | Number | 1 | 1-1024 | low-priority background pool (cleanup) |
+| `max-worker-suspension-secs` | Number | 60 | 0-3600 | timeout before writer pool resumes post-fork |
+| `hnsw-block-size` | Number | 10240 | 0-UINT_MAX | HNSW capacity growth step |
+| `query-string-bytes` | Number | 10240 | 1-UINT_MAX | max query string length |
+| `max-indexes` | Number | 1000 | 1-10000000 | total indexes across all DBs |
+| `backfill-batch-size` | Number | 10240 | 1-INT32_MAX | keys per cron tick (global) |
+| `use-coordinator` | Boolean | false | startup-only, hidden | enable cluster gRPC coordinator |
+| `log-level` | Enum | notice | warning..debug | module log verbosity |
+| `skip-rdb-load` | Boolean | false | | skip vector index data during RDB load |
+| `hnsw-allow-replace-deleted` | Boolean | false | dev | reuse deleted HNSW slots before resize |
+| `search-result-background-cleanup` | Boolean | false | | offload result destruction to utility pool |
+| `high-priority-weight` | Number | 100 | 0-100 | scheduling weight for high vs low priority (100 = backfill only when idle) |
+| `enable-partial-results` | Boolean | true | | default SOMESHARDS in cluster fanout |
+| `enable-consistent-results` | Boolean | false | | default CONSISTENT query behavior |
+| `max-term-expansions` | Number | 200 | 1-100000 | max word expansions for prefix/suffix/fuzzy |
+| `tag-min-prefix-length` | Number | 2 | 0-UINT_MAX | min chars before trailing `*` in TAG wildcards |
+| `prefiltering-threshold-ratio` | String | "0.001" | 0.0-1.0 (dev) | planner threshold: prefilter when filtered/total is below this |
+| `max-nonvector-search-results-fetched` | Number | 100000 | 0-UINT32_MAX | OOM guard for non-vector result sets |
+
+Verify every entry against `src/valkey_search_options.cc` for the target version; a config may have been added, removed, or had its default changed. Hidden configs (`HIDDEN_CONFIG`) don't appear in `CONFIG GET *` / module-discovery output - `use-coordinator` above is hidden and startup-only.
 
 Builder callbacks:
 

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-module-overview.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-module-overview.md
@@ -130,7 +130,6 @@ Registered via the `vmsdk::config` builder pattern. Access via `CONFIG GET searc
 | `use-coordinator` | Boolean | false | startup-only, hidden | enable cluster gRPC coordinator |
 | `log-level` | Enum | notice | warning..debug | module log verbosity |
 | `skip-rdb-load` | Boolean | false | | skip vector index data during RDB load |
-| `hnsw-allow-replace-deleted` | Boolean | false | dev | reuse deleted HNSW slots before resize |
 | `search-result-background-cleanup` | Boolean | false | | offload result destruction to utility pool |
 | `high-priority-weight` | Number | 100 | 0-100 | scheduling weight for high vs low priority (100 = backfill only when idle) |
 | `enable-partial-results` | Boolean | true | | default SOMESHARDS in cluster fanout |

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-module-overview.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-module-overview.md
@@ -1,237 +1,170 @@
-# Module Overview
+# Module overview
 
-Use when understanding module loading, the ValkeySearch singleton, thread pools, VMSDK abstraction, or the overall startup sequence.
+Use when reasoning about module loading, the `ValkeySearch` singleton, thread pools, VMSDK abstraction, or startup sequence.
 
-Source: `src/module_loader.cc`, `src/valkey_search.h`, `src/valkey_search.cc`, `src/version.h`, `vmsdk/src/module.h`
+Source: `src/module_loader.cc`, `src/valkey_search.{h,cc}`, `src/version.h`, `vmsdk/src/module.h`.
 
-## Contents
-
-- [Module Identity](#module-identity)
-- [VALKEY_MODULE Macro and Loading](#valkey_module-macro-and-loading)
-- [ValkeySearch Singleton](#valkeysearch-singleton)
-- [OnLoad Sequence](#onload-sequence)
-- [Thread Pools](#thread-pools)
-- [VMSDK Abstraction Layer](#vmsdk-abstraction-layer)
-- [Registered Commands](#registered-commands)
-- [Configuration System](#configuration-system)
-- [INFO Sections](#info-sections)
-
-## Module Identity
-
-The module registers itself as `search` with version 1.2.0 and requires Valkey server 9.0.1 or later. These constants live in `src/version.h`:
+## Module identity
 
 ```cpp
-constexpr auto kModuleVersion = vmsdk::ValkeyVersion(1, 2, 0);
+// src/version.h
+constexpr auto kModuleVersion        = vmsdk::ValkeyVersion(1, 2, 0);
 constexpr auto kMinimumServerVersion = vmsdk::ValkeyVersion(9, 0, 1);
+#define MODULE_RELEASE_STAGE "rc2"   // "dev" on unstable, "rcN", then "ga"
 ```
 
-The release stage (`MODULE_RELEASE_STAGE`) tracks pre-release status - `"rc2"` during release candidates, `"ga"` for stable releases. Three metadata versions exist for forward/backward compatibility:
+Module registers as `"search"` with ACL category `@search`. Three RDB metadata versions:
 
 | Version | Release | Change |
 |---------|---------|--------|
-| kRelease10 (1.0.0) | 1.0 | Initial release |
-| kRelease11 (1.1.0) | 1.1 | Cluster mode with non-zero DB numbers |
-| kRelease12 (1.2.0) | 1.2 | Full-text search |
+| `kRelease10` | 1.0 | Initial |
+| `kRelease11` | 1.1 | Cluster mode with non-zero DB numbers |
+| `kRelease12` | 1.2 | Full-text search |
 
-## VALKEY_MODULE Macro and Loading
+## `VALKEY_MODULE` macro
 
-The `VALKEY_MODULE(options)` macro in `vmsdk/src/module.h` generates the C entry points `ValkeyModule_OnLoad` and `ValkeyModule_OnUnload`. It:
+Generates `ValkeyModule_OnLoad` / `ValkeyModule_OnUnload` C entry points in `vmsdk/src/module.h`. Flow:
 
-1. Calls `vmsdk::verifyLoadedOnlyOnce()` to prevent double-loading
-2. Calls `vmsdk::TrackCurrentAsMainThread()` to mark the calling thread
-3. Delegates to `vmsdk::module::OnLoad()` which handles `ValkeyModule_Init`, ACL category registration, and command registration
-4. Invokes the `on_load` callback if present
-5. Calls `vmsdk::module::OnLoadDone()` to finalize
+1. `vmsdk::verifyLoadedOnlyOnce()`
+2. `vmsdk::TrackCurrentAsMainThread()`
+3. `vmsdk::module::OnLoad()` - `ValkeyModule_Init`, ACL category, command registration
+4. User `on_load` callback
+5. `vmsdk::module::OnLoadDone()` - finalize
 
-In `src/module_loader.cc`, the options struct configures the module:
+`src/module_loader.cc` wires the options struct (name, version, commands, info, on_load, on_unload). The `on_load` initializes `KeyspaceEventManager` and `ValkeySearch` singletons and calls `ValkeySearch::Instance().OnLoad(...)`.
 
-```cpp
-vmsdk::module::Options options = {
-    .name = "search",
-    .acl_categories = ACLPermissionFormatter({kSearchCategory}),
-    .version = kModuleVersion,
-    .minimum_valkey_server_version = kMinimumServerVersion,
-    .info = valkey_search::ModuleInfo,
-    .commands = { /* 8 commands */ },
-    .on_load = [](ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
-                  int argc, const vmsdk::module::Options &options) {
-        KeyspaceEventManager::InitInstance(...);
-        ValkeySearch::InitInstance(...);
-        return ValkeySearch::Instance().OnLoad(ctx, argv, argc);
-    },
-    .on_unload = [](ValkeyModuleCtx *ctx,
-                    const vmsdk::module::Options &options) {
-        ValkeySearch::Instance().OnUnload(ctx);
-    },
-};
-VALKEY_MODULE(options);
-```
+`ACLPermissionFormatter` strips the `@` prefix from category names for Valkey's module ACL registration.
 
-The `ACLPermissionFormatter` helper strips the `@` prefix from category names (e.g., `@search` becomes `search`) for Valkey's module ACL registration.
+## `ValkeySearch` singleton
 
-## ValkeySearch Singleton
+Stored via `absl::NoDestructor<std::unique_ptr<ValkeySearch>>` in `valkey_search.cc`. Holds:
 
-`ValkeySearch` is the central singleton holding module-wide state. It is stored via `absl::NoDestructor<std::unique_ptr<ValkeySearch>>` in `valkey_search.cc`:
+- Reader / writer / utility `vmsdk::ThreadPool` instances
+- Detached `ValkeyModuleCtx` (`ctx_`) for background ops, lifetime = module
+- Optional `coordinator::Server` + `coordinator::ClientPool` (cluster mode)
+- `ClusterMap` refreshed on server cron
+- `AtForkPrepare()` / `AfterForkParent()` for thread pool suspension
+- `Info()` delegates to `vmsdk::info_field::DoSections()`
+- `GetHNSWBlockSize()` / `SetHNSWBlockSize()` - HNSW vector block allocation
 
-```cpp
-static absl::NoDestructor<std::unique_ptr<ValkeySearch>> valkey_search_instance;
-ValkeySearch &ValkeySearch::Instance() { return **valkey_search_instance; }
-```
+## `OnLoad()` sequence
 
-Key responsibilities:
+1. `ValkeyModule_GetDetachedThreadSafeContext(ctx)` for `ctx_`.
+2. `RegisterModuleType(ctx)` - RDB aux load/save callbacks.
+3. `ModuleConfigManager::Instance().Init(ctx)` - register configs.
+4. `ValkeyModule_LoadConfigs(ctx)`.
+5. `LoadAndParseArgv()` - applies module args. Sanity: reader and writer thread counts must both be enabled or both disabled.
+6. `Startup(ctx)` - creates thread pools, `SchemaManager`, optional coordinator.
+7. Module options: `HANDLE_IO_ERRORS`, `HANDLE_REPL_ASYNC_LOAD`, `NO_IMPLICIT_SIGNAL_MODIFIED`.
+8. JSON module detection for JSON index support.
+9. `VectorExternalizer::Instance().Init(ctx_)`.
+10. `vmsdk::info_field::Validate(ctx)`.
 
-- **Thread pool ownership** - owns reader, writer, and utility `vmsdk::ThreadPool` instances
-- **Background context** - holds a detached `ValkeyModuleCtx` (`ctx_`) valid for the module lifetime
-- **Coordinator** - optionally owns a gRPC `coordinator::Server` and `coordinator::ClientPool` for cluster mode
-- **Cluster map** - maintains a thread-safe `ClusterMap` refreshed on server cron
-- **Fork handling** - implements `AtForkPrepare()` and `AfterForkParent()` for thread pool suspension
-- **INFO reporting** - `Info()` delegates to `vmsdk::info_field::DoSections()` which evaluates all registered info fields
-- **HNSW block size** - `GetHNSWBlockSize()` / `SetHNSWBlockSize()` manage vector block allocation via the config system
+`OnUnload()` frees `ctx_` and destroys the reader thread pool.
 
-## OnLoad Sequence
+## Thread pools
 
-`ValkeySearch::OnLoad()` executes on the main thread during module loading:
+Three `vmsdk::ThreadPool` instances, all created in `Startup()`:
 
-1. **Acquire background context** - `ValkeyModule_GetDetachedThreadSafeContext(ctx)` for lifetime-scoped operations
-2. **Register module type** - `RegisterModuleType(ctx)` for RDB aux load/save callbacks
-3. **Initialize configs** - `ModuleConfigManager::Instance().Init(ctx)` registers all module config parameters
-4. **Load configs** - `ValkeyModule_LoadConfigs(ctx)` loads values from the server config
-5. **Parse argv** - `LoadAndParseArgv()` applies command-line module arguments with a sanity check that reader and writer threads are both enabled or both disabled
-6. **Startup** - `Startup(ctx)` creates thread pools, SchemaManager, and optionally the coordinator
-7. **Set module options** - enables `HANDLE_IO_ERRORS`, `HANDLE_REPL_ASYNC_LOAD`, `NO_IMPLICIT_SIGNAL_MODIFIED`
-8. **JSON detection** - checks if the JSON module is loaded for JSON index support
-9. **Vector externalizer** - `VectorExternalizer::Instance().Init(ctx_)` initializes vector data externalization
-10. **Validate info fields** - `vmsdk::info_field::Validate(ctx)` ensures all registered info fields are valid
+| Pool | Name prefix | Default | Config | Purpose |
+|------|-------------|---------|--------|---------|
+| Reader | `read-worker-` | CPU cores | `reader-threads` | FT.SEARCH / FT.AGGREGATE |
+| Writer | `write-worker-` | CPU cores | `writer-threads` | Mutation processing (add/modify/remove) |
+| Utility | `utility-worker-` | 1 | `utility-threads` | Background cleanup, low-priority tasks |
 
-`OnUnload()` frees the background context and destroys the reader thread pool.
+CPU defaults via `vmsdk::GetPhysicalCPUCoresCount()`. Max 1024/pool. Runtime-resizable via config modify callbacks calling `pool->Resize()`.
 
-## Thread Pools
+- `SupportParallelQueries()` = reader pool has >=1 thread. Zero reader+writer threads = single-threaded mode (main thread executes everything).
+- `ScheduleUtilityTask()` - sync fallback if no utility pool.
+- `ScheduleSearchResultCleanup()` - gated by `search-result-background-cleanup` config.
 
-Three thread pools are created in `Startup()`, each backed by `vmsdk::ThreadPool`:
+## VMSDK layer (`vmsdk/`)
 
-| Pool | Name prefix | Default size | Purpose |
-|------|-------------|-------------|---------|
-| Reader | `read-worker-` | CPU core count | FT.SEARCH / FT.AGGREGATE query execution |
-| Writer | `write-worker-` | CPU core count | Index mutation processing (add/modify/remove records) |
-| Utility | `utility-worker-` | 1 | Low-priority background tasks (search result cleanup) |
-
-Default thread counts come from `vmsdk::GetPhysicalCPUCoresCount()`. All pools are resizable at runtime via module config:
-
-```
-CONFIG SET search.reader-threads 8
-CONFIG SET search.writer-threads 8
-CONFIG SET search.utility-threads 2
-```
-
-Maximum is 1024 threads per pool. The modify callbacks call `pool->Resize(new_value)` to adjust live.
-
-### Parallel query support
-
-`SupportParallelQueries()` returns true when the reader pool has at least one thread. When both reader and writer thread counts are zero, the module operates in single-threaded mode - all mutations and queries execute synchronously on the main thread.
-
-### Utility task scheduling
-
-`ScheduleUtilityTask()` dispatches low-priority work to the utility pool. If no pool exists, the task executes synchronously. `ScheduleSearchResultCleanup()` optionally routes cleanup through the utility pool based on the `search-result-background-cleanup` config.
-
-## VMSDK Abstraction Layer
-
-The `vmsdk/` directory provides a C++ framework over the raw ValkeyModule C API:
+C++ framework over raw `ValkeyModule_*` C API. Never call `ValkeyModule_*` directly.
 
 | Component | File | Purpose |
 |-----------|------|---------|
-| Module bootstrap | `vmsdk/src/module.h` | VALKEY_MODULE macro, command/ACL registration |
-| Thread pool | `vmsdk/src/thread_pool.h` | Worker management, suspend/resume, priority scheduling |
-| Config | `vmsdk/src/module_config.h` | Type-safe config registration (Number, Boolean, Enum, String) |
-| Managed pointers | `vmsdk/src/managed_pointers.h` | RAII wrappers for ValkeyModule objects |
-| Command parser | `vmsdk/src/command_parser.h` | Argument iteration helpers |
+| Module bootstrap | `vmsdk/src/module.h` | `VALKEY_MODULE` macro, command/ACL registration |
+| Thread pool | `vmsdk/src/thread_pool.h` | Workers, suspend/resume, priority |
+| Config | `vmsdk/src/module_config.h` | Type-safe Number/Boolean/Enum/String configs |
+| Managed pointers | `vmsdk/src/managed_pointers.h` | RAII for ValkeyModule objects |
+| Command parser | `vmsdk/src/command_parser.h` | Arg iteration |
 | Blocked client | `vmsdk/src/blocked_client.h` | Async client blocking for mutation visibility |
 | Info fields | `vmsdk/src/info.h` | Declarative INFO section registration |
-| Time-sliced mutex | `vmsdk/src/time_sliced_mrmw_mutex.h` | Multi-reader/multi-writer concurrency primitive |
-| Cluster map | `vmsdk/src/cluster_map.h` | Slot-to-node mapping for cluster mode |
-| CPU monitor | `vmsdk/src/thread_group_cpu_monitor.h` | Per-thread-group CPU usage tracking |
-| Logging | `vmsdk/src/log.h` | VMSDK_LOG macros with rate limiting |
-| Utilities | `vmsdk/src/utils.h` | String conversion, version types, main thread tracking |
+| Time-sliced mutex | `vmsdk/src/time_sliced_mrmw_mutex.h` | Multi-reader / multi-writer primitive |
+| Cluster map | `vmsdk/src/cluster_map.h` | Slot -> node mapping |
+| CPU monitor | `vmsdk/src/thread_group_cpu_monitor.h` | Per-group CPU tracking |
+| Logging | `vmsdk/src/log.h` | `VMSDK_LOG` with rate limiting |
 
-The `vmsdk::CreateCommand<Func>` template wraps command handler functions so they return `absl::Status` instead of raw integers, with automatic error reply formatting.
+`vmsdk::CreateCommand<Func>` wraps handlers to return `absl::Status` instead of C int, with auto error-reply formatting.
 
-## Registered Commands
+## Registered commands
 
-Eight commands are registered in `module_loader.cc`, all under the `@search` ACL category:
+Eight commands, all under `@search` ACL category (`FT.INTERNAL_UPDATE` is internal; `FT._LIST` / `FT._DEBUG` are admin-only):
 
-| Command | Handler | Flags | ACL Categories |
-|---------|---------|-------|----------------|
-| `FT.CREATE` | `FTCreateCmd` | write, fast, deny-oom | @search, @write, @fast |
-| `FT.DROPINDEX` | `FTDropIndexCmd` | write, fast | @search, @write, @fast |
-| `FT.INFO` | `FTInfoCmd` | readonly, fast | @search, @read, @fast |
-| `FT._LIST` | `FTListCmd` | readonly, admin | @search, @read, @slow, @admin |
-| `FT.SEARCH` | `FTSearchCmd` | readonly, deny-oom | @search, @read, @slow |
-| `FT.AGGREGATE` | `FTAggregateCmd` | readonly, deny-oom | @search, @read, @slow |
-| `FT._DEBUG` | `FTDebugCmd` | readonly, admin | @search, @read, @slow, @admin |
-| `FT.INTERNAL_UPDATE` | `FTInternalUpdateCmd` | write, admin, fast | @admin, @search, @write, @fast |
+| Command | Flags | ACL |
+|---------|-------|-----|
+| `FT.CREATE` | write, fast, deny-oom | @search, @write, @fast |
+| `FT.DROPINDEX` | write, fast | @search, @write, @fast |
+| `FT.INFO` | readonly, fast | @search, @read, @fast |
+| `FT._LIST` | readonly, admin | @search, @read, @slow, @admin |
+| `FT.SEARCH` | readonly, deny-oom | @search, @read, @slow |
+| `FT.AGGREGATE` | readonly, deny-oom | @search, @read, @slow |
+| `FT._DEBUG` | readonly, admin | @search, @read, @slow, @admin |
+| `FT.INTERNAL_UPDATE` | write, admin, fast | @admin, @search, @write, @fast |
 
-`FT.INTERNAL_UPDATE` is the cluster-internal replication command - not meant for user invocation. Commands prefixed with `_` (e.g., `FT._LIST`, `FT._DEBUG`) are internal/admin utilities.
+## Configs (`src/valkey_search_options.cc`)
 
-## Configuration System
+Registered via the `vmsdk::config` builder pattern. Access via `CONFIG GET search.<param>` / `CONFIG SET search.<param> <value>`.
 
-Module configuration parameters are registered in `src/valkey_search_options.cc` using the `vmsdk::config` builder pattern. Key parameters:
+| Config | Type | Default | Range |
+|--------|------|---------|-------|
+| `reader-threads` | Number | CPU cores | 1-1024 |
+| `writer-threads` | Number | CPU cores | 1-1024 |
+| `utility-threads` | Number | 1 | 1-1024 |
+| `max-worker-suspension-secs` | Number | 60 | 0-3600 |
+| `hnsw-block-size` | Number | 10240 | 0-UINT_MAX |
+| `query-string-bytes` | Number | 10240 | 1-UINT_MAX |
+| `max-indexes` | Number | 1000 | 1-10000000 |
+| `backfill-batch-size` | Number | 10240 | 1-INT32_MAX |
+| `use-coordinator` | Boolean | false | startup-only, hidden |
+| `log-level` | Enum | notice | warning..debug |
+| `skip-rdb-load` | Boolean | false | |
+| `hnsw-allow-replace-deleted` | Boolean | false | dev |
+| `search-result-background-cleanup` | Boolean | false | |
+| `high-priority-weight` | Number | 100 | 0-100 |
+| `enable-partial-results` | Boolean | true | default SOMESHARDS |
+| `enable-consistent-results` | Boolean | false | default CONSISTENT |
+| `max-term-expansions` | Number | 200 | 1-100000 |
+| `tag-min-prefix-length` | Number | 2 | 0-UINT_MAX |
+| `prefiltering-threshold-ratio` | String | "0.001" | 0.0-1.0 (dev) |
+| `max-nonvector-search-results-fetched` | Number | 100000 | 0-UINT32_MAX |
 
-| Config | Type | Default | Range | Description |
-|--------|------|---------|-------|-------------|
-| `reader-threads` | Number | CPU cores | 1-1024 | Reader thread pool size |
-| `writer-threads` | Number | CPU cores | 1-1024 | Writer thread pool size |
-| `utility-threads` | Number | 1 | 1-1024 | Utility thread pool size |
-| `max-worker-suspension-secs` | Number | 60 | 0-3600 | Max writer suspension during fork |
-| `hnsw-block-size` | Number | 10240 | 0-UINT_MAX | HNSW vector block allocation size |
-| `query-string-bytes` | Number | 10240 | 1-UINT_MAX | Max query string length |
-| `max-indexes` | Number | 1000 | 1-10000000 | Maximum number of indexes |
-| `backfill-batch-size` | Number | 10240 | 1-INT32_MAX | Keys per backfill cron tick |
-| `use-coordinator` | Boolean | false | - | Enable cluster coordinator (hidden, startup-only) |
-| `log-level` | Enum | notice | warning-debug | Module log verbosity |
-| `skip-rdb-load` | Boolean | false | - | Skip loading vector index data from RDB |
-| `hnsw-allow-replace-deleted` | Boolean | false | - | HNSW replace-deleted optimization (dev) |
-| `search-result-background-cleanup` | Boolean | false | - | Offload result cleanup to utility pool |
-| `high-priority-weight` | Number | 100 | 0-100 | Thread pool high-priority task weight |
-| `enable-partial-results` | Boolean | true | - | Default SOMESHARDS in cluster fanout |
-| `enable-consistent-results` | Boolean | false | - | Default CONSISTENT query behavior |
-| `max-term-expansions` | Number | 200 | 1-100000 | Max word expansions for prefix/suffix/fuzzy |
-| `tag-min-prefix-length` | Number | 2 | 0-UINT_MAX | Min chars before trailing `*` in TAG wildcards |
-| `prefiltering-threshold-ratio` | String | "0.001" | 0.0-1.0 | Hybrid query pre-filter vs inline threshold (dev) |
-| `max-nonvector-search-results-fetched` | Number | 100000 | 0-UINT32_MAX | OOM guard for non-vector result sets |
+Builder callbacks:
 
-Access configs at runtime: `CONFIG GET search.<param>` / `CONFIG SET search.<param> <value>`.
+- `.WithValidationCallback(fn)` - runs before value accepted.
+- `.WithModifyCallback(fn)` - runs after value applied (used to resize thread pools).
+- `.Dev()` - only available when log level is debug.
+- Hidden configs (like `use-coordinator`) - set at startup via module args, not via `CONFIG SET`.
 
-Config types use the builder pattern with optional callbacks:
+## INFO sections
 
-```cpp
-// Validation callback - runs before the value is accepted
-.WithValidationCallback(ValidateHNSWBlockSize)
+Declarative `vmsdk::info_field` builders. Appear under `MODULE INFO search`.
 
-// Modify callback - runs after the value is applied
-.WithModifyCallback([](auto new_value) {
-    UpdateThreadPoolCount(pool, new_value);
-})
-```
-
-Hidden configs (like `use-coordinator`) can only be set at startup via module arguments, not via CONFIG SET. Configs marked `.Dev()` are only available when the log level is set to debug.
-
-## INFO Sections
-
-The module registers declarative INFO fields using `vmsdk::info_field` builders. These appear under `MODULE INFO search`:
-
-| Section | Key fields | Visibility |
-|---------|-----------|------------|
+| Section | Fields | Visibility |
+|---------|--------|------------|
 | `memory` | `used_memory_human`, `used_memory_bytes`, `index_reclaimable_memory` | App |
-| `indexing` | `background_indexing_status` (IN_PROGRESS/NO_ACTIVITY) | App |
+| `indexing` | `background_indexing_status` (IN_PROGRESS / NO_ACTIVITY) | App |
 | `thread-pool` | `used_read_cpu`, `used_write_cpu`, `query_queue_size`, `writer_queue_size` | App |
-| `index_stats` | `number_of_indexes`, `total_indexed_documents`, attribute counts | App |
+| `index_stats` | `number_of_indexes`, `total_indexed_documents`, per-type counts | App |
 | `global_ingestion` | Per-type key/field counters, batch metrics | Dev |
-| `time_slice_mutex` | Read/write periods and time, query/upsert/delete counts | Dev |
-| `hnswlib` | Exception counts for add/remove/modify/search/create | App |
+| `time_slice_mutex` | Read/write periods, query/upsert/delete counts | Dev |
+| `hnswlib` | Exception counts per operation | App |
 | `rdb` | Load/save success/failure counts, restore progress | App/Dev |
 | `coordinator` | Internal update parse/call/process failure counts | Dev |
-| `latency` | HNSW/FLAT vector search latency samplers | App |
-| `string_interning` | Store size (unique strings count) | App |
+| `latency` | HNSW/FLAT search latency samplers | App |
+| `string_interning` | Store size | App |
 | `vector_externing` | Entry count, LRU stats, hash errors | App |
-| `query` | Success/failure counts, hybrid/prefilter/vector/text/nonvector breakdowns | App |
+| `query` | Success/failure, hybrid/prefilter/vector/text/nonvector breakdowns | App |
 
-`App` fields appear in standard INFO output; `Dev` fields appear only when `search.log-level` is set to debug or via `FT._DEBUG` commands. Fields marked `CrashSafe` can be emitted during crash reports (no locks, no allocations).
+`App` = standard INFO. `Dev` = log-level=debug or `FT._DEBUG`. Fields marked `CrashSafe` emit during crash reports (no locks, no allocations).

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-schema-manager.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-schema-manager.md
@@ -41,10 +41,10 @@ vmsdk::MainThreadAccessGuard<...> staged_db_to_index_schemas_;
 vmsdk::MainThreadAccessGuard<bool> staging_indices_due_to_repl_load_;
 ```
 
-| Config | Default | Max |
-|--------|---------|-----|
-| `max-indexes` | 1000 | 10 000 000 |
-| `backfill-batch-size` | 10240 | INT32_MAX (global across all indexes) |
+| Config | Default | Max | Purpose |
+|--------|---------|-----|---------|
+| `max-indexes` | 1000 | 10 000 000 | total indexes across all databases |
+| `backfill-batch-size` | 10240 | INT32_MAX | keys scanned per cron tick (global budget) |
 
 ## `CreateIndexSchema` (FT.CREATE)
 

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-schema-manager.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-schema-manager.md
@@ -1,262 +1,150 @@
 # SchemaManager
 
-Use when understanding index registry operations, CRUD for IndexSchema objects, replication staging, FlushDB/SwapDB handling, or RDB save/load of index metadata.
+Use when reasoning about the index registry, `IndexSchema` CRUD, replication staging, FlushDB/SwapDB handling, or RDB save/load of index metadata.
 
-Source: `src/schema_manager.h`, `src/schema_manager.cc`
+Source: `src/schema_manager.{h,cc}`.
 
-## Contents
+## Singleton
 
-- [Singleton and Construction](#singleton-and-construction)
-- [Data Structure](#data-structure)
-- [CreateIndexSchema](#createindexschema)
-- [RemoveIndexSchema](#removeindexschema)
-- [GetIndexSchema and Lookup](#getindexschema-and-lookup)
-- [Staging During Replication](#staging-during-replication)
-- [FlushDB Handling](#flushdb-handling)
-- [SwapDB Handling](#swapdb-handling)
-- [OnLoadingEnded](#onloadingended)
-- [Backfill Orchestration](#backfill-orchestration)
-- [RDB Save and Load](#rdb-save-and-load)
-- [Fingerprinting](#fingerprinting)
-
-## Singleton and Construction
-
-SchemaManager is a singleton that owns all IndexSchema instances in the module. It is initialized during `ValkeySearch::Startup()`:
+Initialized during `ValkeySearch::Startup()`:
 
 ```cpp
 SchemaManager::InitInstance(std::make_unique<SchemaManager>(
     ctx,
     server_events::SubscribeToServerEvents,   // deferred event subscription
-    writer_thread_pool_.get(),                 // mutations thread pool
-    use_coordinator && IsCluster()));          // coordinator mode
+    writer_thread_pool_.get(),
+    use_coordinator && IsCluster()));
 ```
 
-The constructor:
+Constructor:
 
-1. Registers RDB callbacks for `RDB_SECTION_INDEX_SCHEMA` - load, save, section count, and minimum version.
-2. If coordinator is enabled, registers with `MetadataManager` for cluster-wide metadata synchronization with `ComputeFingerprint` and an `OnMetadataCallback` handler.
+1. Registers RDB callbacks for `RDB_SECTION_INDEX_SCHEMA` (load/save/count/min-version).
+2. If coordinator enabled, registers with `MetadataManager` for cluster-wide metadata sync (`ComputeFingerprint` + `OnMetadataCallback`).
 
-Server event subscription is deferred until the first index is created via `SubscribeToServerEventsIfNeeded()`. This avoids unnecessary cron/fork/flush callbacks when no indexes exist.
+Server event subscription is **deferred** until the first index is created (`SubscribeToServerEventsIfNeeded()`) - no cron/fork/flush overhead when no indexes exist.
 
-## Data Structure
+## Data structure
 
-The primary data structure is a two-level map protected by a mutex:
+Two-level map under a mutex:
 
 ```cpp
 mutable absl::Mutex db_to_index_schemas_mutex_;
-absl::flat_hash_map<
-    uint32_t,
+absl::flat_hash_map<uint32_t,
     absl::flat_hash_map<std::string, std::shared_ptr<IndexSchema>>>
-    db_to_index_schemas_;
+    db_to_index_schemas_;   // db_num -> name -> IndexSchema
 ```
 
-The outer map is keyed by database number (`db_num`), the inner map by index name. This allows efficient per-database operations like FlushDB.
-
-A parallel staging map exists for replication loads:
+Parallel staging map for replication loads:
 
 ```cpp
 vmsdk::MainThreadAccessGuard<...> staged_db_to_index_schemas_;
 vmsdk::MainThreadAccessGuard<bool> staging_indices_due_to_repl_load_;
 ```
 
-Configurable limits:
+| Config | Default | Max |
+|--------|---------|-----|
+| `max-indexes` | 1000 | 10 000 000 |
+| `backfill-batch-size` | 10240 | INT32_MAX (global across all indexes) |
 
-| Config | Default | Max | Purpose |
-|--------|---------|-----|---------|
-| `max-indexes` | 1000 | 10,000,000 | Maximum total indexes across all databases |
-| `backfill-batch-size` | 10240 | INT32_MAX | Keys scanned per cron tick across all indexes |
-
-## CreateIndexSchema
-
-`CreateIndexSchema()` is the entry point for `FT.CREATE`:
+## `CreateIndexSchema` (FT.CREATE)
 
 ```cpp
 absl::StatusOr<coordinator::IndexFingerprintVersion>
-CreateIndexSchema(ValkeyModuleCtx *ctx,
-                  const data_model::IndexSchema &index_schema_proto);
+CreateIndexSchema(ValkeyModuleCtx *ctx, const data_model::IndexSchema &proto);
 ```
 
-### Non-coordinated mode (standalone/replica)
+**Non-coordinated (standalone / replica):**
 
-1. Check `max-indexes` limit.
-2. Acquire `db_to_index_schemas_mutex_`.
-3. Call `CreateIndexSchemaInternal()`:
-   - Check for duplicate via `LookupInternal()`.
-   - Call `IndexSchema::Create()` to build the index.
-   - Insert into `db_to_index_schemas_[db_num][name]`.
-   - Call `SubscribeToServerEventsIfNeeded()`.
-4. Return dummy fingerprint/version (0, 0).
+1. `max-indexes` check.
+2. Lock `db_to_index_schemas_mutex_`.
+3. `CreateIndexSchemaInternal()`: `LookupInternal()` for duplicate, `IndexSchema::Create()`, insert, `SubscribeToServerEventsIfNeeded()`.
+4. Return `IndexFingerprintVersion(0, 0)`.
 
-### Coordinated mode (cluster)
+**Coordinated (cluster):**
 
-1. Check `max-indexes` limit.
-2. Check for existing entry in `MetadataManager`.
-3. Pack the protobuf into `google::protobuf::Any`.
-4. Call `MetadataManager::CreateEntry()` which distributes across the cluster.
-5. The MetadataManager calls back `OnMetadataCallback()` on each node, which:
-   - Removes any existing index with the same name.
-   - Calls `CreateIndexSchemaInternal()`.
-   - Sets fingerprint and version on the created schema.
+1. `max-indexes` check.
+2. `MetadataManager` existing-entry check.
+3. Pack proto into `google::protobuf::Any`.
+4. `MetadataManager::CreateEntry()` distributes across the cluster.
+5. `OnMetadataCallback()` on each node removes any same-named index, calls `CreateIndexSchemaInternal()`, sets fingerprint + version.
 
-The return value `IndexFingerprintVersion` contains the fingerprint (highwayhash of serialized protobuf) and version number for cluster consistency.
+Fingerprint = HighwayHash of the serialized proto.
 
-## RemoveIndexSchema
+## `RemoveIndexSchema` (FT.DROPINDEX)
 
-`RemoveIndexSchema()` handles `FT.DROPINDEX`:
+**Non-coordinated:** Lock, `RemoveIndexSchemaInternal()` - move the `shared_ptr` out, erase inner (and outer if DB is empty), call `MarkAsDestructing()` on the schema, return for cleanup.
 
-### Non-coordinated mode
+**Coordinated:** `MetadataManager::DeleteEntry()` -> `OnMetadataCallback(metadata=nullptr)` -> local removal.
 
-1. Acquire mutex.
-2. Call `RemoveIndexSchemaInternal()`:
-   - Look up the index.
-   - Move the `shared_ptr` out of the map.
-   - Erase from the inner map; erase the outer entry if the DB has no remaining indexes.
-   - Call `MarkAsDestructing()` on the removed schema to stop processing pending mutations.
-   - Return the removed schema for cleanup.
+`MarkAsDestructing()` stops the removed schema from processing its mutation backlog (sets `is_destructing_` under `mutated_records_mutex_`). Critical for dropped-index cleanup.
 
-### Coordinated mode
-
-1. Call `MetadataManager::DeleteEntry()`.
-2. MetadataManager calls back `OnMetadataCallback()` with `metadata == nullptr`, which removes the local schema.
-
-`MarkAsDestructing()` is critical - it prevents the index from continuing to process its mutation backlog, avoiding unnecessary CPU and memory usage for a dropped index. It sets `is_destructing_` under `mutated_records_mutex_`.
-
-## GetIndexSchema and Lookup
+## Lookup
 
 ```cpp
-absl::StatusOr<std::shared_ptr<IndexSchema>> GetIndexSchema(
-    uint32_t db_num, absl::string_view name) const;
+absl::StatusOr<std::shared_ptr<IndexSchema>> GetIndexSchema(uint32_t db_num, absl::string_view name) const;
 ```
 
-Acquires `db_to_index_schemas_mutex_` and delegates to `LookupInternal()`, which does a two-level map lookup. Returns `NotFoundError` if the database or name is not present.
+Acquires mutex -> `LookupInternal()` -> two-level lookup. Missing DB or name -> `NotFoundError`.
 
-`GetIndexSchemasInDB(db_num)` returns a copied set of index names for a given database. The copy prevents holding the mutex during iteration but makes it unsuitable for hot paths like FT.SEARCH.
+`GetIndexSchemasInDB(db_num)` returns a **copied** set of names (not suitable for hot paths).
 
-Aggregate statistics methods iterate all indexes under the mutex:
+Aggregates (all iterate under the mutex): `GetNumberOfIndexSchemas`, `GetNumberOfAttributes`, `GetNumberOf{Text,Tag,Numeric,Vector}Attributes`, `GetAttributeCountByType`, `GetTotalIndexedDocuments`, `IsIndexingInProgress`.
 
-| Method | Returns |
-|--------|---------|
-| `GetNumberOfIndexSchemas()` | Total index count |
-| `GetNumberOfAttributes()` | Total attribute count across all indexes |
-| `GetNumberOfTextAttributes()` | Text attributes only |
-| `GetNumberOfTagAttributes()` | Tag attributes only |
-| `GetNumberOfNumericAttributes()` | Numeric attributes only |
-| `GetNumberOfVectorAttributes()` | Vector attributes only |
-| `GetAttributeCountByType(type)` | Attributes by `AttributeType` enum |
-| `GetTotalIndexedDocuments()` | Sum of document_cnt across all indexes |
-| `IsIndexingInProgress()` | True if any index has an active backfill |
+## Replication staging
 
-## Staging During Replication
+Full syncs stage indexes so existing query traffic is undisturbed.
 
-During replication loads (full sync), indexes are staged to avoid disrupting query traffic on existing indexes:
+1. **`OnReplicationLoadStart`** (`VALKEYMODULE_SUBEVENT_LOADING_REPL_START`): sets `staging_indices_due_to_repl_load_ = true`.
+2. **`LoadIndex`** during staging writes to `staged_db_to_index_schemas_[db_num][name]` instead of the live map.
+3. **`OnLoadingEnded`** (loading finished with staging active):
+   - Lock live map.
+   - `RemoveAll()` destroys current live indexes.
+   - `db_to_index_schemas_ = std::move(staged_db_to_index_schemas_.Get())`.
+   - Clear staging map, reset flag.
+   - `OnLoadingEnded()` per loaded schema.
+   - `VectorExternalizer::Instance().ProcessEngineUpdateQueue()`.
 
-### OnReplicationLoadStart
+Atomic swap - queries never observe partial state. Used for both diskless and disk-based replication.
 
-Called on `VALKEYMODULE_SUBEVENT_LOADING_REPL_START`:
+## FlushDB
 
-```cpp
-staging_indices_due_to_repl_load_ = true;
-```
+`OnFlushDBCallback()` on `VALKEYMODULE_SUBEVENT_FLUSHDB_END`:
 
-This flag causes `LoadIndex()` to write to `staged_db_to_index_schemas_` instead of `db_to_index_schemas_`.
+- **Standalone/replica:** remove all indexes in the flushed DB.
+- **Coordinated:** indexes are cluster-level. Copy proto via `old_schema->ToProto()`, remove, recreate via `CreateIndexSchemaInternal()` - preserves definition, clears data. Use `FT.DROPINDEX` to truly remove.
 
-### LoadIndex during staging
+## SwapDB
 
-When `staging_indices_due_to_repl_load_` is true:
+`OnSwapDB()` for `ValkeyModuleEvent_SwapDB`:
 
-```cpp
-staged_db_to_index_schemas_.Get()[db_num][name] = std::move(index_schema);
-```
+- Same-DB (`first == second`): call `OnSwapDB()` on each schema (bookkeeping).
+- Cross-DB: insert empty maps if missing, `std::swap` inner maps (O(1)), call `OnSwapDB()` on all schemas so they update their `db_num_`.
 
-The existing live indexes continue serving queries during the load.
+## `OnLoadingEnded`
 
-### OnLoadingEnded (swap)
+Fires on `VALKEYMODULE_SUBEVENT_LOADING_ENDED`:
 
-When loading completes with staging active:
+1. Staging-to-live swap if staging was active (see above).
+2. `schema->OnLoadingEnded(ctx)` per live index - finalizes text index structures, corrects `db_num_` after mid-load SwapDB.
+3. `VectorExternalizer::Instance().ProcessEngineUpdateQueue()`.
 
-1. Acquire `db_to_index_schemas_mutex_`.
-2. Call `RemoveAll()` to destroy all current live indexes.
-3. Swap: `db_to_index_schemas_ = staged_db_to_index_schemas_.Get()`.
-4. Clear the staging map and reset the staging flag.
-5. Call `OnLoadingEnded()` on each loaded schema to finalize state.
-6. Process vector externalizer update queue.
+## Backfill orchestration
 
-This atomic swap ensures queries never see a partially-loaded state. Staging is used for both diskless and disk-based replication since the overhead is negligible (disk-based sync flushes first, so no additional memory pressure).
+`PerformBackfill(ctx, batch_size)` runs from `OnServerCronCallback`. Iterates all indexes under the mutex, calling `schema->PerformBackfill(ctx, remaining)` with a remaining-count budget that decreases per index - global rate limit across all indexes. Per-tick budget = `backfill-batch-size`.
 
-## FlushDB Handling
+## RDB save/load
 
-`OnFlushDBCallback()` triggers on `VALKEYMODULE_SUBEVENT_FLUSHDB_END`:
+**Save** (`VALKEYMODULE_AUX_AFTER_RDB`): `SaveIndexes()` writes nothing if no indexes (auxsave2 omits empty sections); otherwise `schema->RDBSave(rdb)` per index.
 
-### Non-coordinated mode
+**Load**: per RDB section:
 
-All indexes in the flushed database are removed via `RemoveIndexSchemaInternal()`.
-
-### Coordinated mode
-
-Indexes are recreated after removal because they are a cluster-level construct. The sequence:
-
-1. Copy the index schema protobuf via `old_schema->ToProto()`.
-2. Remove the old schema.
-3. Recreate via `CreateIndexSchemaInternal()`.
-
-This preserves the index definition while clearing its data. To permanently remove an index in coordinated mode, use `FT.DROPINDEX` explicitly.
-
-## SwapDB Handling
-
-`OnSwapDB()` handles `ValkeyModuleEvent_SwapDB`:
-
-- **Same-DB swap** (`dbnum_first == dbnum_second`): calls `OnSwapDB()` on each schema in that DB (useful for internal bookkeeping).
-- **Cross-DB swap**: inserts empty maps if missing, swaps the inner maps between the two databases via `std::swap`, then calls `OnSwapDB()` on all schemas in both DBs so they update their internal `db_num_`.
-
-The swap uses `std::swap` on the hash maps, which is O(1).
-
-## OnLoadingEnded
-
-Called on `VALKEYMODULE_SUBEVENT_LOADING_ENDED` after RDB loading completes:
-
-1. If staging was active, performs the staging-to-live swap (see above).
-2. Iterates all live indexes and calls `schema->OnLoadingEnded(ctx)` on each. This lets indexes finalize post-load state (e.g., text index structures, db_num corrections after SwapDB during load).
-3. Calls `VectorExternalizer::Instance().ProcessEngineUpdateQueue()`.
-
-## Backfill Orchestration
-
-`PerformBackfill()` is called from `SchemaManager::OnServerCronCallback()`:
-
-```cpp
-void PerformBackfill(ValkeyModuleCtx *ctx, uint32_t batch_size);
-```
-
-It iterates all indexes under the mutex and calls `schema->PerformBackfill(ctx, remaining_count)` on each. The remaining batch budget decreases as each index consumes keys, providing a global rate limit across all indexes.
-
-The cron callback dispatches the configured `backfill-batch-size` per tick.
-
-## RDB Save and Load
-
-### Save
-
-`SaveIndexes()` runs during `VALKEYMODULE_AUX_AFTER_RDB`:
-
-1. If no indexes exist, writes nothing (auxsave2 omits empty sections).
-2. Iterates all indexes and calls `schema->RDBSave(rdb)` on each.
-
-### Load
-
-`LoadIndex()` processes each RDB section:
-
-1. Calls `SubscribeToServerEventsIfNeeded()` to receive the loading-ended callback.
-2. Extracts the `IndexSchema` protobuf from the RDB section.
-3. Calls `IndexSchema::LoadFromRDB()` to reconstruct the index.
-4. If staging is active, stores in `staged_db_to_index_schemas_`.
-5. Otherwise, removes any existing index with the same name, then inserts.
-6. Increments `rdb_restore_completed_indexes` for progress tracking.
+1. `SubscribeToServerEventsIfNeeded()`.
+2. Extract `IndexSchema` proto.
+3. `IndexSchema::LoadFromRDB()`.
+4. If staging active, store in `staged_db_to_index_schemas_`.
+5. Else remove any same-named existing, then insert.
+6. Bump `rdb_restore_completed_indexes`.
 
 ## Fingerprinting
 
-`ComputeFingerprint()` uses HighwayHash to generate a 64-bit fingerprint of a serialized IndexSchema protobuf:
-
-```cpp
-static absl::StatusOr<uint64_t> ComputeFingerprint(
-    const google::protobuf::Any &metadata);
-```
-
-The fingerprint is seeded by a fixed 256-bit key (`kHashKey` - four randomly generated 64-bit values). It is used by the coordinator to detect metadata divergence across cluster nodes. Protobuf serialization is non-deterministic across versions, so this assumes fleet-wide module version consistency.
+`ComputeFingerprint(const google::protobuf::Any&)` -> `absl::StatusOr<uint64_t>` via HighwayHash seeded by the fixed `kHashKey` (four 64-bit constants). Used by the coordinator to detect cross-node metadata divergence. **Assumes fleet-wide module-version consistency** - protobuf serialization is not deterministic across versions.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-thread-model.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-thread-model.md
@@ -1,289 +1,154 @@
-# Thread Model
+# Thread model
 
-Use when understanding the concurrency architecture, TimeSlicedMRMWMutex behavior, fork suspension, writer resumption, or main thread vs background thread responsibilities.
+Use when reasoning about concurrency, `TimeSlicedMRMWMutex`, fork suspension, writer resumption, or main-thread vs background-thread split.
 
-Source: `src/valkey_search.cc`, `src/server_events.cc`, `src/index_schema.cc`, `vmsdk/src/time_sliced_mrmw_mutex.h`
+Source: `src/valkey_search.cc`, `src/server_events.cc`, `src/index_schema.cc`, `vmsdk/src/time_sliced_mrmw_mutex.h`.
 
-## Contents
+## Thread contexts
 
-- [Thread Architecture](#thread-architecture)
-- [Main Thread Responsibilities](#main-thread-responsibilities)
-- [Reader Thread Pool](#reader-thread-pool)
-- [Writer Thread Pool](#writer-thread-pool)
-- [Utility Thread Pool](#utility-thread-pool)
-- [gRPC Coordinator Thread](#grpc-coordinator-thread)
-- [TimeSlicedMRMWMutex](#timeslicedmrmwmutex)
-- [Fork Handling](#fork-handling)
-- [Writer Suspension and Resumption](#writer-suspension-and-resumption)
-- [Server Cron Maintenance](#server-cron-maintenance)
-- [Thread Safety Annotations](#thread-safety-annotations)
+| Thread(s) | Default size | Workload |
+|-----------|--------------|----------|
+| Main (Valkey event loop) | 1 | Command parsing, keyspace notifications, cron, backfill scan, RDB load/save, MULTI/EXEC queue |
+| Reader pool | CPU cores | FT.SEARCH / FT.AGGREGATE - `TimeSlicedMRMWMutex` read phase |
+| Writer pool | CPU cores | Index mutations (add/modify/remove) - write phase |
+| Utility pool | 1 | Search-result cleanup, low-priority work |
+| gRPC server | optional | Cluster mode only - `coordinator::Server` for cross-node RPCs |
 
-## Thread Architecture
+Pools created in `ValkeySearch::Startup()` via `vmsdk::ThreadPool(name_prefix, size, wait_time_samples)`. Wait-time sample queue default 100, controlled by `thread-pool-wait-time-samples`.
 
-valkey-search operates across four thread contexts:
+## Main-thread-only state
 
-```
-Main Thread (Valkey event loop)
-  |-- Receives commands (FT.CREATE, FT.SEARCH, etc.)
-  |-- Handles keyspace notifications
-  |-- Runs server cron callbacks
-  |-- Manages backfill scan
-  |
-Reader Thread Pool (N threads, default = CPU cores)
-  |-- Executes query operations (FT.SEARCH, FT.AGGREGATE)
-  |-- Acquires TimeSlicedMRMWMutex in read phase
-  |
-Writer Thread Pool (N threads, default = CPU cores)
-  |-- Processes index mutations (add/modify/remove records)
-  |-- Acquires TimeSlicedMRMWMutex in write phase
-  |
-Utility Thread Pool (1 thread by default)
-  |-- Search result cleanup
-  |-- Low-priority background tasks
-  |
-gRPC Server Thread (optional, cluster mode only)
-  |-- coordinator::Server for cross-node communication
-  |-- Handles SearchIndexPartition and GetGlobalMetadata RPCs
-```
+`vmsdk::MainThreadAccessGuard<T>` wraps data with debug assertions. Key guarded fields:
 
-All pools are created during `ValkeySearch::Startup()`:
-
-```cpp
-reader_thread_pool_ = make_unique<vmsdk::ThreadPool>(
-    "read-worker-", options::GetReaderThreadCount().GetValue(),
-    options::GetThreadPoolWaitTimeSamples().GetValue());
-writer_thread_pool_ = make_unique<vmsdk::ThreadPool>(
-    "write-worker-", options::GetWriterThreadCount().GetValue(),
-    options::GetThreadPoolWaitTimeSamples().GetValue());
-utility_thread_pool_ = make_unique<vmsdk::ThreadPool>(
-    "utility-worker-", options::GetUtilityThreadCount().GetValue(),
-    options::GetThreadPoolWaitTimeSamples().GetValue());
-```
-
-Each pool receives a third argument - the wait-time sample queue size (default 100, configurable via `thread-pool-wait-time-samples`) for tracking task queue latency.
-
-## Main Thread Responsibilities
-
-The main thread (Valkey's event loop) handles all operations that require single-threaded access to Valkey's keyspace: command parsing, keyspace notifications, backfill scanning (`ValkeyModule_Scan`), `UpdateDbInfoKey` writes, FlushDB/SwapDB events, RDB save/load, and MULTI/EXEC queue processing.
-
-`vmsdk::MainThreadAccessGuard<T>` wraps data that must only be accessed on the main thread, with debug assertions in non-release builds. Key guarded fields:
-
-- `IndexSchema::db_key_info_` - database-side key mutation tracking
-- `IndexSchema::backfill_job_` - backfill scan cursor and progress
+- `IndexSchema::db_key_info_` - DB-side key mutation tracking
+- `IndexSchema::backfill_job_` - scan cursor + progress
 - `IndexSchema::multi_mutations_keys_` - pending MULTI/EXEC mutations
 - `SchemaManager::staged_db_to_index_schemas_` - replication staging
 
-## Reader Thread Pool
+## Reader pool
 
-Reader threads execute query operations dispatched from FT.SEARCH and FT.AGGREGATE. Each query:
+Flow: main parses, blocks client, dispatches to reader worker. Worker acquires `ReaderMutexLock(time_sliced_mutex_)` (read phase). Multiple readers concurrent. Results merged on main, client unblocked.
 
-1. Is parsed on the main thread.
-2. If the reader pool has threads, the client is blocked and the query is dispatched to a reader worker.
-3. The reader acquires the `TimeSlicedMRMWMutex` in **read phase**.
-4. Multiple readers execute concurrently during the read phase.
-5. Results are merged and the blocked client is unblocked on the main thread.
+`SupportParallelQueries()` false if reader pool has 0 threads -> queries run synchronously on main.
 
-The reader pool supports priority scheduling and wait-time sampling. `SupportParallelQueries()` returns false if the reader pool has zero threads, in which case queries execute synchronously on the main thread.
+INFO fields: `query_queue_size` (pending queries), `used_read_cpu`.
 
-`query_queue_size` (visible in `FT.INFO`) tracks how many queries are waiting in the reader pool's queue. `used_read_cpu` reports the average CPU utilization of reader threads.
+## Writer pool
 
-## Writer Thread Pool
+Flow: main gets notification, tracks mutation in `tracked_mutated_records_`, schedules task. Worker acquires `WriterMutexLock(time_sliced_mutex_)` (write phase). Multiple writers concurrent on different keys; `mutated_records_mutex_` arbitrates same-key writers.
 
-Writer threads process index mutations (adds, modifies, deletes) dispatched from keyspace notifications and backfill:
-
-1. Main thread receives a keyspace notification.
-2. Mutation data is extracted and tracked in `tracked_mutated_records_`.
-3. A task is scheduled on the writer pool.
-4. The writer acquires the `TimeSlicedMRMWMutex` in **write phase**.
-5. Multiple writers execute concurrently on different keys.
-6. Exclusion between writers on the same key is provided by `mutated_records_mutex_`.
-
-Priority levels control mutation ordering:
+Priorities:
 
 | Priority | Source | Effect |
 |----------|--------|--------|
-| `kHigh` | Real-time keyspace events | Processed before backfill |
-| `kLow` | Backfill scan | Yields to real-time mutations |
+| `kHigh` | real-time keyspace events | processed before backfill |
+| `kLow` | backfill scan | yields to real-time |
 
-The `high-priority-weight` config (default 100, range 0-100) controls the scheduling ratio between high and low priority tasks. At 100, backfill tasks only execute when no real-time mutations are queued.
+`high-priority-weight` (default 100, range 0-100) sets scheduling ratio. 100 = backfill only runs when real-time queue empty.
 
-The writer pool is the one suspended during fork operations (see Fork Handling below). `writer_queue_size` and `used_write_cpu` are reported in INFO.
+Writer pool is **suspended across fork** (see below). INFO: `writer_queue_size`, `used_write_cpu`.
 
-## Utility Thread Pool
-
-The utility pool handles low-priority tasks that should not compete with queries or mutations:
+## Utility pool
 
 ```cpp
 void ScheduleUtilityTask(absl::AnyInvocable<void()> task) {
-    if (utility_thread_pool_) {
-        utility_thread_pool_->Schedule(std::move(task),
-                                       vmsdk::ThreadPool::Priority::kLow);
-    } else {
-        task();
-    }
+    if (utility_thread_pool_) utility_thread_pool_->Schedule(std::move(task), Priority::kLow);
+    else                      task();  // sync fallback
 }
 ```
 
-Primary use: `ScheduleSearchResultCleanup()` offloads destruction of large search result objects. This prevents query latency spikes from deallocation. Controlled by the `search-result-background-cleanup` config (default false).
+Main use: `ScheduleSearchResultCleanup()` - offload destruction of large result sets to avoid query-path latency spikes. Gated by `search-result-background-cleanup` (default false).
 
-If the utility pool is unavailable, tasks execute synchronously in the caller's context.
+## gRPC coordinator (cluster mode)
 
-## gRPC Coordinator Thread
-
-In cluster mode (`use-coordinator=true` and cluster enabled), a gRPC server is started:
+`use-coordinator=true` + cluster enabled:
 
 ```cpp
-coordinator_ = coordinator::ServerImpl::Create(
-    ctx, reader_thread_pool_.get(), coordinator_port);
+coordinator_ = coordinator::ServerImpl::Create(ctx, reader_thread_pool_.get(), coordinator_port);
 ```
 
-The coordinator listens on `valkey_port + 20294` and handles:
+Port = `valkey_port + 20294`. RPCs: `GetGlobalMetadata`, `SearchIndexPartition`. CPU tracked via `vmsdk::ThreadGroupCPUMonitor` -> `coordinator_threads_cpu_time_sec`. Suspended during fork via `coordinator::GRPCSuspender`.
 
-- **GetGlobalMetadata** - returns cluster-wide index metadata for consistency
-- **SearchIndexPartition** - executes a query on the local node's partition and returns results for fanout
+## `TimeSlicedMRMWMutex`
 
-CPU usage of coordinator threads is tracked via `vmsdk::ThreadGroupCPUMonitor` and reported in the `coordinator_threads_cpu_time_sec` INFO field.
+Per-`IndexSchema`. Either multiple concurrent readers OR multiple concurrent writers, never both.
 
-The gRPC server is suspended during fork operations alongside the thread pools via `coordinator::GRPCSuspender`.
+Quotas (10:1 read:write - prioritize query latency):
 
-## TimeSlicedMRMWMutex
+| Parameter | Value |
+|-----------|-------|
+| `read_quota_duration` | 10 ms |
+| `read_switch_grace_period` | 1 ms |
+| `write_quota_duration` | 1 ms |
+| `write_switch_grace_period` | 200 us |
 
-The core concurrency primitive is `vmsdk::TimeSlicedMRMWMutex`, which allows either multiple concurrent readers OR multiple concurrent writers, but never both simultaneously. Each `IndexSchema` owns one instance.
-
-### Modes
-
-```
-[Read Phase]  <-- queries execute here (multiple concurrent readers)
-     |
-     v  (switch when write quota exceeded or read inactivity)
-[Write Phase] <-- mutations execute here (multiple concurrent writers)
-     |
-     v  (switch when read quota exceeded or write inactivity)
-[Read Phase]  ...
-```
-
-### Time quotas
-
-| Parameter | Value | Meaning |
-|-----------|-------|---------|
-| `read_quota_duration` | 10ms | Max read phase when writers are waiting |
-| `read_switch_grace_period` | 1ms | Read inactivity before switching to write |
-| `write_quota_duration` | 1ms | Max write phase when readers are waiting |
-| `write_switch_grace_period` | 200us | Write inactivity before switching to read |
-
-The 10:1 ratio (read 10ms vs write 1ms) prioritizes query latency. Writes get short bursts to process mutations, then yield back to readers.
-
-### Lock acquisition
+Lock construction:
 
 ```cpp
-// Query thread
 vmsdk::ReaderMutexLock lock(&time_sliced_mutex_, may_prolong, ignore_quota);
-
-// Writer thread
 vmsdk::WriterMutexLock lock(&time_sliced_mutex_, may_prolong, ignore_quota);
 ```
 
-- `may_prolong` - indicates the holder may need to extend the phase (prevents premature switch).
-- `ignore_time_quota` - used for critical operations that cannot be interrupted (e.g., MULTI/EXEC batch flush uses `ignore_quota=true`).
+- `may_prolong` - holder may need to extend phase (prevents premature switch).
+- `ignore_time_quota` - critical sections (MULTI/EXEC batch flush uses `ignore_quota=true`).
 
-### Global statistics
+INFO (`time_slice_mutex` section): `read_periods`, `read_time_microseconds`, `write_periods`, `write_time_microseconds`, plus `Metrics` counters `time_slice_queries` / `_upserts` / `_deletes`.
 
-The mutex tracks cumulative statistics via `TimeSlicedMRMWStats`:
+## Fork handling
 
-| Stat | Meaning |
-|------|---------|
-| `read_periods` | Number of read phase activations |
-| `read_time_microseconds` | Total time in read phases |
-| `write_periods` | Number of write phase activations |
-| `write_time_microseconds` | Total time in write phases |
+`pthread_atfork(AtForkPrepare, AfterForkParent, nullptr)` registered in `server_events.cc`.
 
-These appear under the `time_slice_mutex` INFO section alongside `time_slice_queries`, `time_slice_upserts`, and `time_slice_deletes` counters from `Metrics`.
-
-## Fork Handling
-
-Fork events (RDB save, replication) are critical because only the main thread survives in the child process. Background threads are terminated, potentially leaving data structures in inconsistent states.
-
-### AtForkPrepare (pre-fork)
-
-Registered via `pthread_atfork(AtForkPrepare, AfterForkParent, nullptr)` in `server_events.cc`:
+### `AtForkPrepare` (pre-fork)
 
 1. Increment `worker_thread_pool_suspend_cnt`.
-2. Suspend all three thread pools: writer, reader, utility.
-3. Suspend the gRPC server via `GRPCSuspender`.
+2. Suspend writer + reader + utility pools via `SuspendWorkers()` - blocks until in-progress tasks complete.
+3. Suspend gRPC server via `GRPCSuspender`.
 
-`SuspendWorkers()` blocks until all in-progress tasks complete, then prevents new tasks from starting. This guarantees no thread is mutating index data when the fork happens.
+Guarantees no thread is mid-mutation when the fork happens.
 
-### AfterForkParent (post-fork, parent)
+### `AfterForkParent`
 
-After the fork returns in the parent process:
+1. Resume **reader** + **utility** pools immediately - queries can continue.
+2. Start `writer_thread_pool_suspend_watch_` timer.
+3. Resume gRPC server.
 
-1. Resume the **reader** thread pool immediately - queries can resume.
-2. Resume the **utility** thread pool immediately.
-3. Start the writer suspension timer (`writer_thread_pool_suspend_watch_`).
-4. Resume the gRPC server via `GRPCSuspender`.
+Writer pool intentionally NOT resumed. Writer threads dirty pages -> copy-on-write -> memory pressure while the child (RDB save / replication) is alive. Vector mutations modify large contiguous regions - especially expensive under COW.
 
-The writer pool is NOT immediately resumed. This is intentional - writer threads cause page faults that lead to copy-on-write overhead, increasing memory pressure while the child process is still running.
+## Writer resume policy
 
-### Why writers stay suspended
+`max-worker-suspension-secs` (default 60):
 
-When a child process (RDB save or replication) is alive, any writes to shared pages trigger copy-on-write. Vector index mutations are particularly expensive because they modify large contiguous memory regions. Keeping writers suspended reduces dirty pages and OOM risk.
+**`> 0`**: writers resume at the earlier of:
 
-## Writer Suspension and Resumption
+- Fork child dies - `OnForkChildCallback(SUBEVENT_FORK_CHILD_DIED)` -> `ResumeWriterThreadPool(ctx, /*is_expired=*/false)`.
+- Timeout - `OnServerCronCallback` checks `writer_thread_pool_suspend_watch_`; exceeded -> `ResumeWriterThreadPool(ctx, true)` + bump `writer_suspension_expired_cnt`.
 
-The writer thread pool resumes based on the `max-worker-suspension-secs` config (default: 60 seconds):
+**`<= 0`**: resume on any fork child event (born or died). Doesn't check subevent - protects against config changes mid-fork leaving workers stuck.
 
-### max-worker-suspension-secs > 0 (default behavior)
+`ResumeWriterThreadPool()` calls `writer_thread_pool_->ResumeWorkers()` and clears `writer_thread_pool_suspend_watch_`.
 
-Writers resume on whichever comes first:
+Metrics: `worker_pool_suspend_cnt`, `writer_resumed_cnt`, `reader_resumed_cnt`, `writer_suspension_expired_cnt`.
 
-1. **Fork child dies** - `OnForkChildCallback` with `SUBEVENT_FORK_CHILD_DIED` triggers `ResumeWriterThreadPool(ctx, false)`.
-2. **Timeout** - `OnServerCronCallback` checks `writer_thread_pool_suspend_watch_` duration. If it exceeds the config value, calls `ResumeWriterThreadPool(ctx, true)` and increments `writer_suspension_expired_cnt`.
+## Server cron
 
-### max-worker-suspension-secs <= 0
+`ValkeySearch::OnServerCronCallback()` each tick (default 10 Hz):
 
-Writers resume on any fork child event (born or died). The code does not check the subevent type - in case the config was modified mid-fork, it resumes on both events to avoid stuck workers.
+1. `JoinTerminatedWorkers()` on all three pools.
+2. Check writer suspension timeout and resume if needed.
+3. Cluster mode + coordinator: `GetOrRefreshClusterMap()` when stale / inconsistent.
 
-### ResumeWriterThreadPool
+`SchemaManager::OnServerCronCallback()` drives backfill across all indexes per tick. `MetadataManager::OnServerCronCallback()` runs cluster metadata maintenance.
 
-```cpp
-void ResumeWriterThreadPool(ValkeyModuleCtx *ctx, bool is_expired) {
-    writer_thread_pool_->ResumeWorkers();
-    // ... logging and metrics ...
-    writer_thread_pool_suspend_watch_ = std::nullopt;
-}
-```
-
-Clears the suspension watch so cron stops checking. Metrics tracked:
-
-| Metric | Meaning |
-|--------|---------|
-| `worker_pool_suspend_cnt` | Total fork-triggered suspensions |
-| `writer_resumed_cnt` | Total writer pool resumptions |
-| `reader_resumed_cnt` | Total reader pool resumptions |
-| `writer_suspension_expired_cnt` | Resumptions due to timeout (not child death) |
-
-## Server Cron Maintenance
-
-`ValkeySearch::OnServerCronCallback()` runs on every server cron tick (10 times per second by default):
-
-1. **Join terminated workers** - calls `JoinTerminatedWorkers()` on all three pools to clean up threads that exited but were not joined.
-2. **Writer suspension timeout** - checks if the writer pool has been suspended too long and resumes if needed.
-3. **Cluster map refresh** - in cluster mode with coordinator, calls `GetOrRefreshClusterMap()` if the map is stale or inconsistent.
-
-`SchemaManager::OnServerCronCallback()` also runs on each tick and drives backfill processing across all indexes. Additionally, if `MetadataManager` is initialized, its `OnServerCronCallback` runs for cluster metadata maintenance.
-
-## Thread Safety Annotations
-
-The codebase uses Clang's thread safety analysis annotations extensively:
+## Thread-safety annotations (Clang)
 
 | Annotation | Meaning |
 |------------|---------|
-| `ABSL_GUARDED_BY(mutex)` | Field protected by the named mutex |
-| `ABSL_LOCKS_EXCLUDED(mutex)` | Function must not hold the named mutex |
-| `ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex)` | Function requires exclusive lock |
-| `ABSL_SHARED_LOCKS_REQUIRED(mutex)` | Function requires shared lock |
-| `ABSL_LOCKABLE` | Class can be used as a lock |
-| `ABSL_SHARED_LOCK_FUNCTION()` | Function acquires shared lock |
-| `ABSL_UNLOCK_FUNCTION()` | Function releases a lock |
+| `ABSL_GUARDED_BY(m)` | field protected by mutex `m` |
+| `ABSL_LOCKS_EXCLUDED(m)` | function must NOT hold `m` |
+| `ABSL_EXCLUSIVE_LOCKS_REQUIRED(m)` | function requires exclusive lock |
+| `ABSL_SHARED_LOCKS_REQUIRED(m)` | function requires shared lock |
+| `ABSL_LOCKABLE` | type usable as lock |
+| `ABSL_SHARED_LOCK_FUNCTION()` | function acquires shared lock |
+| `ABSL_UNLOCK_FUNCTION()` | function releases lock |
 
-These annotations enable compile-time verification of lock discipline. When modifying concurrent code, ensure annotations are updated to match the actual locking protocol.
+Compile-time lock-discipline verification. Keep annotations in sync when modifying concurrent code.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-thread-model.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/architecture-thread-model.md
@@ -75,12 +75,12 @@ Per-`IndexSchema`. Either multiple concurrent readers OR multiple concurrent wri
 
 Quotas (10:1 read:write - prioritize query latency):
 
-| Parameter | Value |
-|-----------|-------|
-| `read_quota_duration` | 10 ms |
-| `read_switch_grace_period` | 1 ms |
-| `write_quota_duration` | 1 ms |
-| `write_switch_grace_period` | 200 us |
+| Parameter | Value | Meaning |
+|-----------|-------|---------|
+| `read_quota_duration` | 10 ms | max read phase when writers are waiting |
+| `read_switch_grace_period` | 1 ms | read inactivity before switching to write |
+| `write_quota_duration` | 1 ms | max write phase when readers are waiting |
+| `write_switch_grace_period` | 200 us | write inactivity before switching to read |
 
 Lock construction:
 

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-coordinator.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-coordinator.md
@@ -1,132 +1,103 @@
-# gRPC Coordinator
+# gRPC coordinator
 
-Use when working on cluster-mode search fanout, the gRPC service layer, metadata synchronization between shards, or the coordinator port configuration.
+Use when reasoning about cluster-mode fanout, the gRPC service, metadata sync, or the coordinator port.
 
-Source: `src/coordinator/coordinator.proto`, `src/coordinator/server.h`, `server.cc`, `client.h`, `client.cc`, `client_pool.h`, `metadata_manager.h`, `metadata_manager.cc`, `util.h`, `grpc_suspender.h`
+Source: `src/coordinator/coordinator.proto`, `server.{h,cc}`, `client.{h,cc}`, `client_pool.h`, `metadata_manager.{h,cc}`, `util.h`, `grpc_suspender.h`.
 
-## Contents
-
-- gRPC Service Definition (line 22)
-- Port Offset and Address Resolution (line 45)
-- Server Implementation (line 66)
-- Client Implementation (line 86)
-- Client Pool (line 102)
-- MetadataManager Overview (line 108)
-- Fingerprinting with HighwayHash (line 127)
-- Cluster Bus Broadcast (line 143)
-- Reconciliation Protocol (line 153)
-- Staging During Replication (line 175)
-- use-coordinator Config (line 188)
-- gRPC Suspension Guard (line 194)
-
-## gRPC Service Definition
-
-The `Coordinator` service in `coordinator.proto` defines three RPCs:
+## gRPC service (`coordinator.proto`)
 
 ```protobuf
 service Coordinator {
-  rpc GetGlobalMetadata(GetGlobalMetadataRequest)
-      returns (GetGlobalMetadataResponse) {}
-  rpc SearchIndexPartition(SearchIndexPartitionRequest)
-      returns (SearchIndexPartitionResponse) {}
-  rpc InfoIndexPartition(InfoIndexPartitionRequest)
-      returns (InfoIndexPartitionResponse) {}
+  rpc GetGlobalMetadata   (GetGlobalMetadataRequest)   returns (GetGlobalMetadataResponse);
+  rpc SearchIndexPartition(SearchIndexPartitionRequest)returns (SearchIndexPartitionResponse);
+  rpc InfoIndexPartition  (InfoIndexPartitionRequest)  returns (InfoIndexPartitionResponse);
 }
 ```
 
-**GetGlobalMetadata** - Returns the full `GlobalMetadata` protobuf from the local node. Called during reconciliation when a remote node detects a fingerprint or version mismatch. The request is empty; the response contains the entire metadata tree.
+- **GetGlobalMetadata** - full `GlobalMetadata` from the local node. Fetched during reconciliation when fingerprint / version mismatches.
+- **SearchIndexPartition** - vector / hybrid search fanout. Request: index name, query bytes, filter, LIMIT/SORTBY, K/EF, timeout, consistency flags. Response: `NeighborEntry`s with optional content.
+- **InfoIndexPartition** - FT.INFO fanout. Doc/record counts, backfill, mutation queue, per-attribute memory, failures. `FanoutErrorType` enum: `OK`, `INDEX_NAME_ERROR`, `INCONSISTENT_STATE_ERROR`, `COMMUNICATION_ERROR`.
 
-**SearchIndexPartition** - Fans out a vector or hybrid search to a remote shard. The request carries the index name, query bytes, filter predicates, LIMIT/SORTBY parameters, K/EF for vector search, timeout, and consistency flags. The response returns scored `NeighborEntry` results with optional attribute contents.
+Both Search and Info RPCs carry `IndexFingerprintVersion` for consistency. Under `enable_consistency` / `require_consistency` the server also checks slot fingerprints against the cached cluster map.
 
-**InfoIndexPartition** - Fans out `FT.INFO` to a remote shard. The response includes doc counts, record counts, backfill progress, mutation queue size, per-attribute memory, and indexing failures. The `FanoutErrorType` enum distinguishes OK, INDEX_NAME_ERROR, INCONSISTENT_STATE_ERROR, and COMMUNICATION_ERROR.
-
-Both SearchIndexPartition and InfoIndexPartition carry an `IndexFingerprintVersion` for consistency checks. If `enable_consistency` or `require_consistency` is set, the server also checks slot fingerprints against the cached cluster map.
-
-## Port Offset and Address Resolution
-
-Defined in `src/coordinator/util.h`:
+## Port resolution (`util.h`)
 
 ```cpp
 static constexpr int kCoordinatorPortOffset = 20294;
-```
-
-The gRPC port is computed as `valkey_port + 20294`. For the default Valkey port 6379, this yields **26673** - which spells COORD on a telephone keypad. A special case handles TLS port 6378, adding an extra +1 to avoid collision.
-
-```cpp
 inline int GetCoordinatorPort(int valkey_port) {
-  if (valkey_port == 6378) {
-    return valkey_port + kCoordinatorPortOffset + 1;
-  }
-  return valkey_port + kCoordinatorPortOffset;
+  return valkey_port == 6378
+       ? valkey_port + kCoordinatorPortOffset + 1   // avoid collision with TLS offset
+       : valkey_port + kCoordinatorPortOffset;
 }
 ```
 
-When a cluster bus message arrives from a remote node, `HandleBroadcastedMetadata` resolves the sender's IP via `ValkeyModule_GetClusterNodeInfo` and constructs the gRPC address as `ip:GetCoordinatorPort(node_port)`.
+Default 6379 -> **26673** ("COORD" on a phone keypad).
 
-## Server Implementation
+Cluster-bus message -> `HandleBroadcastedMetadata` resolves sender IP via `ValkeyModule_GetClusterNodeInfo`, constructs `ip:GetCoordinatorPort(node_port)`.
 
-`coordinator::ServerImpl` wraps the gRPC C++ async server. `ServerImpl::Create` binds to `[::]:<port>` with insecure credentials.
+## Server (`ServerImpl`)
 
-Channel arguments for performance:
-- `GRPC_ARG_ALLOW_REUSEPORT = 1` - enables SO_REUSEADDR
-- `GRPC_ARG_MINIMAL_STACK = 1` - reduces per-connection overhead
-- `GRPC_ARG_OPTIMIZATION_TARGET = "latency"` - latency-optimized transport
-- `GRPC_ARG_TCP_TX_ZEROCOPY_ENABLED = 1` - zero-copy sends
+Wraps gRPC C++ async server. `ServerImpl::Create` binds `[::]:<port>` insecure. Channel args:
 
-If the initial bind fails, the server retries up to 10 times with increasing backoff (100ms * attempt), running `lsof` diagnostics on each failure to log what process holds the port.
+- `GRPC_ARG_ALLOW_REUSEPORT = 1`
+- `GRPC_ARG_MINIMAL_STACK = 1`
+- `GRPC_ARG_OPTIMIZATION_TARGET = "latency"`
+- `GRPC_ARG_TCP_TX_ZEROCOPY_ENABLED = 1`
 
-`coordinator::Service` implements the three RPCs as `CallbackService` methods:
+Initial bind retries up to 10x with 100 ms * attempt backoff, running `lsof` on each failure to log the holder.
 
-- **GetGlobalMetadata** - Acquires a `GRPCSuspensionGuard`, then dispatches to the main thread via `vmsdk::RunByMain` to read metadata. Returns the full `GlobalMetadata` protobuf.
+`coordinator::Service` `CallbackService` methods:
 
-- **SearchIndexPartition** - Converts the gRPC request to internal `SearchParameters` via `GRPCSearchRequestToParameters`, performs index and optional slot consistency checks, then enqueues the search on the reader thread pool via `query::SearchAsync` in `kRemote` mode. Results are serialized back into `NeighborEntry` messages. A `RemoteResponderSearch` subclass handles completion callbacks.
+- **GetGlobalMetadata** - `GRPCSuspensionGuard` -> `vmsdk::RunByMain` to read metadata.
+- **SearchIndexPartition** - `GRPCSearchRequestToParameters` converts to `SearchParameters`, runs index + slot consistency checks, dispatches to reader pool via `query::SearchAsync(kRemote)`. Results serialized into `NeighborEntry`. `RemoteResponderSearch` handles completion.
+- **InfoIndexPartition** - main thread, `GenerateInfoResponse` looks up `IndexSchema`, checks consistency, populates the response.
 
-- **InfoIndexPartition** - Dispatches to the main thread, calls `GenerateInfoResponse` which looks up the IndexSchema locally, performs consistency checks, and populates the response with doc counts, backfill status, mutation queue size, and per-attribute stats.
+## Client (`ClientImpl`)
 
-## Client Implementation
+Retry policy (gRPC service-config JSON):
 
-`coordinator::ClientImpl` wraps a gRPC stub with retry and timeout policies.
-
-The retry policy (defined as JSON service config):
-- Max 5 attempts
-- Initial backoff 100ms, max 1s, multiplier 1.0
-- Retryable codes: UNAVAILABLE, UNKNOWN, RESOURCE_EXHAUSTED, INTERNAL, DATA_LOSS, NOT_FOUND
+- Max 5 attempts.
+- Backoff: initial 100 ms, max 1 s, multiplier 1.0.
+- Retryable codes: `UNAVAILABLE`, `UNKNOWN`, `RESOURCE_EXHAUSTED`, `INTERNAL`, `DATA_LOSS`, `NOT_FOUND`.
 
 Timeouts:
-- `GetGlobalMetadata` - 60 seconds
-- `SearchIndexPartition` - configurable via `coordinator-query-timeout-secs` (default 25s, range 1-3600s)
-- `InfoIndexPartition` - configurable via `ft-info-rpc-timeout-ms` (default 2500ms)
 
-All RPCs are async. Each allocates a heap struct containing the context, request, response, callback, and latency sample. The callback fires on a gRPC background thread, acquires a `GRPCSuspensionGuard`, invokes the user callback, and records success/failure metrics plus latency samples. Byte counts for requests and responses are tracked in `coordinator_bytes_out` and `coordinator_bytes_in`.
+| RPC | Timeout | Source |
+|-----|---------|--------|
+| `GetGlobalMetadata` | 60 s | fixed |
+| `SearchIndexPartition` | `coordinator-query-timeout-secs` (default 25, 1-3600) | config |
+| `InfoIndexPartition` | `ft-info-rpc-timeout-ms` (default 2500) | config |
 
-## Client Pool
+All async. Each allocates a heap struct for context/request/response/callback/latency sample. Callback fires on a gRPC background thread -> `GRPCSuspensionGuard` -> user callback -> metrics + latency sample. Bytes tracked in `coordinator_bytes_in` / `_out`.
 
-`coordinator::ClientPool` caches gRPC clients by address in a mutex-protected `flat_hash_map`. On first access to a given address, `ClientImpl::MakeInsecureClient` creates a channel with shared channel arguments (retry policy, minimal stack, latency optimization, zero-copy). Subsequent calls return the cached client.
+## Client pool (`ClientPool`)
 
-Each client holds its own detached thread-safe context cloned from the pool's context. The pool is owned by `ValkeySearch` and shared with `MetadataManager`.
+Per-address cache under a mutex, `flat_hash_map`. First access -> `ClientImpl::MakeInsecureClient` creates a channel with the shared args. Subsequent -> cached.
 
-## MetadataManager Overview
+Each client holds its own detached thread-safe context cloned from the pool's. Pool owned by `ValkeySearch`, shared with `MetadataManager`.
 
-`coordinator::MetadataManager` is a singleton managing cluster-wide metadata consistency. It maintains:
+## `MetadataManager`
 
-- `metadata_` - the local `GlobalMetadata` protobuf (main-thread guarded)
-- `staged_metadata_` - temporary storage during replication loads
-- `registered_types_` - map of type names to callbacks (fingerprint, update, min_version)
-- `client_pool_` - reference to the shared gRPC client pool
+Singleton managing cluster-wide metadata consistency.
 
-The manager registers itself for `RDB_SECTION_GLOBAL_METADATA` load/save callbacks during construction. Type registration via `RegisterType` provides:
-- A `FingerprintCallback` for computing entry fingerprints
-- A `MetadataUpdateCallback` invoked when entries are created, modified, or deleted
-- A `MinVersionCallback` to determine minimum module version requirements
+- `metadata_` - local `GlobalMetadata` (main-thread guarded).
+- `staged_metadata_` - during replication loads.
+- `registered_types_` - type name -> callbacks (fingerprint, update, min_version).
+- `client_pool_` - shared pool reference.
+
+Registers for `RDB_SECTION_GLOBAL_METADATA` load/save. `RegisterType` takes:
+
+- `FingerprintCallback` - per-entry fingerprint.
+- `MetadataUpdateCallback` - create/modify/delete.
+- `MinVersionCallback` - minimum module version.
 
 Entry lifecycle:
-- `CreateEntry` - computes fingerprint, triggers callbacks, updates the local metadata tree, increments the version, recomputes the top-level fingerprint, replicates via `FT.INTERNAL_UPDATE`, and broadcasts via cluster bus
-- `DeleteEntry` - sets a tombstone (entry with no content, incremented version), then replicates and broadcasts
-- `GetGlobalMetadata` - returns a deep copy of the local metadata
 
-## Fingerprinting with HighwayHash
+- `CreateEntry` - fingerprint, callbacks, update tree, bump version, recompute top-level fingerprint, replicate via `FT.INTERNAL_UPDATE`, cluster-bus broadcast.
+- `DeleteEntry` - tombstone (content empty, version++), replicate + broadcast.
+- `GetGlobalMetadata` - deep copy of local metadata.
 
-Metadata integrity uses HighwayHash (Google's SIMD-accelerated hash) for deterministic fingerprinting. The hash key is a fixed 256-bit constant:
+## HighwayHash fingerprinting
 
 ```cpp
 static constexpr highwayhash::HHKey kHashKey{
@@ -134,69 +105,60 @@ static constexpr highwayhash::HHKey kHashKey{
     0x1ea3f3f773f3b510, 0x9290a6b4e4db3d51};
 ```
 
-**Per-entry fingerprints** are computed by the registered `FingerprintCallback`, which serializes the protobuf `Any` content and hashes it. This depends on the encoding version - different module versions may produce different fingerprints.
+**Per-entry** fingerprint via the registered `FingerprintCallback` - serializes the proto `Any` and hashes. **Depends on encoding version** - different module versions may produce different fingerprints.
 
-**Top-level fingerprint** (`ComputeTopLevelFingerprint`) summarizes the entire metadata tree. It creates a `ChildMetadataEntry` struct per entry containing the HighwayHash of the type name, HighwayHash of the ID, version, and fingerprint. These are sorted deterministically (by type name hash, then ID hash) and hashed as a contiguous byte array.
+**Top-level** (`ComputeTopLevelFingerprint`) summarizes the tree. Per entry build a `ChildMetadataEntry` {hash(type_name), hash(id), version, fingerprint}. Sort deterministically (by type-name hash then id hash), hash the contiguous buffer.
 
-This two-level scheme enables quick equality checks: if top-level fingerprints match, the metadata is identical. If they diverge, the full `GetGlobalMetadata` RPC is triggered to identify specific differences.
+Two-level scheme: matching top-level -> identical; divergent -> fetch full `GetGlobalMetadata` to find differences.
 
-## Cluster Bus Broadcast
+## Cluster-bus broadcast
 
-Metadata changes propagate via Valkey's cluster bus, not gRPC. `BroadcastMetadata` serializes the `GlobalMetadataVersionHeader` (containing `top_level_fingerprint`, `top_level_version`, `top_level_min_version`) and sends it with `ValkeyModule_SendClusterMessage` using receiver ID `0x00`.
+Metadata changes propagate via **Valkey cluster bus**, not gRPC. `BroadcastMetadata` serializes `GlobalMetadataVersionHeader` (`top_level_fingerprint`, `top_level_version`, `top_level_min_version`) and sends with `ValkeyModule_SendClusterMessage` (receiver ID `0x00`).
 
-The broadcast is lightweight - only the version header, not the full metadata. Recipients compare versions and fingerprints to decide whether to fetch the full metadata via gRPC.
+Header-only (lightweight). Recipients compare version+fingerprint to decide if a full fetch is needed.
 
-A periodic timer fires every ~30 seconds (with +/-25% jitter) via `MetadataManagerSendMetadataBroadcast` to ensure convergence even if point-to-point messages are lost. The timer is started on the first server cron tick after the first `FT.CREATE`.
+Periodic timer every ~30 s (±25% jitter) via `MetadataManagerSendMetadataBroadcast` ensures convergence under lost messages. Starts on first server cron after first `FT.CREATE`. `RegisterForClusterMessages` subscribes `MetadataManagerOnClusterMessageCallback` for message type `0x00`.
 
-Registration: `RegisterForClusterMessages` subscribes `MetadataManagerOnClusterMessageCallback` for message type `0x00`.
+## Reconciliation
 
-## Reconciliation Protocol
+`HandleBroadcastedMetadata`:
 
-When `HandleBroadcastedMetadata` receives a version header from a remote node:
+1. Skip if RDB/AOF loading.
+2. Skip if replica (primaries only).
+3. Proposed version `<` local -> ignore.
+4. Versions equal but fingerprints differ, OR proposed version higher -> fetch full via `GetGlobalMetadata` gRPC.
+5. `ReconcileMetadata` merges.
 
-1. **Skip if loading** - metadata updates are paused during RDB/AOF loading
-2. **Skip if replica** - only primaries process metadata broadcasts
-3. **Version check** - if the proposed version is less than local, ignore it
-4. **Fingerprint comparison** - if versions match but fingerprints differ, or if the proposed version is higher, fetch the full metadata via `GetGlobalMetadata` gRPC RPC from the sender
-5. **Merge** - `ReconcileMetadata` merges the remote metadata into the local copy
+`ReconcileMetadata` merge rules:
 
-The merge algorithm in `ReconcileMetadata`:
-- For each entry in the proposed metadata, compare with the existing entry
-- Skip if the proposed version is lower
-- At equal versions, prefer higher `encoding_version` (newer module features win)
-- At equal versions and encoding versions, use fingerprint as a tiebreaker (higher fingerprint wins)
-- Re-fingerprint entries if the encoding version is lower than the local version (unstable fingerprints across module versions)
-- Trigger registered callbacks for each accepted change
-- Call `CallFTInternalUpdateForReconciliation` to replicate accepted changes
-- Recompute the top-level fingerprint and version; broadcast if the fingerprint changed
+- Skip entries with lower proposed version.
+- Equal version -> prefer higher `encoding_version` (newer module features win).
+- Equal version + encoding -> fingerprint tiebreak (higher wins).
+- Re-fingerprint if proposed encoding_version < local (unstable fingerprints across versions).
+- Invoke registered callbacks per accepted change.
+- `CallFTInternalUpdateForReconciliation` replicates accepted changes.
+- Recompute top-level fingerprint + version; broadcast if fingerprint changed.
 
-Health tracking: `last_healthy_metadata_millis_` records the timestamp of the last successful reconciliation. `metadata_reconciliation_completed_count_` increments on each success.
+Health: `last_healthy_metadata_millis_`, `metadata_reconciliation_completed_count_`.
 
-## Staging During Replication
+## Replication staging
 
-During replica RDB loads, metadata is staged rather than applied immediately:
+- `OnReplicationLoadStart` -> `staging_metadata_due_to_repl_load_ = true`.
+- `LoadMetadata` writes to `staged_metadata_`.
+- `OnLoadingEnded` clears local metadata, reconciles from staged with `prefer_incoming=true, trigger_callbacks=false`, clears staged.
 
-- `OnReplicationLoadStart` sets `staging_metadata_due_to_repl_load_ = true`
-- `LoadMetadata` writes to `staged_metadata_` instead of `metadata_`
-- `OnLoadingEnded` clears the local metadata and reconciles from the staged copy with `prefer_incoming = true` and `trigger_callbacks = false`
-- After applying, the staged metadata is cleared
+Non-replication loads (restart): `LoadMetadata` merges directly into `metadata_` via `ReconcileMetadata`.
 
-Prevents partial metadata from being visible during the load and ensures the replica's metadata is a consistent snapshot from the primary.
+## `use-coordinator`
 
-For non-replication loads (e.g., restart from RDB), `LoadMetadata` merges directly into `metadata_` via `ReconcileMetadata`.
+Boolean, `options::GetUseCoordinator()`. Enabled -> `ValkeySearch::InitCoordinator` starts gRPC server, creates client pool, inits `MetadataManager`, registers for cluster messages + server cron. Disabled -> standalone or basic cluster without gRPC fanout.
 
-## use-coordinator Config
+## gRPC suspension (`GRPCSuspender` / `GRPCSuspensionGuard`)
 
-The `use-coordinator` boolean config (exposed via `options::GetUseCoordinator()`) controls whether the coordinator layer is active. When enabled, `ValkeySearch::InitCoordinator` starts the gRPC server, creates the client pool, initializes the `MetadataManager`, and registers for cluster messages and server cron events.
+Prevents gRPC callbacks from touching shared state during `fork()`.
 
-When disabled, the module operates in standalone or basic cluster mode without gRPC fanout. Search and info commands execute only against the local shard.
+- `Suspend()` - blocks until in-flight callbacks drain, prevents new ones.
+- `Resume()` - releases.
+- `GRPCSuspensionGuard` - RAII at the start of every gRPC callback (incr on ctor, decr on dtor).
 
-## gRPC Suspension Guard
-
-`GRPCSuspender` and `GRPCSuspensionGuard` prevent gRPC callbacks from accessing shared mutexes during `fork()` (used by Valkey for BGSAVE/BGREWRITEAOF).
-
-- `GRPCSuspender::Suspend()` - blocks until all in-flight gRPC callbacks complete, then prevents new ones from starting
-- `GRPCSuspender::Resume()` - releases suspended callbacks
-- `GRPCSuspensionGuard` - RAII guard acquired at the start of every gRPC callback; increments count on construction, decrements on destruction
-
-The suspender uses `absl::Mutex` with two condition variables: one for waiting until in-flight tasks drain, another for blocked callbacks waiting to resume. The singleton uses `absl::NoDestructor` to avoid destruction races with gRPC event engine threads at process exit.
+Impl: `absl::Mutex` + two condition variables (drain wait, resume wait). Singleton via `absl::NoDestructor` to avoid destruction races with gRPC event engine threads at process exit.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-coordinator.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-coordinator.md
@@ -65,7 +65,7 @@ Timeouts:
 | RPC | Timeout | Source |
 |-----|---------|--------|
 | `GetGlobalMetadata` | 60 s | fixed |
-| `SearchIndexPartition` | `coordinator-query-timeout-secs` (default 25, 1-3600) | config |
+| `SearchIndexPartition` | `coordinator-query-timeout-secs` (default 120, 1-3600) | config |
 | `InfoIndexPartition` | `ft-info-rpc-timeout-ms` (default 2500) | config |
 
 All async. Each allocates a heap struct for context/request/response/callback/latency sample. Callback fires on a gRPC background thread -> `GRPCSuspensionGuard` -> user callback -> metrics + latency sample. Bytes tracked in `coordinator_bytes_in` / `_out`.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-metrics.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-metrics.md
@@ -74,7 +74,7 @@ Metrics::GetStats().some_counter++;
 
 ## Latency samplers
 
-`vmsdk::LatencySampler` - HdrHistogram style (1 ns .. 1 s, precision 2 -> ~40 KiB, ~1% error). Submit via `SAMPLE_EVERY_N(100)` which creates a `StopWatch` recording every 100th call. Success / failure tracked separately.
+`vmsdk::LatencySampler` (`vmsdk/src/latency_sampler.h`) - wraps `hdr_histogram` with range 1 ns to 1 s, `LATENCY_PRECISION = 2` (two significant figures, ~1% relative error). **Lazily allocated** - no memory until the first sample is submitted. Submit via `SAMPLE_EVERY_N(100)` - a thread-local counter yields a `StopWatch` once per N calls (zero-indexed), destructor records on destruction. Success / failure tracked separately.
 
 - `hnsw_vector_index_search_latency`
 - `flat_vector_index_search_latency`

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-metrics.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-metrics.md
@@ -1,212 +1,168 @@
-# Metrics, FT.INFO, and FT._DEBUG
+# Metrics, FT.INFO, FT._DEBUG
 
-Use when working on observability, understanding the metrics system, implementing FT.INFO cluster fanout, using FT._DEBUG for diagnostics, or adding new metrics counters.
+Use when reasoning about observability, the `Metrics` singleton, FT.INFO fanout, or FT._DEBUG diagnostics.
 
-Source: `src/metrics.h`, `src/commands/ft_info.cc`, `src/commands/ft_info_parser.h`, `src/commands/ft_debug.cc`
+Source: `src/metrics.h`, `src/commands/ft_info.{cc,_parser.h}`, `src/commands/ft_debug.cc`.
 
-## Contents
+## `Metrics` singleton
 
-- Metrics Singleton (line 19)
-- Counter Categories (line 29)
-- Latency Samplers (line 87)
-- RDB Restore Progress (line 107)
-- FT.INFO Command (line 119)
-- FT.INFO Scopes and Fanout (line 138)
-- InfoIndexPartition Response (line 154)
-- FT._DEBUG Command (line 180)
-- FT._DEBUG Subcommands (line 184)
-
-## Metrics Singleton
-
-`Metrics` is a singleton class with a nested `Stats` struct holding all counters and latency samplers. Access is via:
+Meyers pattern (`static Metrics instance` in `GetInstance()`). Nested `Stats` struct holds counters and samplers. Access:
 
 ```cpp
 Metrics::GetStats().some_counter++;
 ```
 
-The singleton uses the Meyers pattern (`static Metrics instance` in `GetInstance()`). The `Stats` struct is mutable, allowing modification through the const singleton reference. This is safe because individual counters use `std::atomic` for thread-safe access from background threads, while non-atomic counters are accessed only from the main thread.
+`Stats` is mutable on the const singleton reference. Per-counter thread safety: atomics for background-thread counters; non-atomic counters are main-thread-only.
 
-## Counter Categories
+## Counter groups
 
-### Query Counters (main thread unless noted)
-- `query_successful_requests_cnt` / `query_failed_requests_cnt` - total query outcomes
-- `query_result_record_dropped_cnt` - records dropped during query processing
-- `query_hybrid_requests_cnt` - hybrid (vector + filter) queries
-- `query_nonvector_requests_cnt` (atomic) - pure non-vector queries
-- `query_vector_requests_cnt` (atomic) - pure vector queries
-- `query_text_requests_cnt` (atomic) - full-text queries
-- `query_inline_filtering_requests_cnt` (atomic) - inline filter path
-- `query_prefiltering_requests_cnt` (atomic) - prefilter path
+### Query (main thread unless noted)
 
-### Index Exception Counters (all atomic)
-HNSW: `hnsw_add_exceptions_cnt`, `hnsw_remove_exceptions_cnt`, `hnsw_modify_exceptions_cnt`, `hnsw_search_exceptions_cnt`, `hnsw_create_exceptions_cnt`
+- `query_successful_requests_cnt`, `query_failed_requests_cnt`
+- `query_result_record_dropped_cnt`
+- `query_hybrid_requests_cnt`
+- `query_nonvector_requests_cnt`, `query_vector_requests_cnt`, `query_text_requests_cnt` (atomic)
+- `query_inline_filtering_requests_cnt`, `query_prefiltering_requests_cnt` (atomic)
 
-FLAT: `flat_add_exceptions_cnt`, `flat_remove_exceptions_cnt`, `flat_modify_exceptions_cnt`, `flat_search_exceptions_cnt`, `flat_create_exceptions_cnt`
+### Index exceptions (atomic)
 
-### Thread Pool Counters (all atomic)
-- `worker_thread_pool_suspend_cnt` - total suspensions (fork protection)
-- `writer_worker_thread_pool_resumed_cnt` / `reader_worker_thread_pool_resumed_cnt`
-- `writer_worker_thread_pool_suspension_expired_cnt`
+- HNSW: `hnsw_{add,remove,modify,search,create}_exceptions_cnt`
+- FLAT: `flat_{add,remove,modify,search,create}_exceptions_cnt`
 
-### RDB Counters (main thread)
-- `rdb_load_success_cnt` / `rdb_load_failure_cnt`
-- `rdb_save_success_cnt` / `rdb_save_failure_cnt`
+### Thread pool (atomic)
 
-### Coordinator Counters (all atomic)
-Server-side: `coordinator_server_get_global_metadata_success_cnt` / `_failure_cnt`, `coordinator_server_search_index_partition_success_cnt` / `_failure_cnt`
+`worker_thread_pool_suspend_cnt`, `writer_worker_thread_pool_resumed_cnt`, `reader_worker_thread_pool_resumed_cnt`, `writer_worker_thread_pool_suspension_expired_cnt`.
 
-Client-side: `coordinator_client_get_global_metadata_success_cnt` / `_failure_cnt`, `coordinator_client_search_index_partition_success_cnt` / `_failure_cnt`
+### RDB (main thread)
 
-Bandwidth: `coordinator_bytes_out`, `coordinator_bytes_in`
+`rdb_{load,save}_{success,failure}_cnt`.
 
-### FT.INTERNAL_UPDATE Counters (all atomic)
-- `ft_internal_update_parse_failures_cnt` - protobuf deserialization failures
-- `ft_internal_update_process_failures_cnt` - CreateEntryOnReplica failures
-- `ft_internal_update_call_failures_cnt` - ValkeyModule_Call failures
-- `process_internal_update_callback_failures_cnt` - callback invocation failures
-- `ft_internal_update_skipped_entries_cnt` - corrupted entries skipped during AOF load
+### Coordinator (atomic)
 
-### Ingestion Counters (all atomic)
-- `ingest_hash_keys` / `backfill_hash_keys` - HASH key ingestion
-- `ingest_json_keys` / `backfill_json_keys` - JSON key ingestion
-- `ingest_field_vector` / `ingest_field_numeric` / `ingest_field_tag` / `ingest_field_text` - per-field-type counts
-- `ingest_last_batch_size` / `ingest_total_batches` / `ingest_total_failures`
+Server: `coordinator_server_{get_global_metadata,search_index_partition}_{success,failure}_cnt`.
+Client: `coordinator_client_{get_global_metadata,search_index_partition}_{success,failure}_cnt`.
+Bytes: `coordinator_bytes_{out,in}`.
 
-### Time Slice Mutex Counters (all atomic)
-- `time_slice_read_periods` / `time_slice_read_time` (microseconds)
-- `time_slice_queries`
-- `time_slice_write_periods` / `time_slice_write_time` (microseconds)
-- `time_slice_upserts` / `time_slice_deletes`
+### FT.INTERNAL_UPDATE (atomic)
 
-### Miscellaneous (all atomic)
-- `info_fanout_retry_cnt` / `info_fanout_fail_cnt`
-- `pause_handle_cluster_message_round_cnt`
-- `text_query_blocked_cnt` / `text_query_retry_cnt`
-- `reclaimable_memory` (main thread)
+`ft_internal_update_{parse,process,call}_failures_cnt`, `process_internal_update_callback_failures_cnt`, `ft_internal_update_skipped_entries_cnt`.
 
-## Latency Samplers
+### Ingestion (atomic)
 
-Latency samplers use `vmsdk::LatencySampler` with HdrHistogram-style recording (1 nanosecond to 1 second range, precision 2 - correlating to ~40KiB memory and ~1% error).
+`ingest_hash_keys`, `backfill_hash_keys`, `ingest_json_keys`, `backfill_json_keys`, `ingest_field_{vector,numeric,tag,text}`, `ingest_last_batch_size`, `ingest_total_batches`, `ingest_total_failures`.
 
-Samplers are submitted via `SAMPLE_EVERY_N(100)` which creates a `StopWatch` that records every 100th call. Each sampler tracks percentiles internally.
+### Time-slice mutex (atomic)
 
-Index search latency:
+`time_slice_read_periods`, `time_slice_read_time` (us), `time_slice_queries`, `time_slice_write_periods`, `time_slice_write_time` (us), `time_slice_upserts`, `time_slice_deletes`.
+
+### Misc (atomic)
+
+`info_fanout_{retry,fail}_cnt`, `pause_handle_cluster_message_round_cnt`, `text_query_{blocked,retry}_cnt`, `reclaimable_memory` (main thread).
+
+## Latency samplers
+
+`vmsdk::LatencySampler` - HdrHistogram style (1 ns .. 1 s, precision 2 -> ~40 KiB, ~1% error). Submit via `SAMPLE_EVERY_N(100)` which creates a `StopWatch` recording every 100th call. Success / failure tracked separately.
+
 - `hnsw_vector_index_search_latency`
 - `flat_vector_index_search_latency`
+- Coordinator client: `{get_global_metadata,search_index_partition}_{success,failure}_latency` (4 samplers)
+- Coordinator server: `{get_global_metadata,search_index_partition}_{success,failure}_latency` (4 samplers)
 
-Coordinator client latency (4 samplers):
-- `coordinator_client_get_global_metadata_success_latency` / `_failure_latency`
-- `coordinator_client_search_index_partition_success_latency` / `_failure_latency`
+## RDB restore progress (atomic)
 
-Coordinator server latency (4 samplers):
-- `coordinator_server_get_global_metadata_success_latency` / `_failure_latency`
-- `coordinator_server_search_index_partition_success_latency` / `_failure_latency`
+- `rdb_restore_in_progress` (bool)
+- `rdb_restore_total_indexes`, `rdb_restore_completed_indexes`
+- `rdb_restore_current_index_keys_total`, `_loaded`
+- `rdb_restore_backpressure_wait_cycles`
 
-Success and failure latencies are tracked separately to distinguish healthy request times from error-path times.
+Set at `PerformRDBLoad` start, cleared on completion.
 
-## RDB Restore Progress
+## FT.INFO
 
-Atomic progress counters enable monitoring of RDB load progress:
-
-- `rdb_restore_in_progress` (atomic bool) - true during `PerformRDBLoad`
-- `rdb_restore_total_indexes` - total section count from RDB header
-- `rdb_restore_completed_indexes` - incremented per completed section
-- `rdb_restore_current_index_keys_total` / `rdb_restore_current_index_keys_loaded` - per-index key progress
-- `rdb_restore_backpressure_wait_cycles` - backpressure events during restore
-
-These counters are set at the start of `PerformRDBLoad` and cleared when loading completes. They allow external monitoring tools (and FT.INFO) to report restore progress.
-
-## FT.INFO Command
-
-`FTInfoCmd` in `ft_info.cc` parses the command via `InfoCommand::ParseCommand` and executes via `InfoCommand::Execute`.
-
-The `InfoCommand` struct (`ft_info_parser.h`):
+`FTInfoCmd` -> `InfoCommand::ParseCommand` -> `InfoCommand::Execute`.
 
 ```cpp
 struct InfoCommand {
   std::shared_ptr<IndexSchema> index_schema;
   std::string index_schema_name;
   InfoScope scope{InfoScope::kLocal};
-  bool enable_partial_results;  // default from config
-  bool require_consistency;     // default from config
+  bool enable_partial_results;  // config default
+  bool require_consistency;     // config default
   uint32_t timeout_ms{0};
 };
 ```
 
-The command supports at minimum `FT.INFO <index_name>`. Additional options control scope, consistency, and timeouts.
+Minimum syntax: `FT.INFO <index>`.
 
-## FT.INFO Scopes and Fanout
+### Scopes
 
-Three scopes defined in `InfoScope`:
+- **`kLocal`** - local shard only.
+- **`kPrimary`** - fan out to all primaries.
+- **`kCluster`** - fan out to all cluster nodes.
 
-- **kLocal** - query only the local shard's IndexSchema
-- **kPrimary** - fan out to all primary nodes (cluster mode)
-- **kCluster** - fan out to all cluster nodes
+Cluster-mode fanout uses gRPC `InfoIndexPartition` RPCs. Fanout ops in `src/query/cluster_info_fanout_operation.h` + `src/query/primary_info_fanout_operation.h`.
 
-In cluster mode, `FT.INFO` fans out via gRPC `InfoIndexPartition` RPCs. The response aggregates data from all shards. Fanout operations are implemented in `src/query/cluster_info_fanout_operation.h` and `src/query/primary_info_fanout_operation.h`.
+### Timeouts
 
-Configurable timeouts:
-- `ft-info-timeout-ms` - overall FT.INFO timeout (default 5000ms, range 100-300000ms)
-- `ft-info-rpc-timeout-ms` - per-RPC timeout (default 2500ms, range 100-300000ms)
+| Config | Default | Range |
+|--------|---------|-------|
+| `ft-info-timeout-ms` | 5000 | 100-300000 |
+| `ft-info-rpc-timeout-ms` | 2500 | 100-300000 |
 
-Fanout error handling is tracked via `info_fanout_retry_cnt` and `info_fanout_fail_cnt` in Metrics.
+Errors -> `info_fanout_{retry,fail}_cnt`.
 
-## InfoIndexPartition Response
+## `InfoIndexPartitionResponse` (gRPC)
 
-The gRPC `InfoIndexPartitionResponse` carries per-shard data:
+| Field | Type | Meaning |
+|-------|------|---------|
+| `exists` | bool | index on this shard |
+| `index_name` | string | |
+| `db_num` | uint32 | |
+| `num_docs` | uint64 | document count |
+| `num_records` | uint64 | index records across attributes |
+| `hash_indexing_failures` | uint64 | keys that failed indexing |
+| `backfill_scanned_count` | uint64 | |
+| `backfill_db_size` | uint64 | |
+| `backfill_inqueue_tasks` | uint64 | |
+| `backfill_complete_percent` | float | |
+| `backfill_in_progress` | bool | |
+| `mutation_queue_size` | uint64 | |
+| `recent_mutations_queue_delay` | uint64 | |
+| `state` | string | |
+| `error` | string | |
+| `error_type` | `FanoutErrorType` | |
+| `attributes` | repeated `AttributeInfo` | identifier, alias, `user_indexed_memory`, `num_records` |
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `exists` | bool | Whether the index exists on this shard |
-| `index_name` | string | Index name |
-| `db_num` | uint32 | Database number |
-| `num_docs` | uint64 | Document count |
-| `num_records` | uint64 | Total index records across all attributes |
-| `hash_indexing_failures` | uint64 | Keys that failed indexing |
-| `backfill_scanned_count` | uint64 | Keys scanned during backfill |
-| `backfill_db_size` | uint64 | Total DB size for backfill |
-| `backfill_inqueue_tasks` | uint64 | Pending backfill tasks |
-| `backfill_complete_percent` | float | Backfill completion percentage |
-| `backfill_in_progress` | bool | Whether backfill is active |
-| `mutation_queue_size` | uint64 | Pending mutations |
-| `recent_mutations_queue_delay` | uint64 | Queue processing delay |
-| `state` | string | Index state |
-| `error` | string | Error description if any |
-| `error_type` | FanoutErrorType | Error classification |
-| `attributes` | repeated AttributeInfo | Per-attribute details |
+## FT._DEBUG
 
-Each `AttributeInfo` contains identifier, alias, `user_indexed_memory`, and `num_records`.
+Debug-only, gated by `vmsdk::config::IsDebugModeEnabled()`. Debug off -> replies "ERR unknown command" (appears non-existent). All args logged at WARNING.
 
-## FT._DEBUG Command
+| Subcommand | Notes |
+|------------|-------|
+| `SHOW_INFO` | dump info variable metadata |
+| `CONTROLLED_VARIABLE SET/GET/LIST` | test control variables |
+| `PAUSEPOINT SET/RESET/TEST/LIST` | thread pausing for tests |
+| `TEXTINFO <index> ...` | schema-level text index info |
+| `STRINGPOOLSTATS` | string interning pool stats |
+| `SHOW_METADATA` | `MetadataManager` table |
+| `SHOW_INDEXSCHEMAS` | IndexSchema tables |
+| `LIST_METRICS [APP\|DEV] [NAMES_ONLY]` | |
+| `LIST_CONFIGS [VERBOSE] [APP\|DEV\|HIDDEN]` | |
+| `HELP` | |
 
-`FTDebugCmd` is a debug-only command gated by `vmsdk::config::IsDebugModeEnabled()`. When debug mode is off, it replies with "ERR unknown command" to appear non-existent. All arguments are logged at WARNING level.
+### Pausepoints
 
-## FT._DEBUG Subcommands
+`vmsdk::debug::PausePoint("label")` at strategic locations. If SET, the calling thread blocks. Tests: TEST polls until threads are paused, RESET releases. **Never use on main thread or while holding locks.**
 
-| Subcommand | Syntax | Description |
-|------------|--------|-------------|
-| `SHOW_INFO` | `FT._DEBUG SHOW_INFO` | Dump info variable metadata |
-| `CONTROLLED_VARIABLE SET` | `FT._DEBUG CONTROLLED_VARIABLE SET <name> <value>` | Set a test control variable |
-| `CONTROLLED_VARIABLE GET` | `FT._DEBUG CONTROLLED_VARIABLE GET <name>` | Get a test control variable |
-| `CONTROLLED_VARIABLE LIST` | `FT._DEBUG CONTROLLED_VARIABLE LIST` | List all controlled variables |
-| `PAUSEPOINT SET` | `FT._DEBUG PAUSEPOINT SET <name>` | Enable a named pausepoint |
-| `PAUSEPOINT RESET` | `FT._DEBUG PAUSEPOINT RESET <name>` | Release threads paused at this point |
-| `PAUSEPOINT TEST` | `FT._DEBUG PAUSEPOINT TEST <name>` | Return count of threads waiting |
-| `PAUSEPOINT LIST` | `FT._DEBUG PAUSEPOINT LIST` | List all pausepoints |
-| `TEXTINFO` | `FT._DEBUG TEXTINFO <index> ...` | Schema-level text index info |
-| `STRINGPOOLSTATS` | `FT._DEBUG STRINGPOOLSTATS` | String interning pool statistics |
-| `SHOW_METADATA` | `FT._DEBUG SHOW_METADATA` | Dump MetadataManager table |
-| `SHOW_INDEXSCHEMAS` | `FT._DEBUG SHOW_INDEXSCHEMAS` | Dump IndexSchema tables |
-| `LIST_METRICS` | `FT._DEBUG LIST_METRICS [APP\|DEV] [NAMES_ONLY]` | List app or dev metrics |
-| `LIST_CONFIGS` | `FT._DEBUG LIST_CONFIGS [VERBOSE] [APP\|DEV\|HIDDEN]` | List config entries |
-| `HELP` | `FT._DEBUG HELP` | Show available subcommands |
+### Controlled variables
 
-**Pausepoints** are a testing mechanism. Background threads call `vmsdk::debug::PausePoint("label")` at strategic locations. If a pausepoint is SET, the calling thread blocks. Tests use TEST to poll until threads are paused, then RESET to release them. Pausepoints must not be used on the main thread or while holding locks.
+`CONTROLLED_BOOLEAN`, `CONTROLLED_SIZE_T` - debug-only, not replicated. Examples (coordinator): `ForceRemoteFailCount` (forces gRPC failures), `ForceIndexNotFoundError`, `PauseHandleClusterMessage`.
 
-**Controlled Variables** (`CONTROLLED_BOOLEAN`, `CONTROLLED_SIZE_T`) are debug-only config values used in test code. Examples in the coordinator: `ForceRemoteFailCount` forces gRPC failures, `ForceIndexNotFoundError` simulates missing indexes, `PauseHandleClusterMessage` delays cluster message processing. These are not replicated.
+### `STRINGPOOLSTATS`
 
-**STRINGPOOLSTATS** returns 4 arrays: inline string stats, out-of-line string stats, by-refcount histogram, and by-size histogram. Each bucket reports Count, Bytes, AvgSize, Allocated, AvgAllocated, and Utilization percentage. Results are also logged at NOTICE level.
+Four arrays: inline-string stats, out-of-line stats, by-refcount histogram, by-size histogram. Each bucket: Count, Bytes, AvgSize, Allocated, AvgAllocated, Utilization%. Also logged at NOTICE.
 
-**LIST_METRICS** distinguishes APP (user-facing) and DEV (internal) metrics. The optional NAMES_ONLY flag returns only metric names without values.
+### `LIST_METRICS` / `LIST_CONFIGS`
 
-**LIST_CONFIGS** supports VERBOSE mode (detailed metadata per config) and filtering by APP, DEV, or HIDDEN visibility categories.
+- LIST_METRICS: APP vs DEV. `NAMES_ONLY` for names without values.
+- LIST_CONFIGS: `VERBOSE` for detailed metadata, filters on APP / DEV / HIDDEN.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-metrics.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-metrics.md
@@ -18,46 +18,59 @@ Metrics::GetStats().some_counter++;
 
 ### Query (main thread unless noted)
 
-- `query_successful_requests_cnt`, `query_failed_requests_cnt`
-- `query_result_record_dropped_cnt`
-- `query_hybrid_requests_cnt`
-- `query_nonvector_requests_cnt`, `query_vector_requests_cnt`, `query_text_requests_cnt` (atomic)
-- `query_inline_filtering_requests_cnt`, `query_prefiltering_requests_cnt` (atomic)
+- `query_{successful,failed}_requests_cnt` - overall query outcomes
+- `query_result_record_dropped_cnt` - records dropped during processing
+- `query_hybrid_requests_cnt` - hybrid (vector + filter) queries
+- `query_{nonvector,vector,text}_requests_cnt` (atomic) - per query-type
+- `query_{inline_filtering,prefiltering}_requests_cnt` (atomic) - planner path taken
 
-### Index exceptions (atomic)
+### Index exceptions (atomic - caught hnswlib exceptions)
 
 - HNSW: `hnsw_{add,remove,modify,search,create}_exceptions_cnt`
 - FLAT: `flat_{add,remove,modify,search,create}_exceptions_cnt`
 
 ### Thread pool (atomic)
 
-`worker_thread_pool_suspend_cnt`, `writer_worker_thread_pool_resumed_cnt`, `reader_worker_thread_pool_resumed_cnt`, `writer_worker_thread_pool_suspension_expired_cnt`.
+- `worker_thread_pool_suspend_cnt` - total fork-triggered suspensions
+- `{writer,reader}_worker_thread_pool_resumed_cnt` - total resumes after suspension
+- `writer_worker_thread_pool_suspension_expired_cnt` - writer resumes due to `max-worker-suspension-secs` timeout (vs child-died signal)
 
 ### RDB (main thread)
 
-`rdb_{load,save}_{success,failure}_cnt`.
+`rdb_{load,save}_{success,failure}_cnt` - aux-load and aux-save outcomes.
 
 ### Coordinator (atomic)
 
-Server: `coordinator_server_{get_global_metadata,search_index_partition}_{success,failure}_cnt`.
-Client: `coordinator_client_{get_global_metadata,search_index_partition}_{success,failure}_cnt`.
-Bytes: `coordinator_bytes_{out,in}`.
+- `coordinator_server_{get_global_metadata,search_index_partition}_{success,failure}_cnt` - server-side RPC outcomes
+- `coordinator_client_{get_global_metadata,search_index_partition}_{success,failure}_cnt` - client-side RPC outcomes
+- `coordinator_bytes_{out,in}` - request/response bytes across all RPCs
 
 ### FT.INTERNAL_UPDATE (atomic)
 
-`ft_internal_update_{parse,process,call}_failures_cnt`, `process_internal_update_callback_failures_cnt`, `ft_internal_update_skipped_entries_cnt`.
+- `ft_internal_update_parse_failures_cnt` - proto deserialization failed
+- `ft_internal_update_process_failures_cnt` - `CreateEntryOnReplica` failed
+- `ft_internal_update_call_failures_cnt` - `ValkeyModule_Call` failed
+- `process_internal_update_callback_failures_cnt` - registered callback failed
+- `ft_internal_update_skipped_entries_cnt` - corrupted entries skipped during AOF load (gated by `skip-corrupted-internal-update-entries`)
 
 ### Ingestion (atomic)
 
-`ingest_hash_keys`, `backfill_hash_keys`, `ingest_json_keys`, `backfill_json_keys`, `ingest_field_{vector,numeric,tag,text}`, `ingest_last_batch_size`, `ingest_total_batches`, `ingest_total_failures`.
+- `{ingest,backfill}_{hash,json}_keys` - key ingestion counts by source and data type
+- `ingest_field_{vector,numeric,tag,text}` - per-field-type counts
+- `ingest_last_batch_size`, `ingest_total_batches`, `ingest_total_failures` - batch-level metrics
 
 ### Time-slice mutex (atomic)
 
-`time_slice_read_periods`, `time_slice_read_time` (us), `time_slice_queries`, `time_slice_write_periods`, `time_slice_write_time` (us), `time_slice_upserts`, `time_slice_deletes`.
+- `time_slice_{read,write}_periods` - number of phase activations
+- `time_slice_{read,write}_time` (us) - total time in each phase
+- `time_slice_queries`, `time_slice_upserts`, `time_slice_deletes` - operation counts per phase
 
 ### Misc (atomic)
 
-`info_fanout_{retry,fail}_cnt`, `pause_handle_cluster_message_round_cnt`, `text_query_{blocked,retry}_cnt`, `reclaimable_memory` (main thread).
+- `info_fanout_{retry,fail}_cnt` - cluster FT.INFO fanout outcomes
+- `pause_handle_cluster_message_round_cnt` - cluster-bus message pauses (test hook)
+- `text_query_{blocked,retry}_cnt` - text-query contention events
+- `reclaimable_memory` (main thread) - memory recoverable by GC
 
 ## Latency samplers
 

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-replication.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/cluster-replication.md
@@ -1,38 +1,22 @@
-# RDB Serialization and Replication
+# RDB serialization and replication
 
-Use when working on RDB persistence, snapshot serialization, the protobuf-based RDB format, AOF replication of metadata, or the FT.INTERNAL_UPDATE command.
+Use when reasoning about RDB format, `SafeRDB`, chunked vector data, the module type registration, or `FT.INTERNAL_UPDATE`.
 
-Source: `src/rdb_serialization.h`, `src/rdb_serialization.cc`, `src/rdb_section.proto`, `src/commands/ft_internal_update.cc`, `src/coordinator/metadata_manager.cc`
+Source: `src/rdb_serialization.{h,cc}`, `src/rdb_section.proto`, `src/commands/ft_internal_update.cc`, `src/coordinator/metadata_manager.cc`.
 
-## Contents
+## Format
 
-- RDB Format Overview (line 21)
-- RDB Section Types (line 33)
-- Supplemental Content (line 62)
-- SafeRDB Wrapper (line 78)
-- Iterator Classes (line 101)
-- Chunk Streaming (line 124)
-- RDB Load Path (line 138)
-- RDB Save Path (line 170)
-- Module Type Registration (line 184)
-- FT.INTERNAL_UPDATE Command (line 201)
-- Staging During Replication Loads (line 225)
+Protobuf-based RDB aux section format.
 
-## RDB Format Overview
+1. **Header**: encoding version check + semantic version (unsigned) + section count (unsigned).
+2. **RDBSection sequence**: serialized protobuf string per section.
+3. **Supplemental content**: optional chunked binary data after each section.
 
-valkey-search uses a protobuf-based RDB aux section format. The format structure:
+Encoding version at load time is `kCurrentEncVer = 1`. Semantic version tracks the minimum module version needed to read. Newer-than-local -> version mismatch error.
 
-1. **Header**: encoding version check + semantic version (unsigned int) + section count (unsigned int)
-2. **RDBSection sequence**: each section is a serialized protobuf string
-3. **Supplemental content**: optional chunked binary data following each section
+Module type name is `"Vk-Search"` (9 chars, Valkey max).
 
-The encoding version is checked at load time (`kCurrentEncVer = 1`). The semantic version tracks the minimum module version needed to read the RDB. If the RDB was written by a newer module, loading fails with a version mismatch error.
-
-The module type name is `"Vk-Search"` (9 chars, matching Valkey's module type name length requirement).
-
-## RDB Section Types
-
-Defined in `rdb_section.proto`:
+## Section types (`rdb_section.proto`)
 
 ```protobuf
 enum RDBSectionType {
@@ -40,196 +24,174 @@ enum RDBSectionType {
   RDB_SECTION_INDEX_SCHEMA = 1;
   RDB_SECTION_GLOBAL_METADATA = 2;
 }
-```
 
-**RDB_SECTION_INDEX_SCHEMA** - Contains an `IndexSchema` protobuf with the full schema definition and attribute list. Each `FT.CREATE` index produces one section. Supplemental content carries the actual index data (index content, key-to-ID mappings, and optionally the mutation queue in V2 format).
-
-**RDB_SECTION_GLOBAL_METADATA** - Contains the `coordinator.GlobalMetadata` protobuf with the cluster-wide metadata tree. At most one section of this type exists per RDB.
-
-The `RDBSection` message wraps these:
-
-```protobuf
 message RDBSection {
   RDBSectionType type = 1;
   uint32 supplemental_count = 2;
   oneof contents {
-    IndexSchema index_schema_contents = 3;
-    coordinator.GlobalMetadata global_metadata_contents = 4;
+    IndexSchema                 index_schema_contents   = 3;
+    coordinator.GlobalMetadata  global_metadata_contents = 4;
   }
 }
 ```
 
-## Supplemental Content
+- **INDEX_SCHEMA** - one per FT.CREATE. Supplemental carries index data (contents, key-to-ID, optionally V2 mutation queue).
+- **GLOBAL_METADATA** - at most one, cluster-wide metadata tree.
 
-Supplemental content provides chunked binary data without requiring full in-memory serialization. Each section declares its `supplemental_count`. Three types exist:
+## Supplemental content
 
 ```protobuf
 enum SupplementalContentType {
-  SUPPLEMENTAL_CONTENT_INDEX_CONTENT = 1;
-  SUPPLEMENTAL_CONTENT_KEY_TO_ID_MAP = 2;
-  SUPPLEMENTAL_CONTENT_INDEX_EXTENSION = 3;
+  SUPPLEMENTAL_CONTENT_INDEX_CONTENT    = 1;
+  SUPPLEMENTAL_CONTENT_KEY_TO_ID_MAP    = 2;
+  SUPPLEMENTAL_CONTENT_INDEX_EXTENSION  = 3;
 }
 ```
 
-Each supplemental section starts with a `SupplementalContentHeader` identifying the type and associated attribute. The data follows as a sequence of `SupplementalContentChunk` messages. An empty chunk (no `binary_content` field) signals EOF for that supplemental section.
+Each supplemental begins with a `SupplementalContentHeader` (type + associated attribute), followed by `SupplementalContentChunk` messages. Empty chunk (no `binary_content`) = EOF for that supplemental.
 
-`MutationQueueHeader` (V2) carries a `backfilling` flag for the saved mutation queue state.
+`MutationQueueHeader` (V2) carries a `backfilling` flag for saved mutation state.
 
-## SafeRDB Wrapper
+## `SafeRDB`
 
-`SafeRDB` wraps `ValkeyModuleIO*` and converts raw Valkey I/O operations into `absl::StatusOr` results, forcing error handling at every call site:
+Wraps `ValkeyModuleIO*`, returns `absl::StatusOr` so every call-site must handle errors.
 
 ```cpp
 class SafeRDB {
- public:
   explicit SafeRDB(ValkeyModuleIO *rdb);
-  virtual absl::StatusOr<size_t> LoadSizeT();
-  virtual absl::StatusOr<unsigned int> LoadUnsigned();
-  virtual absl::StatusOr<int> LoadSigned();
-  virtual absl::StatusOr<double> LoadDouble();
+  virtual absl::StatusOr<size_t>                   LoadSizeT();
+  virtual absl::StatusOr<unsigned int>             LoadUnsigned();
+  virtual absl::StatusOr<int>                      LoadSigned();
+  virtual absl::StatusOr<double>                   LoadDouble();
   virtual absl::StatusOr<vmsdk::UniqueValkeyString> LoadString();
-  virtual absl::Status SaveSizeT(size_t val);
-  virtual absl::Status SaveUnsigned(unsigned int val);
-  virtual absl::Status SaveSigned(int val);
-  virtual absl::Status SaveDouble(double val);
-  virtual absl::Status SaveStringBuffer(absl::string_view buf);
+  virtual absl::Status SaveSizeT       (size_t);
+  virtual absl::Status SaveUnsigned    (unsigned int);
+  virtual absl::Status SaveSigned      (int);
+  virtual absl::Status SaveDouble      (double);
+  virtual absl::Status SaveStringBuffer(absl::string_view);
 };
 ```
 
-Each method calls the underlying `ValkeyModule_Load*` or `ValkeyModule_Save*` function, then checks `ValkeyModule_IsIOError`. On error, it returns `absl::InternalError` with a descriptive message. The virtual methods allow test mocking.
+Each method calls the raw `ValkeyModule_Load*` / `Save*`, checks `ValkeyModule_IsIOError`, returns `absl::InternalError` on fail. Virtual -> test mocking.
 
-## Iterator Classes
+## Iterators
 
-Three nested iterator classes enforce strict consumption of the RDB stream:
+Three nested iterators enforce strict stream consumption. All move-only (deleted copy). Destructors warn / debug-assert if not consumed.
 
-**RDBSectionIter** - Iterates over sections. After calling `Next()`, the caller must call `IterateSupplementalContent()` and fully consume the returned iterator before calling `Next()` again. Destructor asserts `remaining_ == 0`.
+- **`RDBSectionIter`** - iterates sections. After `Next()`, caller MUST call `IterateSupplementalContent()` and fully drain before the next `Next()`. Dtor asserts `remaining_ == 0`.
+- **`SupplementalContentIter`** - iterates supplementals for one section. After `Next()` (header), caller MUST drain via `IterateChunks()`. Dtor asserts.
+- **`SupplementalContentChunkIter`** - iterates chunks. Buffers one ahead so `HasNext()` is accurate. Empty chunk = EOF. Dtor warns.
 
-**SupplementalContentIter** - Iterates over supplemental content for one section. After `Next()` returns the header, the caller must call `IterateChunks()` and fully consume the chunk iterator. Destructor asserts `remaining_ == 0`.
-
-**SupplementalContentChunkIter** - Iterates over binary chunks. Buffers one chunk ahead so `HasNext()` is accurate. An empty chunk signals EOF. Destructor warns if not fully consumed.
-
-All iterators are move-only (deleted copy constructors). The destructors log warnings and fire debug assertions if the stream was not fully consumed - this catches programming errors where supplemental data is accidentally skipped.
-
-For unknown section types, `PerformRDBLoad` manually drains all supplemental content:
+Unknown section types - manually drain:
 
 ```cpp
-auto supp_it = it.IterateSupplementalContent();
-while (supp_it.HasNext()) {
-  auto _ = supp_it.Next();
-  auto chunk_it = supp_it.IterateChunks();
-  while (chunk_it.HasNext()) { auto _ = chunk_it.Next(); }
+auto supp = it.IterateSupplementalContent();
+while (supp.HasNext()) {
+  (void)supp.Next();
+  auto chunk = supp.IterateChunks();
+  while (chunk.HasNext()) (void)chunk.Next();
 }
 ```
 
-## Chunk Streaming
+## Chunk streams
 
-Two adapter classes bridge the RDB chunk format to the `hnswlib::InputStream`/`OutputStream` interfaces used by vector indexes:
+Bridge between RDB chunks and `hnswlib::InputStream` / `OutputStream` for vector index save/load.
 
-**RDBChunkInputStream** - Wraps `SupplementalContentChunkIter`. `LoadChunk()` returns each chunk's `binary_content` as a `unique_ptr<string>`. Provides convenience methods:
-- `LoadString()` - loads a chunk and returns its content as a string
-- `LoadObject<T>()` - loads a chunk and reinterprets it as a trivially-copyable type T, with size validation
-- `AtEnd()` - checks if all chunks have been consumed
+**`RDBChunkInputStream`** wraps `SupplementalContentChunkIter`:
 
-**RDBChunkOutputStream** - Wraps `SafeRDB*`. `SaveChunk()` serializes each chunk as a `SupplementalContentChunk` protobuf and writes it via `SaveStringBuffer`. Provides:
-- `SaveString()` - saves a string_view as a chunk
-- `SaveObject<T>()` - saves a trivially-copyable object as a chunk
-- `Close()` - writes an empty string (EOF marker); called automatically by destructor if not already closed
+- `LoadChunk()` -> `unique_ptr<string>` (binary_content).
+- `LoadString()` - chunk as string.
+- `LoadObject<T>()` - reinterpret as trivially-copyable T with size validation.
+- `AtEnd()` - all chunks consumed.
 
-## RDB Load Path
+**`RDBChunkOutputStream`** wraps `SafeRDB*`:
 
-`AuxLoadCallback` is the entry point, registered as `aux_load` in the module type. It wraps the `ValkeyModuleIO*` in a `SafeRDB` and calls `PerformRDBLoad`:
+- `SaveChunk()` - wraps in `SupplementalContentChunk` proto, `SaveStringBuffer`.
+- `SaveString()`, `SaveObject<T>()`.
+- `Close()` - empty-string EOF marker; auto-called by dtor if not explicit.
 
-1. Validate encoding version (`kCurrentEncVer = 1`)
-2. Load and validate semantic version (must not exceed current module version)
-3. Load section count
-4. Initialize restore progress tracking in `Metrics::GetStats()`:
-   - `rdb_restore_in_progress = true`
-   - `rdb_restore_total_indexes = section_count`
-   - `rdb_restore_completed_indexes = 0`
-5. Iterate sections via `RDBSectionIter`
-6. For each section, look up the registered callback in `kRegisteredRDBSectionCallbacks` by section type
-7. Call the load callback with the section protobuf and supplemental content iterator
-8. For unregistered types, log a warning and drain all supplemental data
-9. Set `rdb_restore_in_progress = false` on success
+## Load path (`AuxLoadCallback`)
 
-Callbacks are dispatched via a static map:
+Registered as `aux_load` on the module type.
 
-```cpp
-extern absl::flat_hash_map<data_model::RDBSectionType, RDBSectionCallbacks>
-    kRegisteredRDBSectionCallbacks;
-```
+1. Encoding version check (`kCurrentEncVer = 1`).
+2. Semantic version <= current module version.
+3. Load section count.
+4. Restore progress in `Metrics::GetStats()`: `rdb_restore_in_progress = true`, `_total_indexes = section_count`, `_completed_indexes = 0`.
+5. `RDBSectionIter` per section, dispatch via `kRegisteredRDBSectionCallbacks[type]`.
+6. Unknown type -> warn + drain.
+7. On success: `rdb_restore_in_progress = false`, bump `rdb_load_success_cnt`.
 
-`RegisterRDBCallback` populates this map (main-thread only). Each entry provides:
-- `load` - per-section load callback
-- `save` - single callback for all sections of this type
-- `section_count` - returns how many sections to write
-- `minimum_semantic_version` - returns the minimum version needed
+`kRegisteredRDBSectionCallbacks` is an `absl::flat_hash_map<RDBSectionType, RDBSectionCallbacks>`. `RegisterRDBCallback` (main-thread only) registers: `load`, `save`, `section_count`, `minimum_semantic_version`.
 
-On load success, `rdb_load_success_cnt` increments. On failure, `rdb_load_failure_cnt` increments and `VALKEYMODULE_ERR` is returned.
+Failure -> `rdb_load_failure_cnt++`, return `VALKEYMODULE_ERR`.
 
-## RDB Save Path
+## Save path (`AuxSaveCallback`)
 
-`AuxSaveCallback` is the entry point, registered as `aux_save2` with trigger `VALKEYMODULE_AUX_AFTER_RDB`. It calls `PerformRDBSave`:
+Registered as `aux_save2` with trigger `VALKEYMODULE_AUX_AFTER_RDB` (writes after base RDB data so aux load happens after keys are available).
 
-1. Aggregate section counts from all registered callbacks
-2. Compute the minimum semantic version across all types that have sections to save
-3. If total section count is 0, return immediately (nothing to write)
-4. Write the header: minimum version (unsigned) + section count (unsigned)
-5. Call each save callback in sequence for types with sections > 0
+1. Sum section counts from all registered callbacks.
+2. Minimum semantic version across types with sections > 0.
+3. Total 0 -> return immediately.
+4. Header: minimum version + section count.
+5. Call each save callback for types with sections > 0.
 
-The save triggers `AFTER_RDB` ensures data is written after the base RDB data, so aux load happens after keys are available.
+Metrics: `rdb_save_success_cnt` / `rdb_save_failure_cnt`.
 
-On success, `rdb_save_success_cnt` increments. On failure, `rdb_save_failure_cnt` increments.
+## Module type (dummy)
 
-## Module Type Registration
-
-`RegisterModuleType` creates a dummy data type (`"Vk-Search"`) solely to get aux callbacks. The `rdb_load`, `rdb_save`, `aof_rewrite`, and `free` callbacks all assert-fail if called - the module never creates instances of this type. Only `aux_load` and `aux_save2` are meaningful.
+`RegisterModuleType` creates `"Vk-Search"` solely to get aux callbacks. Module never creates instances:
 
 ```cpp
 static ValkeyModuleTypeMethods tm = {
-    .version = VALKEYMODULE_TYPE_METHOD_VERSION,
-    .rdb_load = [](ValkeyModuleIO*, int) -> void* { DCHECK(false); },
-    .rdb_save = [](ValkeyModuleIO*, void*) { DCHECK(false); },
-    .aof_rewrite = [](ValkeyModuleIO*, ValkeyModuleString*, void*) { DCHECK(false); },
-    .free = [](void*) { DCHECK(false); },
-    .aux_load = AuxLoadCallback,
+    .version           = VALKEYMODULE_TYPE_METHOD_VERSION,
+    .rdb_load          = [](...) -> void* { DCHECK(false); },
+    .rdb_save          = [](...)          { DCHECK(false); },
+    .aof_rewrite       = [](...)          { DCHECK(false); },
+    .free              = [](...)          { DCHECK(false); },
+    .aux_load          = AuxLoadCallback,
     .aux_save_triggers = VALKEYMODULE_AUX_AFTER_RDB,
-    .aux_save2 = AuxSaveCallback,
+    .aux_save2         = AuxSaveCallback,
 };
 ```
 
-## FT.INTERNAL_UPDATE Command
+## `FT.INTERNAL_UPDATE`
 
-`FT.INTERNAL_UPDATE` replicates metadata changes from primary to replicas. It is an internal command - not user-facing.
+Replicates metadata changes primary -> replicas. Internal, not user-facing.
 
-**Arguments**: `FT.INTERNAL_UPDATE <id> <serialized_entry> <serialized_header>`
-- `id` - the encoded metadata entry identifier
-- `serialized_entry` - protobuf-serialized `GlobalMetadataEntry`
-- `serialized_header` - protobuf-serialized `GlobalMetadataVersionHeader`
+**Syntax**: `FT.INTERNAL_UPDATE <id> <serialized_entry> <serialized_header>`
 
-**Processing flow** (`FTInternalUpdateCmd`):
-1. Parse `GlobalMetadataEntry` from argv[2]
-2. Parse `GlobalMetadataVersionHeader` from argv[3]
-3. If the node is a replica or is loading, call `CreateEntryOnReplica` to apply the metadata update
-4. Call `ValkeyModule_ReplicateVerbatim(ctx)` to propagate to downstream replicas
-5. Reply OK
+- `id` - encoded entry identifier.
+- `serialized_entry` - `GlobalMetadataEntry` proto.
+- `serialized_header` - `GlobalMetadataVersionHeader` proto.
 
-**Error handling**: `HandleInternalUpdateFailure` provides resilient error recovery:
-- Parse failures increment `ft_internal_update_parse_failures_cnt`
-- Process failures increment `ft_internal_update_process_failures_cnt`
-- During AOF loading, if `skip-corrupted-internal-update-entries` config is enabled, corrupted entries are skipped with a warning (incrementing `ft_internal_update_skipped_entries_cnt`)
-- If skip is disabled during AOF loading, the process aborts via `CHECK(false)`
+**Flow** (`FTInternalUpdateCmd`):
 
-**Replication path**: `MetadataManager::ReplicateFTInternalUpdate` is called by `CreateEntry` and `DeleteEntry` on the primary. It serializes the entry and header, then calls `ValkeyModule_Call` to invoke `FT.INTERNAL_UPDATE`, which triggers AOF recording. During reconciliation, `CallFTInternalUpdateForReconciliation` does the same for remotely-received updates.
+1. Parse both protos.
+2. Replica or loading -> `CreateEntryOnReplica` applies the update.
+3. `ValkeyModule_ReplicateVerbatim(ctx)` propagates to downstream replicas.
+4. Reply OK.
 
-## Staging During Replication Loads
+**Error handling** (`HandleInternalUpdateFailure`):
 
-When a replica receives an RDB from its primary, metadata must not be applied piecemeal:
+| Failure | Counter |
+|---------|---------|
+| Parse | `ft_internal_update_parse_failures_cnt` |
+| Process | `ft_internal_update_process_failures_cnt` |
+| AOF load + `skip-corrupted-internal-update-entries` enabled | `ft_internal_update_skipped_entries_cnt` + warn |
 
-1. `OnReplicationLoadStart` - sets `staging_metadata_due_to_repl_load_ = true`
-2. During load, `LoadMetadata` writes to `staged_metadata_` instead of the live `metadata_`
-3. `OnLoadingEnded` - clears `metadata_`, reconciles from `staged_metadata_` with `prefer_incoming = true` and `trigger_callbacks = false`
-4. Fingerprint and version are populated to each `IndexSchema` via `SchemaManager::PopulateFingerprintVersionFromMetadata`
-5. Staged metadata is cleared; `is_loading_` is reset
+AOF load + skip disabled -> `CHECK(false)` (abort).
 
-For non-replication loads (server restart from RDB), `LoadMetadata` merges directly into `metadata_` via `ReconcileMetadata` with `prefer_incoming = true`, allowing the existing state (if any) to be merged with the loaded data.
+**Replication path**: `MetadataManager::ReplicateFTInternalUpdate` called by `CreateEntry` / `DeleteEntry` on the primary - serializes entry+header, `ValkeyModule_Call("FT.INTERNAL_UPDATE", ...)` - triggers AOF recording. Reconciliation uses `CallFTInternalUpdateForReconciliation` for remotely-received updates.
+
+## Replication load staging
+
+Replica receiving RDB - metadata must not be applied piecemeal.
+
+1. `OnReplicationLoadStart` -> `staging_metadata_due_to_repl_load_ = true`.
+2. `LoadMetadata` writes to `staged_metadata_`.
+3. `OnLoadingEnded` - clear `metadata_`, reconcile from staged with `prefer_incoming=true, trigger_callbacks=false`.
+4. Fingerprint + version populated per `IndexSchema` via `SchemaManager::PopulateFingerprintVersionFromMetadata`.
+5. Clear staged; reset `is_loading_`.
+
+Non-replication (restart from RDB): `LoadMetadata` merges directly into `metadata_` via `ReconcileMetadata(prefer_incoming=true)` - existing state merges with loaded data.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-build.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-build.md
@@ -1,146 +1,102 @@
-# Build System
+# Build system
 
-Use when building valkey-search from source, configuring CMake, understanding dependencies, or troubleshooting build failures.
+Use when building valkey-search, configuring CMake, or troubleshooting build failures.
 
-Source: `CMakeLists.txt`, `build.sh`, `submodules/CMakeLists.txt`, `third_party/CMakeLists.txt`, `cmake/Modules/valkey_search.cmake`
+Source: `CMakeLists.txt`, `build.sh`, `submodules/CMakeLists.txt`, `third_party/CMakeLists.txt`, `cmake/Modules/valkey_search.cmake`.
 
-## Contents
+## Requirements
 
-- [Build Requirements](#build-requirements)
-- [CMake Structure](#cmake-structure)
-- [Dependencies](#dependencies)
-- [VMSDK Abstraction Layer](#vmsdk-abstraction-layer)
-- [build.sh](#buildsh)
-- [Sanitizer Builds](#sanitizer-builds)
-- [Platform Notes](#platform-notes)
-- [Troubleshooting](#troubleshooting)
+- C++20 (GCC 12+ or Clang 16+).
+- CMake 3.16+.
+- Ninja (default) or Make.
+- Linux or macOS only (top-level CMakeLists rejects non-UNIX).
+- `CMAKE_POSITION_INDEPENDENT_CODE ON` globally.
 
-## Build Requirements
-
-- C++20 (GCC 12+ or Clang 16+)
-- CMake 3.16+
-- Ninja (default) or Make
-- Linux or macOS only - the top-level CMakeLists.txt rejects non-UNIX platforms
-- Position-independent code enabled globally (`CMAKE_POSITION_INDEPENDENT_CODE ON`)
-
-## CMake Structure
-
-The top-level `CMakeLists.txt` orchestrates the build:
+## Layout
 
 ```
-CMakeLists.txt          # Project root - options, submodule init, subdirectories
-  submodules/           # gRPC, Protobuf, Abseil, GoogleTest, HighwayHash, Benchmark
-  third_party/          # hnswlib, ICU, SimSIMD, Snowball, hdrhistogram_c
-  vmsdk/                # Valkey Module SDK abstraction layer
-  src/                  # Module source (produces libsearch.so/.dylib)
-  testing/              # GoogleTest unit tests
+CMakeLists.txt        # root: options, submodule init, subdirs
+submodules/           # gRPC, Protobuf, Abseil, GoogleTest, HighwayHash, Benchmark
+third_party/          # hnswlib, ICU, SimSIMD, Snowball, hdrhistogram_c
+vmsdk/                # Valkey Module SDK C++ wrapper
+src/                  # module (libsearch.{so,dylib})
+testing/              # GoogleTest unit tests
 ```
 
-Key CMake options:
+CMake options:
 
 | Option | Default | Purpose |
 |--------|---------|---------|
-| `BUILD_UNIT_TESTS` | ON | Build GoogleTest unit test binaries |
-| `WITH_SUBMODULES_SYSTEM` | OFF | Use system-installed gRPC/Protobuf/Abseil instead of building from source |
-| `SAN_BUILD` | "" | Sanitizer: `address` or `thread` |
+| `BUILD_UNIT_TESTS` | ON | GoogleTest binaries |
+| `WITH_SUBMODULES_SYSTEM` | OFF | Use system gRPC/Protobuf/Abseil instead of building |
+| `SAN_BUILD` | "" | `address` or `thread` |
 
-The `cmake/Modules/valkey_search.cmake` module provides helper functions (`valkey_search_add_static_library`, `valkey_search_add_shared_library`) that apply consistent compile flags and link GoogleTest for `gtest_prod.h` support.
+`cmake/Modules/valkey_search.cmake` provides `valkey_search_add_static_library` / `_shared_library` helpers that apply consistent compile flags and link GoogleTest (for `gtest_prod.h`).
 
-## Dependencies
+## Submodules (built from source by default)
 
-### Submodules (built from source by default)
+| Dependency | Version | Use |
+|------------|---------|-----|
+| gRPC | v1.70.1 | coordinator RPC |
+| Protobuf | via gRPC | schema + RDB section |
+| Abseil | via gRPC | data structures, status, sync |
+| GoogleTest | main | unit tests |
+| HighwayHash | master | index fingerprints |
+| Google Benchmark | v1.8.3 | micro-benchmarks (disabled under SAN) |
 
-These are cloned and built during the CMake configure step via `submodules/CMakeLists.txt`:
+`--use-system-modules` skips building submodules. CI uses pre-built `.deb`s from `/opt/valkey-search-deps/`.
 
-| Dependency | Version | Purpose |
-|------------|---------|---------|
-| gRPC | v1.70.1 | Cluster coordinator inter-node RPC |
-| Protobuf | (via gRPC) | Index schema and RDB section serialization |
-| Abseil | (via gRPC) | Data structures, status, synchronization |
-| GoogleTest | main | Unit test framework |
-| HighwayHash | master | Fast hashing for index fingerprints |
-| Google Benchmark | v1.8.3 | Micro-benchmarks (disabled during sanitizer builds) |
+## Third-party (vendored)
 
-Use `--use-system-modules` to skip building these from source and use system-installed versions instead. CI uses pre-built `.deb` packages from `/opt/valkey-search-deps/` for speed.
+| Library | Dir | Use |
+|---------|-----|-----|
+| hnswlib | `third_party/hnswlib/` | HNSW ANN |
+| ICU | `third_party/icu/` | Unicode normalization |
+| SimSIMD | `third_party/simsimd/` | SIMD vector distance |
+| Snowball | `third_party/snowball/` | stemming |
+| hdrhistogram_c | `third_party/hdrhistogram_c/` | latency histograms |
 
-### Third-party (vendored in `third_party/`)
+ICU is built static with embedded data. `build_icu_if_needed()` in `build.sh` builds out-of-tree in `${BUILD_DIR}/icu/`, producing `libicudata.a`, `libicui18n.a`, `libicuuc.a` under `${BUILD_DIR}/icu/install/lib/`.
 
-Built via `third_party/CMakeLists.txt`, these are committed or vendored sources:
+## VMSDK layer (`vmsdk/`)
 
-| Library | Directory | Purpose |
-|---------|-----------|---------|
-| hnswlib | `third_party/hnswlib/` | HNSW approximate nearest neighbor index |
-| ICU | `third_party/icu/` | Unicode normalization and locale-aware text processing |
-| SimSIMD | `third_party/simsimd/` | SIMD-accelerated vector distance computations |
-| Snowball | `third_party/snowball/` | Stemming for full-text search |
-| hdrhistogram_c | `third_party/hdrhistogram_c/` | High dynamic range histogram for latency metrics |
-
-ICU is built as static libraries with embedded data. The `build_icu_if_needed()` function in `build.sh` runs an out-of-tree build in `${BUILD_DIR}/icu/`, producing `libicudata.a`, `libicui18n.a`, and `libicuuc.a` under `${BUILD_DIR}/icu/install/lib/`.
-
-## VMSDK Abstraction Layer
-
-The `vmsdk/` directory is an in-tree SDK that wraps the raw ValkeyModule C API into C++ abstractions:
+In-tree C++ wrapper over raw ValkeyModule C API. Compiled as static `vmsdklib`, linked into final `.so`. Ships `testing_infra/` with mocked contexts.
 
 | Header | Purpose |
 |--------|---------|
-| `managed_pointers.h` | RAII wrappers (`UniqueValkeyString`) for `ValkeyModuleString*` |
-| `blocked_client.h` | Blocked client management with category tracking |
-| `module_config.h` | Type-safe module configuration with builder pattern |
-| `module.h` | `VALKEY_MODULE()` macro, `Options` struct, command registration |
-| `thread_pool.h` | Thread pool for async search and utility tasks |
-| `cluster_map.h` | Cluster topology and fanout target computation |
-| `module_type.h` | Custom data type registration |
-| `memory_allocation.h` | Valkey-aware memory allocation wrappers |
-| `latency_sampler.h` | Latency measurement sampling |
-| `time_sliced_mrmw_mutex.h` | Multi-reader multi-writer mutex with time slicing |
+| `managed_pointers.h` | RAII (e.g. `UniqueValkeyString` for `ValkeyModuleString*`) |
+| `blocked_client.h` | blocked clients + category tracking |
+| `module_config.h` | type-safe configs (builder) |
+| `module.h` | `VALKEY_MODULE()`, `Options`, command registration |
+| `thread_pool.h` | async search + utility pools |
+| `cluster_map.h` | cluster topology + fanout targets |
+| `module_type.h` | custom data type registration |
+| `memory_allocation.h` | Valkey-aware allocation |
+| `latency_sampler.h` | latency sampling |
+| `time_sliced_mrmw_mutex.h` | MRMW mutex with time slicing |
 
-VMSDK is compiled as a static library (`vmsdklib`) and linked into the final shared library. It also ships a `testing_infra/` directory providing mocked ValkeyModule contexts for unit tests.
+## `build.sh`
 
-## build.sh
-
-The primary developer build script. It auto-detects when CMake reconfiguration is needed by comparing timestamps of `CMakeLists.txt` and `.cmake` files against the build output.
-
-### Common Commands
+Auto-detects CMake reconfigure (compares `CMakeLists.txt` + `.cmake` timestamps vs build output).
 
 ```bash
-# Default release build (auto-configures if needed)
-./build.sh
-
-# Force CMake reconfigure + debug build
+./build.sh                                # default release
 ./build.sh --configure --debug
-
-# Build with AddressSanitizer
-./build.sh --asan
-
-# Build with ThreadSanitizer
-./build.sh --tsan
-
-# Apply clang-format to all source files
-./build.sh --format
-
-# Run all unit tests after build
-./build.sh --run-tests
-
-# Run a specific test binary
-./build.sh --run-tests=vector_test
-
-# Run integration tests
+./build.sh --asan                         # AddressSanitizer
+./build.sh --tsan                         # ThreadSanitizer
+./build.sh --format                       # clang-format
+./build.sh --run-tests                    # all unit tests
+./build.sh --run-tests=vector_test        # one suite
 ./build.sh --run-integration-tests
-
-# Run integration tests matching a pattern
-./build.sh --run-integration-tests=oss
-
-# Limit parallel build jobs
+./build.sh --run-integration-tests=oss    # pattern
 ./build.sh --jobs=4
-
-# Clean build directory
 ./build.sh --clean
 ```
 
-### Build Directories
+Build dirs by config:
 
-| Configuration | Directory |
-|---------------|-----------|
+| Config | Dir |
+|--------|-----|
 | Release | `.build-release/` |
 | Debug | `.build-debug/` |
 | Release + ASan | `.build-release-asan/` |
@@ -148,69 +104,57 @@ The primary developer build script. It auto-detects when CMake reconfiguration i
 | Debug + ASan | `.build-debug-asan/` |
 | Debug + TSan | `.build-debug-tsan/` |
 
-### Output
+Output: `.build-release/libsearch.{so,dylib}`. Load with `valkey-server --loadmodule .build-release/libsearch.so`.
 
-The build produces a single shared library:
+### Flow
 
-- Linux: `.build-release/libsearch.so`
-- macOS: `.build-release/libsearch.dylib`
+1. `build_icu_if_needed()` (cached in `${BUILD_DIR}/icu/`).
+2. Auto-detect CMake reconfigure via timestamp comparison.
+3. `configure()` - `cmake` with generator + options.
+4. `build()` - Ninja or Make.
+5. Optionally tests.
 
-Load it with:
+### Env
 
-```bash
-valkey-server --loadmodule .build-release/libsearch.so
-```
+| Var | Use |
+|-----|-----|
+| `CMAKE_GENERATOR` | override generator (default `Ninja`) |
+| `CMAKE_EXTRA_ARGS` | extra cmake args |
+| `SAN_BUILD` | `address` / `thread` for downstream scripts |
 
-### Build Flow
+## Sanitizer builds
 
-1. `build_icu_if_needed()` - builds ICU static libraries in `${BUILD_DIR}/icu/` if not cached
-2. Auto-detect if CMake configure is required (timestamp comparison of `CMakeLists.txt` and `*.cmake` files)
-3. `configure()` - runs `cmake` with the selected generator and options
-4. `build()` - runs Ninja (or Make) to compile and link
-5. Optionally runs unit tests, integration tests, or both
+AddressSanitizer / ThreadSanitizer compile the entire dependency stack with sanitizer flags (submodules rebuilt with `-fsanitize=address` / `=thread` in `CXXFLAGS`, `CFLAGS`, `LDFLAGS`).
 
-### Environment Variables
+- ASan runtime: `ASAN_OPTIONS="detect_odr_violation=0"`.
+- Suppressions: `ci/asan.supp`, `ci/tsan.supp`.
+- Sanitizer tests continue past failures to collect all reports.
+- Google Benchmark disabled under SAN (instrumentation distorts timing).
 
-| Variable | Purpose |
-|----------|---------|
-| `CMAKE_GENERATOR` | Override build generator (default: `Ninja`) |
-| `CMAKE_EXTRA_ARGS` | Additional CMake arguments |
-| `SAN_BUILD` | Sanitizer type (`address` or `thread`) for downstream scripts |
-
-## Sanitizer Builds
-
-AddressSanitizer and ThreadSanitizer builds compile the entire dependency stack with sanitizer flags. Submodules are rebuilt with `-fsanitize=address` or `-fsanitize=thread` in `CXXFLAGS`, `CFLAGS`, and `LDFLAGS`.
-
-ASan builds set `ASAN_OPTIONS="detect_odr_violation=0"` at runtime. Suppression files are in `ci/asan.supp` and `ci/tsan.supp`.
-
-During sanitizer test runs, all unit tests continue running even after a failure (rather than stopping at the first failure) to collect the full set of sanitizer reports.
-
-Google Benchmark is disabled for sanitizer builds since instrumentation distorts timing results.
-
-## Platform Notes
+## Platform notes
 
 ### Linux
 
-- Default build uses Ninja. Falls back to Make if Ninja is unavailable.
-- On Debian-based systems, Ninja is invoked as `ninja`. On RedHat-based systems, it is `ninja-build`.
-- The linker uses `--version-script` from `vmsdk/versionscript.lds` to control exported symbols.
-- `--allow-multiple-definition` and `--start-group`/`--end-group` flags handle circular library dependencies.
+- Ninja default; Make fallback.
+- `ninja` (Debian) vs `ninja-build` (RedHat).
+- Linker uses `--version-script` from `vmsdk/versionscript.lds`.
+- `--allow-multiple-definition` + `--start-group`/`--end-group` handle circular library deps.
 
 ### macOS
 
-- Uses `clang` (Apple's default). Requires Xcode command line tools.
-- Suppresses `-Wno-defaulted-function-deleted` warnings from Apple Clang.
-- Works around a zlib `fdopen` detection issue in the gRPC submodule.
-- Module output is `.dylib` instead of `.so`.
-- No integration tests run on macOS in CI - build-only verification.
+- Apple `clang` + Xcode command line tools.
+- Suppresses `-Wno-defaulted-function-deleted` from Apple Clang.
+- Works around gRPC submodule zlib `fdopen` detection.
+- `.dylib` output.
+- No integration tests in CI on macOS (build-only verification).
 
 ## Troubleshooting
 
-| Problem | Cause | Solution |
-|---------|-------|----------|
-| CMake fails to find gRPC/Protobuf | Submodules not built | Run `./build.sh --configure` to trigger full configure |
-| ICU build fails | Missing source in `third_party/icu/` | ICU source is committed to the repo - check your checkout |
-| Ninja not found | Package name varies by distro | Install `ninja-build` (RedHat) or `ninja` (Debian/macOS) |
-| Link errors about multiple definitions | Missing `--start-group` | Ensure Linux build uses the CMake-generated link flags |
-| `GCC version too old` | GCC below 12 | Upgrade to GCC 12+ or use the dev container |
-| Benchmark disabled warning | SAN_BUILD is set | Expected - Google Benchmark is skipped for sanitizer builds |
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| CMake can't find gRPC/Protobuf | submodules not built | `./build.sh --configure` (full configure) |
+| ICU build fails | missing source in `third_party/icu/` | ICU source is committed - check checkout |
+| Ninja not found | package name varies | `ninja-build` (RH) / `ninja` (Debian/macOS) |
+| Multiple-definition link errors | missing `--start-group` | ensure Linux build uses generated link flags |
+| "GCC version too old" | GCC < 12 | upgrade or use dev container |
+| "Benchmark disabled" warning | `SAN_BUILD` set | expected - skipped for SAN builds |

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-ci-pipeline.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-ci-pipeline.md
@@ -12,11 +12,11 @@ Source: `.github/workflows/`, `.devcontainer/Dockerfile`, `ci/build_ubuntu.sh`.
 
 | Workflow | File | What | Timeout |
 |----------|------|------|---------|
-| Unit Tests | `unittests.yml` | GoogleTest binaries | default |
-| Unit Tests (ASan) | `unittests-asan.yml` | AddressSanitizer unit | default |
-| Unit Tests (TSan) | `unittests-tsan.yml` | ThreadSanitizer unit | default |
-| Integration Tests | `integration_tests.yml` | Python suite | 140 min |
-| Integration Tests (ASan) | `integration_tests-asan.yml` | | 140 min |
+| Unit Tests | `unittests.yml` | builds module, runs all GoogleTest binaries | default |
+| Unit Tests (ASan) | `unittests-asan.yml` | builds with AddressSanitizer, runs unit tests | default |
+| Unit Tests (TSan) | `unittests-tsan.yml` | builds with ThreadSanitizer, runs unit tests | default |
+| Integration Tests | `integration_tests.yml` | builds module, runs full Python integration suite | 140 min |
+| Integration Tests (ASan) | `integration_tests-asan.yml` | integration with AddressSanitizer | 140 min |
 
 ### On source file changes
 

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-ci-pipeline.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-ci-pipeline.md
@@ -1,230 +1,181 @@
-# CI Pipeline
+# CI pipeline
 
-Use when understanding CI workflows, debugging CI failures, or adding new CI checks.
+Use when reasoning about CI workflows, debugging failures, or adding checks.
 
-Source: `.github/workflows/`, `.devcontainer/Dockerfile`, `ci/build_ubuntu.sh`
+Source: `.github/workflows/`, `.devcontainer/Dockerfile`, `ci/build_ubuntu.sh`.
 
-## Contents
+## Shape
 
-- [Overview](#overview)
-- [Workflows](#workflows)
-- [Docker Build Environment](#docker-build-environment)
-- [Pre-built Dependencies](#pre-built-dependencies)
-- [CI Scripts](#ci-scripts)
-- [Clang Format Check](#clang-format-check)
-- [Test Artifact Upload](#test-artifact-upload)
-- [Endurance Test Configuration](#endurance-test-configuration)
-- [CI Build Flow](#ci-build-flow)
-- [Debugging CI Failures](#debugging-ci-failures)
+11 GitHub Actions workflows. Most test workflows build a Docker image from `.devcontainer/Dockerfile` and run tests inside - consistent local + CI tooling.
 
-## Overview
+### On every PR / push to `main` or `fulltext`
 
-valkey-search runs 11 GitHub Actions workflows. Most test workflows use a Docker-based approach: they build a Docker image from `.devcontainer/Dockerfile` and execute tests inside the container. This ensures consistent tooling across local development and CI.
+| Workflow | File | What | Timeout |
+|----------|------|------|---------|
+| Unit Tests | `unittests.yml` | GoogleTest binaries | default |
+| Unit Tests (ASan) | `unittests-asan.yml` | AddressSanitizer unit | default |
+| Unit Tests (TSan) | `unittests-tsan.yml` | ThreadSanitizer unit | default |
+| Integration Tests | `integration_tests.yml` | Python suite | 140 min |
+| Integration Tests (ASan) | `integration_tests-asan.yml` | | 140 min |
 
-## Workflows
+### On source file changes
 
-### On Every PR and Push to main/fulltext
+| Workflow | Paths | Action |
+|----------|-------|--------|
+| Clang Format | `clang_tidy_format.yml` triggers on `src/**`, `testing/**`, `vmsdk/src/**`, `vmsdk/testing/**` | clang-format on modified `.cc`/`.h` (excludes `third_party/` + `rax/`) |
 
-| Workflow | File | What it does | Timeout |
-|----------|------|-------------|---------|
-| Unit Tests | `unittests.yml` | Builds module, runs all GoogleTest binaries | Default |
-| Unit Tests (ASan) | `unittests-asan.yml` | Builds with AddressSanitizer, runs all unit tests | Default |
-| Unit Tests (TSan) | `unittests-tsan.yml` | Builds with ThreadSanitizer, runs all unit tests | Default |
-| Integration Tests | `integration_tests.yml` | Builds module, runs full Python integration suite | 140 min |
-| Integration Tests (ASan) | `integration_tests-asan.yml` | Integration tests with AddressSanitizer | 140 min |
+### All pushes / PRs (no branch filter)
 
-### On Source File Changes (PR and push to main/fulltext)
+| Workflow | Action |
+|----------|--------|
+| `spell_check.yml` | `typos` with `.config/typos.toml` |
 
-| Workflow | File | Trigger Paths | What it does |
-|----------|------|--------------|-------------|
-| Clang Format | `clang_tidy_format.yml` | `src/**`, `testing/**`, `vmsdk/src/**`, `vmsdk/testing/**` | Checks clang-format on modified `.cc`/`.h` files (excludes `third_party/` and `rax/`) |
+### `main` only
 
-### On All Pushes and PRs (no branch filter)
+| Workflow | Action |
+|----------|--------|
+| `macos.yml` | macOS build (no tests) |
 
-| Workflow | File | What it does |
-|----------|------|-------------|
-| Spellcheck | `spell_check.yml` | Runs `typos` with config from `.config/typos.toml` |
+### Scheduled / manual
 
-### On PR/Push to main Only
-
-| Workflow | File | What it does |
-|----------|------|-------------|
-| macOS Build | `macos.yml` | Builds on macOS (build only, no tests) |
-
-### Scheduled / Manual
-
-| Workflow | File | Trigger | What it does |
-|----------|------|---------|-------------|
-| Endurance Tests | `endurance_tests.yml` | Daily at 09:00 UTC + manual | Long-running memtier_benchmark stability tests via `scripts/benchmark/run_endurance_test.sh` |
-| Delete Old Workflows | `delete old workflows.yml` | Monthly (1st of month) | Cleans up workflow runs older than 90 days, keeps minimum 6 |
-| Release Trigger | `trigger-search-release.yml` | On release publish + manual | Dispatches `search-release` event to `valkey-bundle` for extension packaging |
+| Workflow | Trigger | Action |
+|----------|---------|--------|
+| `endurance_tests.yml` | daily 09:00 UTC + manual | `scripts/benchmark/run_endurance_test.sh` |
+| `delete old workflows.yml` | monthly (1st) | remove runs > 90 days, keep >= 6 |
+| `trigger-search-release.yml` | release publish + manual | dispatch `search-release` to `valkey-bundle` |
 
 ### Concurrency
 
-All workflows use concurrency groups scoped to the branch/PR head ref with `cancel-in-progress: true`. This means pushing a new commit cancels any in-progress run for the same branch.
+All workflows use concurrency groups scoped to branch/PR head ref with `cancel-in-progress: true` - new commit cancels in-progress runs.
 
-## Docker Build Environment
+## Docker environment
 
-The `.devcontainer/Dockerfile` is based on Ubuntu 24.04 (Noble) and includes:
+`.devcontainer/Dockerfile` = Ubuntu 24.04 (Noble). Includes GCC, CMake, Ninja, clang-format, clang-tidy, clangd, Python 3.12 + venv, memtier-benchmark (Redis packages), SSL dev libs.
 
-- GCC, CMake, Ninja
-- clang-format, clang-tidy, clangd
-- Python 3.12 with venv
-- memtier-benchmark (from Redis packages)
-- SSL development libraries
+`.devcontainer/setup.sh` preps context. Same Dockerfile serves:
 
-A `.devcontainer/setup.sh` script prepares the build context. The same Dockerfile is used for:
-- CI workflows (built as `presubmit-image`)
-- VS Code dev containers (configured via `devcontainer_base.json`)
-- Endurance test runs (built as `endurance-test-image`)
+- CI (`presubmit-image`).
+- VS Code dev containers (`devcontainer_base.json`).
+- Endurance (`endurance-test-image`).
 
-## Pre-built Dependencies
+## Pre-built deps
 
-CI speed is optimized by using pre-built `.deb` packages for the C++ dependencies (gRPC, Protobuf, Abseil, GoogleTest, HighwayHash). The `ci/build_ubuntu.sh` script:
+To speed up CI, C++ deps (gRPC, Protobuf, Abseil, GoogleTest, HighwayHash) come from pre-built `.deb`s. `ci/build_ubuntu.sh`:
 
-1. Detects architecture (`amd64` or `arm64`) and distro via `lsb_release`
-2. Downloads a platform-specific `.deb` from the GitHub releases page
-3. Installs it to `/opt/valkey-search-deps/` (or `/opt/valkey-search-deps-asan/` for sanitizer builds)
-4. Sets `CMAKE_PREFIX_PATH` to find the pre-built packages
-5. Passes `--use-system-modules` to `build.sh` to skip building submodules from source
+1. Detect arch (`amd64` / `arm64`) + distro via `lsb_release`.
+2. Download platform-specific `.deb` from GitHub releases.
+3. Install to `/opt/valkey-search-deps/` (or `-asan/` for SAN).
+4. Set `CMAKE_PREFIX_PATH`.
+5. Pass `--use-system-modules` to `build.sh` to skip submodule build.
 
-The deb naming convention is:
-```
-valkey-search-deps-{distro}-{codename}{san-suffix}-{arch}.deb
-```
+Naming: `valkey-search-deps-<distro>-<codename>[-<san>]-<arch>.deb`. Examples: `valkey-search-deps-ubuntu-noble-amd64.deb`, `valkey-search-deps-ubuntu-noble-asan-amd64.deb`.
 
-For example: `valkey-search-deps-ubuntu-noble-amd64.deb` or `valkey-search-deps-ubuntu-noble-asan-amd64.deb`.
-
-## CI Scripts
+## CI scripts
 
 | Script | Purpose |
 |--------|---------|
-| `ci/build_ubuntu.sh` | Main CI entry point - downloads deps, sets up env, calls `build.sh` |
-| `ci/check_clang_format.sh` | Verifies a single file matches clang-format output |
-| `ci/refresh_comp_db.sh` | Regenerates `compile_commands.json` for clang-tidy |
-| `ci/check_changes.sh` | Utility for detecting changed files |
+| `ci/build_ubuntu.sh` | main CI entry - deps + env + `build.sh` |
+| `ci/check_clang_format.sh` | per-file clang-format check |
+| `ci/refresh_comp_db.sh` | regenerates `compile_commands.json` for clang-tidy |
+| `ci/check_changes.sh` | changed-file detection |
 | `ci/entrypoint.sh` | Docker container entrypoint |
-| `ci/asan.supp` | AddressSanitizer suppression rules |
-| `ci/tsan.supp` | ThreadSanitizer suppression rules |
+| `ci/asan.supp` | ASan suppressions |
+| `ci/tsan.supp` | TSan suppressions |
 
-## Clang Format Check
+## Clang format
 
-The `clang_tidy_format.yml` workflow only checks files modified in the PR (not the entire codebase). It:
+`clang_tidy_format.yml` checks only PR-modified files, not the whole tree.
 
-1. Determines the base branch (PR base or previous commit for pushes)
-2. Builds the Docker image and generates `compile_commands.json` via `ci/refresh_comp_db.sh`
-3. Finds modified `.cc` and `.h` files (excluding `third_party/` and `src/indexes/text/rax/`)
-4. Runs `ci/check_clang_format.sh` on each file
+1. Determine base branch (PR base or previous commit for pushes).
+2. Build Docker image, `ci/refresh_comp_db.sh` for `compile_commands.json`.
+3. Find modified `.cc` / `.h` (exclude `third_party/`, `src/indexes/text/rax/`).
+4. `ci/check_clang_format.sh` per file.
 
-Clang-tidy is defined in the workflow but currently disabled (pending codebase-wide tidy pass).
+clang-tidy is defined in the workflow but currently disabled (pending codebase-wide tidy pass).
 
-To format locally before pushing:
+Local: `./build.sh --format`. Formats `src/`, `testing/`, `vmsdk/src/`, `vmsdk/testing/` (excludes `src/indexes/text/rax/`).
 
-```bash
-./build.sh --format
-```
+## Artifacts
 
-This formats files under `src/`, `testing/`, `vmsdk/src/`, and `vmsdk/testing/`, excluding `src/indexes/text/rax/`.
+| Workflow | Name | Contents |
+|----------|------|----------|
+| Unit | `unittest-results` | `tests.out`, binaries' output |
+| Integration | `integration-test-results` | server logs, module binaries, framework output |
+| Endurance | `endurance-test-results-{run}` | benchmark CSV/JSON, server logs, metadata (90-day retention) |
 
-## Test Artifact Upload
+## Endurance inputs
 
-All test workflows upload results as GitHub Actions artifacts:
+| Param | Default |
+|-------|---------|
+| `branch_version` | `unstable` |
+| `enable_tls` | true |
+| `test_duration` | 3600 s |
+| `threads` | 10 |
+| `clients` | 10 (per thread) |
+| `pipeline_depth` | 1 |
+| `data_size` | 1024 |
+| `workload_type` | `mixed` (or `read_only` / `write_only`) |
+| `keyspace_size` | 1 000 000 |
 
-| Workflow | Artifact Name | Contents |
-|----------|--------------|----------|
-| Unit tests | `unittest-results` | Test binaries output, `tests.out` |
-| Integration tests | `integration-test-results` | Server logs, module binaries, test framework output |
-| Endurance tests | `endurance-test-results-{run}` | Benchmark results (CSV, JSON), server logs, metadata |
+Entry: `scripts/benchmark/run_endurance_test.sh` inside the container.
 
-Endurance test artifacts are retained for 90 days.
+## Standard test-job sequence
 
-## Endurance Test Configuration
+1. Checkout.
+2. Build dev container image.
+3. Run `ci/build_ubuntu.sh` with flags inside container.
+4. Upload artifacts (pass or fail).
 
-The endurance workflow accepts manual inputs for fine-grained control:
+`ci/build_ubuntu.sh` bridges GH Actions and `build.sh`:
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `branch_version` | unstable | Valkey server branch to test against |
-| `enable_tls` | true | Enable TLS for benchmark connections |
-| `test_duration` | 3600 (1 hour) | Test duration in seconds |
-| `threads` | 10 | memtier benchmark threads |
-| `clients` | 10 | memtier benchmark clients per thread |
-| `pipeline_depth` | 1 | Command pipeline depth |
-| `data_size` | 1024 | Data size in bytes |
-| `workload_type` | mixed | mixed, read_only, or write_only |
-| `keyspace_size` | 1000000 | Number of keys |
+1. Detect arch/distro for correct `.deb`.
+2. Download + install pre-built deps if not cached.
+3. `ulimit -c unlimited` (core dumps).
+4. `CMAKE_PREFIX_PATH` -> `/opt/valkey-search-deps/`.
+5. Integration-only runs: `BUILD_UNIT_TESTS=OFF`.
+6. `build.sh --use-system-modules --test-errors-stdout` + original CI flags.
 
-The test entry point is `scripts/benchmark/run_endurance_test.sh`, invoked inside the Docker container.
+## Branch targeting
 
-## CI Build Flow
-
-The standard CI workflow for test jobs follows this sequence:
-
-1. **Checkout** - clone the repository
-2. **Docker build** - build the dev container image from `.devcontainer/Dockerfile`
-3. **Run tests** - execute `ci/build_ubuntu.sh` inside the container with appropriate flags
-4. **Upload artifacts** - save test output regardless of pass/fail
-
-The `ci/build_ubuntu.sh` script is the bridge between GitHub Actions and the standard `build.sh`:
-
-1. Detects architecture and distro for the correct `.deb` package
-2. Downloads and installs pre-built dependencies if not cached
-3. Enables core dumps (`ulimit -c unlimited`)
-4. Sets `CMAKE_PREFIX_PATH` pointing to `/opt/valkey-search-deps/`
-5. For integration-only runs, disables unit test binary compilation (`BUILD_UNIT_TESTS=OFF`)
-6. Calls `build.sh --use-system-modules --test-errors-stdout` with the original CI flags
-
-## Branch Targeting
-
-Most PR/push workflows trigger on:
-- Pull requests targeting `main` or `fulltext` branches
-- Direct pushes to `main` or `fulltext` branches
-- Manual `workflow_dispatch` trigger
+Most workflows: PR to `main` / `fulltext`, pushes to `main` / `fulltext`, manual `workflow_dispatch`.
 
 Exceptions:
-- The macOS workflow targets only `main`
-- The spellcheck workflow triggers on all branches (no branch filter)
-- The clang format workflow triggers only when source files change (path filters)
 
-## Debugging CI Failures
+- macOS: `main` only.
+- Spellcheck: all branches.
+- Clang format: path-filter triggered (source file changes only).
 
-1. Download the test artifact from the failed workflow run
-2. For unit test failures, check `tests.out` in the artifact
-3. For integration test failures, check server logs in `valkey-test-framework/`
-4. For sanitizer failures, look for ASan/TSan reports in the test output
-5. Reproduce locally using the same build flags:
+## Debugging
+
+1. Download failed artifact.
+2. Unit: check `tests.out`.
+3. Integration: server logs in `valkey-test-framework/`.
+4. SAN: look for ASan/TSan reports in test output.
+5. Local repro:
    ```bash
-   # Reproduce an ASan unit test failure
    ./build.sh --asan --run-tests --test-errors-stdout
-   
-   # Reproduce an integration test failure
    ./build.sh --run-integration-tests=test_name --retries=1
    ```
 
-### Common CI Failure Patterns
+### Common patterns
 
-| Symptom | Likely Cause | Fix |
-|---------|-------------|-----|
-| Clang format check fails | Source file not formatted | Run `./build.sh --format` and commit |
-| ASan unit test fails with ODR violation | Duplicate symbol definitions | Suppressed via `ASAN_OPTIONS=detect_odr_violation=0`; check if new code introduces real duplicates |
-| Integration test timeout (140 min) | Test deadlock or slow server startup | Check server logs in artifact, look for module load errors |
-| macOS build fails | Platform-specific code or missing macOS guard | Check `#ifdef APPLE` guards and linker flags |
-| Spellcheck fails | Typo in source or docs | Fix the typo or add to `.config/typos.toml` exceptions |
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Clang format fails | unformatted file | `./build.sh --format` + commit |
+| ASan ODR violation | duplicate symbols | suppressed via `ASAN_OPTIONS=detect_odr_violation=0`; check for real duplicates |
+| Integration 140 min timeout | deadlock / slow startup | check server logs for module load errors |
+| macOS build fails | platform-specific code / missing guard | check `#ifdef APPLE` + linker flags |
+| Spellcheck fails | typo | fix or add to `.config/typos.toml` |
 
-### Running the Full CI Locally
-
-To approximate the full CI pipeline on a local machine:
+### Run full CI locally
 
 ```bash
-# Build the Docker image
 docker build -t presubmit-image -f .devcontainer/Dockerfile .
 
-# Run unit tests (matching CI)
 docker run --privileged --rm -v "$(pwd):/workspace" \
   --user "ubuntu:ubuntu" presubmit-image \
   sudo ci/build_ubuntu.sh --run-tests
 
-# Run integration tests (matching CI)
 docker run --privileged --rm -v "$(pwd):/workspace" \
   --user "ubuntu:ubuntu" presubmit-image \
   sudo ci/build_ubuntu.sh --run-integration-tests

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-code-structure.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-code-structure.md
@@ -1,255 +1,196 @@
-# Code Structure
+# Code structure
 
-Use when navigating the source tree, adding new features, understanding component relationships, or planning code changes.
+Use when navigating the source tree, adding a feature, or planning a change.
 
-Source: `src/`, `vmsdk/`, `testing/`, top-level `CMakeLists.txt`
+Source: `src/`, `vmsdk/`, `testing/`, top-level `CMakeLists.txt`.
 
-## Contents
-
-- [Directory Layout](#directory-layout)
-- [IndexBase Abstract Class](#indexbase-abstract-class)
-- [How to Add a New Index Type](#how-to-add-a-new-index-type)
-- [Command Registration Pattern](#command-registration-pattern)
-- [VMSDK Key Abstractions](#vmsdk-key-abstractions)
-- [How to Add a New Query Feature](#how-to-add-a-new-query-feature)
-- [Key Singletons](#key-singletons)
-- [Proto Files](#proto-files)
-
-## Directory Layout
+## Layout
 
 ```
 valkey-search/
-  build.sh                  # Developer build script
-  CMakeLists.txt            # Top-level CMake configuration
+  build.sh
+  CMakeLists.txt
   src/
-    module_loader.cc        # Entry point: VALKEY_MODULE() macro, command table
-    valkey_search.cc/h      # ValkeySearch singleton - thread pools, lifecycle
-    valkey_search_options.cc/h # Module configuration options
-    schema_manager.cc/h     # Index schema registry (per-db map of schemas)
-    index_schema.cc/h       # Single index schema - attributes, key prefixes
-    keyspace_event_manager.cc/h  # Subscribes to key mutations, routes to indexes
-    server_events.cc/h      # Server event callbacks (loading, flushing, etc.)
-    attribute.cc/h          # Attribute metadata and extraction
-    attribute_data_type.cc/h # Custom Valkey data type for attribute storage
-    rdb_serialization.cc/h  # Protobuf-based RDB save/load
-    vector_externalizer.cc/h # LRU-based vector data externalization
-    acl.cc/h                # ACL prefix-based permission checks
-    metrics.h               # Metrics counter definitions
-    version.h               # Module version constants
-    commands/               # Command implementations
-      commands.cc/h         # QueryCommand base, async reply/timeout/free
-      ft_create.cc          # FT.CREATE implementation
-      ft_search.cc/h        # FT.SEARCH implementation
-      ft_aggregate.cc/h     # FT.AGGREGATE implementation
-      ft_aggregate_exec.cc/h # FT.AGGREGATE execution engine
-      ft_dropindex.cc       # FT.DROPINDEX implementation
-      ft_info.cc            # FT.INFO implementation
-      ft_list.cc            # FT._LIST implementation
-      ft_debug.cc           # FT._DEBUG implementation
-      ft_internal_update.cc # FT.INTERNAL_UPDATE (replication)
-      ft_*_parser.cc/h      # Command argument parsers
-      filter_parser.cc/h    # Filter expression parser
-      *.json                # Command metadata (flags, arity, key specs)
-    indexes/                # Index implementations
-      index_base.h          # IndexBase abstract class, IndexerType enum
-      vector_base.cc/h      # VectorBase - shared vector index logic
-      vector_hnsw.cc/h      # HNSW approximate nearest neighbor index
-      vector_flat.cc/h      # FLAT brute-force vector index
-      numeric.cc/h          # Numeric range index (segment tree)
-      tag.cc/h              # Tag index (inverted index)
-      text.cc/h             # Full-text search index (wrapper)
-      universal_set_fetcher.cc/h # Universal set fetcher for query planning
-      text/                 # Full-text internals
-        text_index.cc/h     # Core text index with posting lists
-        lexer.cc/h          # Text tokenizer/lexer
-        posting.cc/h        # Posting list data structure
-        term.cc/h           # Term storage and lookup
-        rax_wrapper.cc/h    # Radix tree wrapper over vendored rax
-        flat_position_map.cc/h  # Position tracking for proximity queries
-        proximity.cc/h      # Proximity query evaluation
-        orproximity.cc/h    # OR-proximity query evaluation
-        text_fetcher.cc/h   # Text content fetching for scoring
-        unicode_normalizer.cc/h # ICU-based Unicode normalization
-        fuzzy.h             # Fuzzy matching support
-        text_iterator.h     # Text index iterator interface
-        radix_tree.h        # Radix tree type alias
-        rax/                # Vendored rax radix tree (C, excluded from formatting)
-    query/                  # Query engine
-      search.cc/h           # Core search logic, SearchParameters, SearchAsync
-      planner.cc/h          # Query plan generation
-      predicate.cc/h        # Filter predicates (numeric, tag, text)
-      content_resolution.cc/h # Key content fetching and attribute extraction
-      response_generator.cc/h # Search result formatting
-      fanout.cc/h           # Cluster fanout coordination
-      fanout_operation_base.h # Base class for fanout operations
-      cluster_info_fanout_operation.cc/h # FT.INFO cluster fanout
-      primary_info_fanout_operation.cc/h # FT.INFO primary fanout
-    coordinator/            # gRPC cluster coordinator
-      server.cc/h           # gRPC server for receiving fanout requests
-      client.cc/h           # gRPC client for sending fanout requests
-      client_pool.h         # Connection pool management
-      metadata_manager.cc/h # Index metadata synchronization across nodes
-      search_converter.cc/h # Protobuf <-> internal type conversion
-      info_converter.cc/h   # FT.INFO protobuf conversion
-      grpc_suspender.cc/h   # Graceful gRPC shutdown
-      util.h                # Coordinator utility functions
-      coordinator.proto     # gRPC service definition
-    expr/                   # Expression evaluation
-      expr.cc/h             # Filter expression AST and evaluator
-      value.cc/h            # Typed values for expression evaluation
-    utils/                  # Utility libraries
-      allocator.cc/h        # Custom memory allocator
-      cancel.cc/h           # Cancellation tokens for query timeouts
-      string_interning.cc/h # Interned string pointers for memory efficiency
-      patricia_tree.h       # Patricia tree (prefix trie) for key tracking
-      segment_tree.h        # Segment tree for numeric range queries
-      lru.h                 # LRU cache template
-      intrusive_list.h      # Intrusive doubly-linked list
-      intrusive_ref_count.h # Intrusive reference counting
-      scanner.h             # String scanner utility
-      inlined_priority_queue.h # Priority queue for top-K results
-  vmsdk/                    # Valkey Module SDK
+    module_loader.cc       VALKEY_MODULE(), command table
+    valkey_search.{cc,h}   ValkeySearch singleton - pools, lifecycle
+    valkey_search_options.{cc,h}
+    schema_manager.{cc,h}  index registry (per-db)
+    index_schema.{cc,h}    one schema - attributes, prefixes, backfill
+    keyspace_event_manager.{cc,h}  routes key mutations to indexes
+    server_events.{cc,h}   loading / flushing / fork callbacks
+    attribute.{cc,h}       attribute metadata + extraction
+    attribute_data_type.{cc,h}  custom data type for attribute storage
+    rdb_serialization.{cc,h}    protobuf RDB
+    vector_externalizer.{cc,h}  LRU vector externalization
+    acl.{cc,h}             prefix-based ACL checks
+    metrics.h  version.h
+    commands/
+      commands.{cc,h}       QueryCommand base; async reply/timeout/free
+      ft_create.cc  ft_search.{cc,h}  ft_aggregate.{cc,h}
+      ft_aggregate_exec.{cc,h}
+      ft_dropindex.cc  ft_info.cc  ft_list.cc  ft_debug.cc
+      ft_internal_update.cc  ft_*_parser.{cc,h}  filter_parser.{cc,h}
+      *.json                command metadata (flags, arity, key specs)
+    indexes/
+      index_base.h          IndexBase, IndexerType
+      vector_base.{cc,h}    shared vector logic
+      vector_hnsw.{cc,h}    HNSW
+      vector_flat.{cc,h}    FLAT
+      numeric.{cc,h}        segment tree
+      tag.{cc,h}            Patricia tree
+      text.{cc,h}           full-text wrapper
+      universal_set_fetcher.{cc,h}
+      text/
+        text_index.{cc,h}   postings
+        lexer.{cc,h}        tokenizer
+        posting.{cc,h}  term.{cc,h}  rax_wrapper.{cc,h}
+        flat_position_map.{cc,h}  proximity.{cc,h}  orproximity.{cc,h}
+        text_fetcher.{cc,h}  unicode_normalizer.{cc,h}  fuzzy.h
+        text_iterator.h  radix_tree.h
+        rax/                  vendored rax (C; excluded from formatting)
+    query/
+      search.{cc,h}         SearchParameters, SearchAsync
+      planner.{cc,h}        prefilter vs inline
+      predicate.{cc,h}      numeric / tag / text
+      content_resolution.{cc,h}
+      response_generator.{cc,h}
+      fanout.{cc,h}  fanout_operation_base.h
+      cluster_info_fanout_operation.{cc,h}
+      primary_info_fanout_operation.{cc,h}
+    coordinator/
+      server.{cc,h}  client.{cc,h}  client_pool.h
+      metadata_manager.{cc,h}
+      search_converter.{cc,h}  info_converter.{cc,h}
+      grpc_suspender.{cc,h}  util.h  coordinator.proto
+    expr/
+      expr.{cc,h}  value.{cc,h}
+    utils/
+      allocator.{cc,h}  cancel.{cc,h}  string_interning.{cc,h}
+      patricia_tree.h  segment_tree.h  lru.h
+      intrusive_list.h  intrusive_ref_count.h  scanner.h
+      inlined_priority_queue.h
+  vmsdk/
     src/
-      module.h              # VALKEY_MODULE() macro, Options struct
-      managed_pointers.h    # UniqueValkeyString, RAII wrappers
-      blocked_client.h      # Blocked client tracking by category
-      module_config.h       # Type-safe config with builder pattern
-      thread_pool.h         # Thread pool with priority scheduling
-      cluster_map.h         # Cluster topology and fanout targets
-      module_type.h         # Custom data type registration
-      memory_allocation.h   # Valkey-aware memory allocation
-      memory_tracker.h      # Memory usage tracking
-      command_parser.h      # Command argument iteration helpers
-      concurrency.h         # Thread utilities
-      time_sliced_mrmw_mutex.h # Multi-reader multi-writer mutex
-      log.h                 # Structured logging
-      info.h                # Module info callback helpers
-      debug.h               # Debug command helpers
-      utils.h               # General utilities
-      testing_infra/        # VMSDK mock infrastructure for unit tests
-      valkey_module_api/    # Valkey module API headers
-    versionscript.lds       # Linux symbol export control
-  testing/                  # Unit tests (see testing.md)
-  integration/              # Python integration tests
-  third_party/              # Vendored libraries
-  submodules/               # External dependency build scripts
+      module.h              VALKEY_MODULE(), Options
+      managed_pointers.h    UniqueValkeyString, RAII
+      blocked_client.h      blocked clients by category
+      module_config.h       type-safe configs (builder)
+      thread_pool.h         priority scheduling
+      cluster_map.h         topology + fanout targets
+      module_type.h         custom data type registration
+      memory_allocation.h  memory_tracker.h  command_parser.h
+      concurrency.h  time_sliced_mrmw_mutex.h
+      log.h  info.h  debug.h  utils.h
+      testing_infra/        mock ValkeyModule_* for unit tests
+      valkey_module_api/    Valkey API headers
+    versionscript.lds       Linux symbol export
+  testing/
+  integration/
+  third_party/  submodules/
 ```
 
-## IndexBase Abstract Class
-
-All index types implement `IndexBase` defined in `src/indexes/index_base.h`:
+## `IndexBase` (`src/indexes/index_base.h`)
 
 ```cpp
 class IndexBase {
  public:
-  virtual absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
-                                         absl::string_view data) = 0;
-  virtual absl::StatusOr<bool> RemoveRecord(const InternedStringPtr& key,
-                                            DeletionType deletion_type) = 0;
-  virtual absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
-                                            absl::string_view data) = 0;
-  virtual int RespondWithInfo(ValkeyModuleCtx* ctx) const = 0;
-  virtual absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const = 0;
-  virtual std::unique_ptr<data_model::Index> ToProto() const = 0;
-  virtual size_t GetTrackedKeyCount() const = 0;
-  virtual uint32_t GetMutationWeight() const = 0;
-  // ... key tracking, iteration, NormalizeStringRecord
+  virtual absl::StatusOr<bool> AddRecord   (const InternedStringPtr&, absl::string_view) = 0;
+  virtual absl::StatusOr<bool> RemoveRecord(const InternedStringPtr&, DeletionType)      = 0;
+  virtual absl::StatusOr<bool> ModifyRecord(const InternedStringPtr&, absl::string_view) = 0;
+  virtual int                  RespondWithInfo(ValkeyModuleCtx*) const = 0;
+  virtual absl::Status         SaveIndex(RDBChunkOutputStream) const  = 0;
+  virtual std::unique_ptr<data_model::Index> ToProto() const          = 0;
+  virtual size_t               GetTrackedKeyCount() const             = 0;
+  virtual uint32_t             GetMutationWeight() const              = 0;
+  // + key tracking / iteration / NormalizeStringRecord
 };
 ```
 
-The `IndexerType` enum and string-to-enum mapping:
+`IndexerType` enum and `kIndexerTypeByStr`:
 
-| Type | Enum | String Key | Implementation |
-|------|------|-----------|---------------|
-| HNSW vector | `kHNSW` | (via `kVector`) | `vector_hnsw.cc` (wraps hnswlib) |
-| FLAT vector | `kFlat` | (via `kVector`) | `vector_flat.cc` (brute-force) |
-| Numeric | `kNumeric` | `"NUMERIC"` | `numeric.cc` (segment tree) |
-| Tag | `kTag` | `"TAG"` | `tag.cc` (inverted index) |
-| Text | `kText` | `"TEXT"` | `text.cc` -> `text/text_index.cc` |
+| Enum | String | Impl |
+|------|--------|------|
+| `kHNSW` | (via `kVector`) | `vector_hnsw.cc` (hnswlib) |
+| `kFlat` | (via `kVector`) | `vector_flat.cc` (brute force) |
+| `kNumeric` | `"NUMERIC"` | `numeric.cc` (segment tree) |
+| `kTag` | `"TAG"` | `tag.cc` (Patricia tree) |
+| `kText` | `"TEXT"` | `text.cc` -> `text/text_index.cc` |
 
-The `kIndexerTypeByStr` map recognizes `"VECTOR"`, `"TAG"`, `"NUMERIC"`, and `"TEXT"`. Vector indexes are further resolved to HNSW or FLAT based on the algorithm parameter.
+`kIndexerTypeByStr` accepts `"VECTOR"`, `"TAG"`, `"NUMERIC"`, `"TEXT"`. Vector is resolved to HNSW / FLAT by the algorithm parameter.
 
-## How to Add a New Index Type
+## Adding a new index type
 
-1. **Define the index class** in `src/indexes/new_type.cc/h`:
-   - Inherit from `IndexBase`
-   - Implement all pure virtual methods: `AddRecord`, `RemoveRecord`, `ModifyRecord`, `RespondWithInfo`, `SaveIndex`, `ToProto`, key tracking, `GetMutationWeight`
-2. **Add the enum value** to `IndexerType` in `index_base.h` and the string mapping in `kIndexerTypeByStr`
-3. **Create the CMake target** in `src/indexes/CMakeLists.txt` as a static library
-4. **Wire into IndexSchema**: update `src/index_schema.cc` to instantiate your index type based on the schema proto attribute type
-5. **Add RDB serialization**: extend `rdb_serialization.cc` and the `index_schema.proto` with new fields
-6. **Add FT.CREATE parser support**: extend `src/commands/ft_create_parser.cc` to parse your type's parameters
-7. **Add FT.INFO support**: implement `RespondWithInfo` and update `ft_info.cc` if needed
-8. **Write unit tests** in `testing/` and add to the `indexes_test` binary in `testing/CMakeLists.txt`
-9. **Write integration tests** in `integration/`
+1. `src/indexes/new_type.{cc,h}` inheriting `IndexBase` - implement all pure virtuals.
+2. Add enum value in `index_base.h` + string mapping in `kIndexerTypeByStr`.
+3. CMake target in `src/indexes/CMakeLists.txt`.
+4. Wire into `src/index_schema.cc` instantiation by proto type.
+5. Extend `rdb_serialization.cc` + `index_schema.proto` fields.
+6. Extend `src/commands/ft_create_parser.cc`.
+7. `RespondWithInfo` + update `ft_info.cc` if needed.
+8. Unit tests -> `indexes_test` binary.
+9. Integration tests in `integration/`.
 
-## Command Registration Pattern
-
-Commands are registered in `src/module_loader.cc` via the `vmsdk::module::Options` struct:
+## Command registration (`module_loader.cc`)
 
 ```cpp
 vmsdk::module::Options options = {
     .name = "search",
-    .acl_categories = ACLPermissionFormatter({valkey_search::kSearchCategory}),
-    .commands = {
-        {
-            .cmd_name = "FT.CREATE",
-            .permissions = {...},
-            .flags = {vmsdk::module::kWriteFlag, vmsdk::module::kFastFlag,
-                      vmsdk::module::kDenyOOMFlag},
-            .cmd_func = &vmsdk::CreateCommand<valkey_search::FTCreateCmd>,
-        },
-        // ... more commands
-    },
-    .on_load = [](ValkeyModuleCtx *ctx, ...) { /* init singletons */ },
-    .on_unload = [](ValkeyModuleCtx *ctx, ...) { /* cleanup */ },
+    .acl_categories = ACLPermissionFormatter({kSearchCategory}),
+    .commands = {{
+        .cmd_name    = "FT.CREATE",
+        .permissions = {...},
+        .flags       = {kWriteFlag, kFastFlag, kDenyOOMFlag},
+        .cmd_func    = &vmsdk::CreateCommand<FTCreateCmd>,
+    }, /* ... */},
+    .on_load   = [](ctx, ...) { /* init singletons */ },
+    .on_unload = [](ctx, ...) { /* cleanup */ },
 };
 VALKEY_MODULE(options);
 ```
 
-The `VALKEY_MODULE(options)` macro generates the `ValkeyModule_OnLoad` and `ValkeyModule_OnUnload` entry points. Each command function has the signature `absl::Status Func(ValkeyModuleCtx*, ValkeyModuleString**, int)` - returning an error status causes VMSDK to reply with the error message.
+Handler signature: `absl::Status Func(ValkeyModuleCtx*, ValkeyModuleString**, int)`. Error status -> VMSDK replies with the error message.
 
-Registered commands: `FT.CREATE`, `FT.SEARCH`, `FT.AGGREGATE`, `FT.DROPINDEX`, `FT.INFO`, `FT._LIST`, `FT._DEBUG`, `FT.INTERNAL_UPDATE`.
+Commands: `FT.CREATE`, `FT.SEARCH`, `FT.AGGREGATE`, `FT.DROPINDEX`, `FT.INFO`, `FT._LIST`, `FT._DEBUG`, `FT.INTERNAL_UPDATE`.
 
-## VMSDK Key Abstractions
+## VMSDK abstractions
 
-| Abstraction | What it replaces | Why |
-|-------------|-----------------|-----|
-| `UniqueValkeyString` | Raw `ValkeyModuleString*` | RAII - auto-frees on scope exit |
-| `BlockedClient` | Raw `ValkeyModule_BlockClient` | Category tracking, timeout, measurement |
-| `vmsdk::config::Builder` | Raw `ValkeyModule_RegisterConfig` | Type-safe, validated, with change callbacks |
-| `vmsdk::ThreadPool` | Manual thread management | Priority scheduling, CPU monitoring |
-| `vmsdk::module::Options` | Manual `ValkeyModule_CreateCommand` calls | Declarative command table with ACL |
-| `vmsdk::cluster_map` | Manual cluster slot management | Automatic topology refresh, fanout targeting |
-| `TimeSlicedMRMWMutex` | Standard mutex | Multi-reader multi-writer with time slicing for fork safety |
+| Abstraction | Replaces | Why |
+|-------------|----------|-----|
+| `UniqueValkeyString` | raw `ValkeyModuleString*` | RAII auto-free |
+| `BlockedClient` | raw `ValkeyModule_BlockClient` | category, timeout, measurement |
+| `vmsdk::config::Builder` | raw `ValkeyModule_RegisterConfig` | type-safe + validation + callbacks |
+| `vmsdk::ThreadPool` | manual threads | priority scheduling, CPU monitor |
+| `vmsdk::module::Options` | manual `CreateCommand` | declarative command table |
+| `vmsdk::cluster_map` | manual slot management | topology refresh + fanout |
+| `TimeSlicedMRMWMutex` | standard mutex | MRMW + time-slice + fork-safe |
 
-## How to Add a New Query Feature
+## Adding a new query feature
 
-1. **Parser**: extend the relevant parser in `src/commands/` (e.g., `ft_search_parser.cc` for FT.SEARCH parameters)
-2. **SearchParameters**: add fields to `SearchParameters` in `src/query/search.h`
-3. **Query planner**: update `src/query/planner.cc` if the feature affects query planning
-4. **Predicate**: if adding a new filter type, create or extend predicates in `src/query/predicate.cc`
-5. **Expression**: if adding filter expression operators, extend `src/expr/expr.cc` and `src/expr/value.cc`
-6. **Response**: update `src/query/response_generator.cc` if the output format changes
-7. **Fanout**: update `src/query/fanout.cc` and the converter in `src/coordinator/search_converter.cc` if the feature needs cluster support
-8. **Tests**: add parser tests, unit tests for the logic, and integration tests
+1. Parser in `src/commands/` (e.g., `ft_search_parser.cc`).
+2. `SearchParameters` fields in `src/query/search.h`.
+3. Planner -> `src/query/planner.cc` if it affects planning.
+4. New filter type -> `src/query/predicate.cc`.
+5. New expression operator -> `src/expr/expr.cc` + `value.cc`.
+6. Response format -> `src/query/response_generator.cc`.
+7. Cluster support -> `src/query/fanout.cc` + `src/coordinator/search_converter.cc`.
+8. Parser tests + unit + integration.
 
-## Key Singletons
+## Singletons
 
-| Singleton | Access | Responsibility |
-|-----------|--------|---------------|
-| `ValkeySearch::Instance()` | `src/valkey_search.h` | Module lifecycle, thread pools, coordinator |
-| `SchemaManager::Instance()` | `src/schema_manager.h` | Index schema registry, per-db lookup |
-| `KeyspaceEventManager` | `src/keyspace_event_manager.h` | Routes key mutations to indexes |
+| Singleton | Header | Role |
+|-----------|--------|------|
+| `ValkeySearch::Instance()` | `valkey_search.h` | module lifecycle, pools, coordinator |
+| `SchemaManager::Instance()` | `schema_manager.h` | index registry, per-db lookup |
+| `KeyspaceEventManager` | `keyspace_event_manager.h` | route mutations to indexes |
 
-Both `ValkeySearch` and `KeyspaceEventManager` are initialized in `module_loader.cc` during `on_load`.
+Both `ValkeySearch` and `KeyspaceEventManager` init in `module_loader.cc` `on_load`.
 
-## Proto Files
+## Protos
 
 | File | Purpose |
 |------|---------|
-| `src/index_schema.proto` | Index schema definition (attributes, types, parameters) |
+| `src/index_schema.proto` | schema definition (attributes, types, params) |
 | `src/rdb_section.proto` | RDB persistence format |
-| `src/coordinator/coordinator.proto` | gRPC service for cluster coordination |
+| `src/coordinator/coordinator.proto` | gRPC service |
 
-Proto files are compiled to C++ via CMake's `valkey_search_create_proto_library` function defined in `cmake/Modules/valkey_search.cmake`.
+Compiled to C++ via CMake's `valkey_search_create_proto_library` (`cmake/Modules/valkey_search.cmake`).

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-testing.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-testing.md
@@ -59,12 +59,33 @@ In `integration/`. Load `libsearch.so` into a real Valkey process and exercise c
 
 ### Coverage
 
-- Core: `test_vss_basic`, `test_fulltext*`, `test_ft_create*`, `test_ft_dropindex*`, `test_postfilter`, `test_filter_expressions`, `test_non_vector`, `test_query_parser`.
-- Persistence / modules: `test_saverestore`, `test_endurance_save_restore`, `test_rdb_load_*`, `test_json_operations`, `test_cross_module_compat`.
-- Behaviour: `test_oom_handling`, `test_eviction`, `test_expired`, `test_copy`, `test_multi_lua`, `test_flushall`, `test_cancel`, `test_debug`, `test_aggregate_metrics`.
-- Cluster: `test_info*`, `test_multidb_search`, `test_dbnum`, `test_singleslot`, `test_versioning`.
-- Security: `test_valkey_search_acl`.
-- `compatibility/` subtree for cross-version.
+| File | Covers |
+|------|--------|
+| `test_vss_basic.py` | vector similarity search fundamentals |
+| `test_fulltext*.py` | full-text search, space performance, inflight blocking |
+| `test_ft_create*.py` | index creation and consistency |
+| `test_ft_dropindex*.py` | index deletion and consistency |
+| `test_postfilter.py` | post-filter expression evaluation |
+| `test_filter_expressions.py` | pre-filter predicates |
+| `test_non_vector.py` | non-vector field queries |
+| `test_query_parser.py` | query parsing edge cases |
+| `test_saverestore.py`, `test_endurance_save_restore.py` | RDB persistence round-trips |
+| `test_rdb_load_*.py` | RDB compatibility (v1.0, without module) |
+| `test_json_operations.py`, `test_cross_module_compat.py` | JSON module cross-compatibility |
+| `test_oom_handling.py` | out-of-memory behavior |
+| `test_eviction.py`, `test_expired.py` | key eviction and expiration |
+| `test_copy.py` | key copy behavior |
+| `test_multi_lua.py` | MULTI/EXEC and Lua interactions |
+| `test_flushall.py` | FLUSHALL behavior |
+| `test_cancel.py` | query cancellation |
+| `test_debug.py` | FT._DEBUG command |
+| `test_aggregate_metrics.py` | FT.AGGREGATE metrics |
+| `test_info*.py` | FT.INFO (cluster, primary, local) |
+| `test_multidb_search.py`, `test_dbnum.py` | multi-database |
+| `test_singleslot.py` | single-slot query behavior |
+| `test_versioning.py` | module versioning |
+| `test_valkey_search_acl.py` | ACL permission enforcement |
+| `compatibility/` | cross-version compatibility subtree |
 
 ### Running
 

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-testing.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/contributing-testing.md
@@ -1,241 +1,154 @@
 # Testing
 
-Use when running tests, adding new test cases, understanding the test infrastructure, or debugging test failures.
+Use when running tests, adding test cases, or debugging failures.
 
-Source: `testing/CMakeLists.txt`, `testing/`, `testing/integration/`, `integration/`, `build.sh`
+Source: `testing/`, `testing/CMakeLists.txt`, `testing/integration/`, `integration/`, `build.sh`.
 
-## Contents
+## Tiers
 
-- [Test Tiers](#test-tiers)
-- [Unit Tests](#unit-tests)
-- [Python Integration Tests](#python-integration-tests)
-- [Stability and Endurance Tests](#stability-and-endurance-tests)
-- [Test Output and Debugging](#test-output-and-debugging)
-- [Adding a New Test](#adding-a-new-test)
+| Tier | Framework | Location | Scope |
+|------|-----------|----------|-------|
+| Unit | GoogleTest (C++) | `testing/` | components in isolation w/ mocked Valkey API |
+| Integration | pytest | `integration/` | full module loaded into real Valkey |
+| Stability | Python + `memtier_benchmark` | `testing/integration/` | sustained load |
 
-## Test Tiers
+## Unit tests
 
-valkey-search has three test tiers:
+### Binaries
 
-| Tier | Framework | Location | What it tests |
-|------|-----------|----------|---------------|
-| Unit tests | GoogleTest (C++) | `testing/` | Individual components in isolation with mocked Valkey API |
-| Integration tests (Python) | pytest | `integration/` | Full module loaded into a real Valkey server |
-| Stability / endurance tests | Python + memtier_benchmark | `testing/integration/` | Long-running load and stability with memtier_benchmark |
+`testing/CMakeLists.txt` groups sources into 7 binaries:
 
-## Unit Tests
+| Binary | Scope |
+|--------|-------|
+| `commands_test` | FT.CREATE / SEARCH / AGGREGATE / DROPINDEX / INFO / LIST parsers, filter, INTERNAL_UPDATE |
+| `indexes_test` | index_schema, numeric, tag, text, vector, lexer, posting |
+| `core_test` | valkey_search, schema_manager, keyspace_event_manager, server_events, attribute_data_type, MULTI/EXEC, vector_externalizer, ACL, RDB |
+| `query_test` | search, response_generator |
+| `coordinator_test` | metadata_manager, client |
+| `valkey_utils_test` | allocator, intrusive_list, intrusive_ref_count, LRU, patricia_tree, segment_tree, string_interning |
+| `text_index_test` | flat_position_map, radix, rax_wrapper, text_index_schema |
 
-### Test Binaries
+### Infrastructure
 
-The `testing/CMakeLists.txt` groups test source files into seven binaries:
+`testing/common.{h,cc}` provides mocked `ValkeyModuleCtx`/`ValkeyModuleString` via VMSDK's `vmsdk/src/testing_infra/`, index-schema/test-data helpers. Shared `testing_common_base` static library linked by all test binaries. `testing_common_coordinator` interface library for coordinator-needing tests.
 
-| Binary | Test Files | Scope |
-|--------|-----------|-------|
-| `commands_test` | FT.CREATE/SEARCH/AGGREGATE/DROPINDEX/INFO/LIST parsers, filter, FT.INTERNAL_UPDATE | Command parsing and execution |
-| `indexes_test` | index_schema, numeric, tag, text, vector, lexer, posting | Index data structures and operations |
-| `core_test` | valkey_search, schema_manager, keyspace_event_manager, server_events, attribute_data_type, MULTI/EXEC, vector_externalizer, ACL, RDB serialization | Core module lifecycle |
-| `query_test` | search, response_generator | Query execution and result formatting |
-| `coordinator_test` | metadata_manager, client | gRPC coordinator communication |
-| `valkey_utils_test` | allocator, intrusive_list, intrusive_ref_count, LRU, patricia_tree, segment_tree, string_interning | Utility data structures |
-| `text_index_test` | flat_position_map, radix, rax_wrapper, text_index_schema | Full-text index internals |
-
-### Test Infrastructure
-
-Tests use `testing/common.h` and `testing/common.cc` which provide:
-
-- Mocked `ValkeyModuleCtx` and `ValkeyModuleString` via VMSDK's testing infrastructure (`vmsdk/src/testing_infra/`)
-- Helper functions for creating index schemas and test data
-- A shared `testing_common_base` static library linked by all test binaries
-- A `testing_common_coordinator` interface library for tests needing coordinator functionality
-
-### Running Unit Tests
+### Running
 
 ```bash
-# Build and run all unit tests
-./build.sh --run-tests
-
-# Run a specific test binary
-./build.sh --run-tests=commands_test
-
-# Run with verbose output on failure
-./build.sh --run-tests --test-errors-stdout
-
-# Run with AddressSanitizer
+./build.sh --run-tests                              # all
+./build.sh --run-tests=commands_test                # one binary
+./build.sh --run-tests --test-errors-stdout         # print failed output
 ./build.sh --asan --run-tests
-
-# Run with ThreadSanitizer
 ./build.sh --tsan --run-tests
 ```
 
-Test binaries are placed in `.build-release/tests/` (or the corresponding build directory). They can also be run directly:
+Binaries under `.build-release/tests/`. Direct invocation:
 
 ```bash
 .build-release/tests/indexes_test --gtest_brief=1
 .build-release/tests/commands_test --gtest_filter="*FTCreate*"
 ```
 
-Test output is logged to `.build-release/tests.out`. Individual test output goes to `.build-release/current_test.out` during execution.
+Output at `.build-release/tests.out`. Per-test during exec at `.build-release/current_test.out`.
 
-### Sanitizer Behavior
+Under `--asan` / `--tsan` the runner continues past failures (collect full report set); exits non-zero if any failed. Google Benchmark disabled for SAN.
 
-When running with `--asan` or `--tsan`, the test runner does not stop at the first failure. All test binaries run to completion so the full set of sanitizer reports can be collected. The script exits with a non-zero code if any test failed.
+## Integration tests (Python)
 
-## Python Integration Tests
+In `integration/`. Load `libsearch.so` into a real Valkey process and exercise commands end-to-end.
 
-Located in `integration/`, these tests load `libsearch.so` into a real Valkey server process and exercise commands end-to-end.
+### Coverage
 
-### Test Categories
+- Core: `test_vss_basic`, `test_fulltext*`, `test_ft_create*`, `test_ft_dropindex*`, `test_postfilter`, `test_filter_expressions`, `test_non_vector`, `test_query_parser`.
+- Persistence / modules: `test_saverestore`, `test_endurance_save_restore`, `test_rdb_load_*`, `test_json_operations`, `test_cross_module_compat`.
+- Behaviour: `test_oom_handling`, `test_eviction`, `test_expired`, `test_copy`, `test_multi_lua`, `test_flushall`, `test_cancel`, `test_debug`, `test_aggregate_metrics`.
+- Cluster: `test_info*`, `test_multidb_search`, `test_dbnum`, `test_singleslot`, `test_versioning`.
+- Security: `test_valkey_search_acl`.
+- `compatibility/` subtree for cross-version.
 
-| File Pattern | What it tests |
-|-------------|---------------|
-| `test_vss_basic.py` | Vector similarity search fundamentals |
-| `test_fulltext*.py` | Full-text search, space performance, inflight blocking |
-| `test_ft_create*.py` | Index creation and consistency |
-| `test_ft_dropindex*.py` | Index deletion and consistency |
-| `test_postfilter.py` | Post-filter expression evaluation |
-| `test_filter_expressions.py` | Pre-filter predicates |
-| `test_saverestore.py`, `test_endurance_save_restore.py` | RDB persistence round-trips |
-| `test_json_operations.py`, `test_cross_module_compat.py` | JSON module cross-compatibility |
-| `test_oom_handling.py` | Out-of-memory behavior |
-| `test_valkey_search_acl.py` | ACL permission enforcement |
-| `test_multidb_search.py`, `test_dbnum.py` | Multi-database search |
-| `test_info*.py` | FT.INFO output, cluster info, primary info |
-| `test_eviction.py`, `test_expired.py` | Key eviction and expiration handling |
-| `test_copy.py` | Key copy behavior |
-| `test_multi_lua.py` | MULTI/EXEC and Lua script interactions |
-| `test_rdb_load_*.py` | RDB compatibility (v1.0, without module) |
-| `test_cancel.py` | Query cancellation |
-| `test_debug.py` | FT._DEBUG command |
-| `test_non_vector.py` | Non-vector field queries |
-| `test_query_parser.py` | Query parsing edge cases |
-| `test_aggregate_metrics.py` | FT.AGGREGATE metrics |
-| `test_flushall.py` | FLUSHALL behavior |
-| `test_singleslot.py` | Single-slot query behavior |
-| `test_versioning.py` | Module versioning |
-| `compatibility/` | Cross-version compatibility tests |
-
-### Running Integration Tests
+### Running
 
 ```bash
-# Build and run all integration tests
 ./build.sh --run-integration-tests
-
-# Run with a pattern filter
 ./build.sh --run-integration-tests=test_vss_basic
-
-# Run only OSS integration tests (skips stability tests)
-./build.sh --run-integration-tests=oss
-
-# Run with retries
+./build.sh --run-integration-tests=oss           # skip stability
 ./build.sh --run-integration-tests --retries=3
-
-# Run with ASan
 ./build.sh --asan --run-integration-tests
 ```
 
-### Integration Test Infrastructure
+### `integration/run.sh` flow
 
-The `integration/run.sh` script:
+1. Locate `valkey-server` (download via `setup_valkey_server` if needed).
+2. Locate `valkey-json` module for cross-module tests.
+3. Python venv + install deps.
+4. pytest against `integration/` with optional `-k` filter.
+5. Under SAN - terminate server, grep logs for ASan/TSan errors.
 
-1. Locates `valkey-server` binary (downloads if needed via `setup_valkey_server`)
-2. Locates the `valkey-json` module for cross-module tests
-3. Creates a Python virtual environment and installs test dependencies
-4. Runs pytest against `integration/` with optional pattern filtering
-5. After sanitizer runs, terminates the server and checks server logs for ASan/TSan errors
+### Env
 
-Key environment variables used by tests:
+| Var | Use |
+|-----|-----|
+| `MODULE_PATH` | `libsearch.so` |
+| `VALKEY_SERVER_PATH` | `valkey-server` |
+| `JSON_MODULE_PATH` | `libjson.so` for cross-module |
+| `LOGS_DIR` | server log dir |
+| `TEST_PATTERN` | pytest `-k` filter |
+| `INTEG_RETRIES` | flaky retry count |
+| `PYTEST_CAPTURE_DISABLED` | `1` disables capture |
 
-| Variable | Purpose |
-|----------|---------|
-| `MODULE_PATH` | Path to `libsearch.so` |
-| `VALKEY_SERVER_PATH` | Path to `valkey-server` binary |
-| `JSON_MODULE_PATH` | Path to `libjson.so` for cross-module tests |
-| `LOGS_DIR` | Server log output directory |
-| `TEST_PATTERN` | pytest `-k` filter expression |
-| `INTEG_RETRIES` | Number of retry attempts for flaky tests |
-| `PYTEST_CAPTURE_DISABLED` | Set to `1` to disable pytest output capture |
+Base class `valkey_search_test_case.py` handles server startup, module loading, cleanup.
 
-The base test class `valkey_search_test_case.py` handles server startup, module loading, and cleanup.
+## Stability / endurance (`testing/integration/`)
 
-## Stability and Endurance Tests
+- `vector_search_integration_test.py` - vector search under load.
+- `stability_test.py` - long-running sustained write/read.
+- `ft_internal_update_integration_test.py` - INTERNAL_UPDATE replication under load.
 
-Located in `testing/integration/`, these are Python scripts that use `memtier_benchmark` for sustained load generation against a Valkey server with the search module loaded:
+`testing/integration/run.sh`:
 
-- `vector_search_integration_test.py` - vector search integration under load
-- `stability_test.py` - long-running stability under sustained write/read traffic
-- `ft_internal_update_integration_test.py` - FT.INTERNAL_UPDATE replication under load
-
-The `testing/integration/run.sh` script:
-
-1. Builds a Python virtual environment in the build directory
-2. Sets up the Valkey server and JSON module binaries
-3. Verifies `memtier_benchmark` is available in PATH
-4. Runs the selected test with server process management
-5. For sanitizer builds, terminates the server and checks logs for ASan/TSan errors
-
-Key environment variables:
-
-| Variable | Purpose |
-|----------|---------|
-| `MEMTIER_PATH` | Path to memtier_benchmark binary |
-| `VALKEY_SEARCH_PATH` | Path to `libsearch.so` |
-| `TEST_UNDECLARED_OUTPUTS_DIR` | Directory for test output artifacts |
-| `TEST_TMPDIR` | Temporary directory for test working files |
+1. Build Python venv in build dir.
+2. Set up server + JSON module binaries.
+3. Require `memtier_benchmark` in PATH.
+4. Run selected test with server process management.
+5. SAN builds - terminate + grep logs.
 
 ```bash
-# Run stability tests (from testing/integration/)
 cd testing/integration && ./run.sh --test stability
-
-# Run vector search integration test
 cd testing/integration && ./run.sh --test vector_search_integration
-
-# Run with sanitizer
-cd testing/integration && ./run.sh --asan
+cd testing/integration && ./run.sh --asan    # only vector_search_integration supported under SAN
 ```
 
-When running with sanitizers, only `vector_search_integration` is supported.
+| Env | Use |
+|-----|-----|
+| `MEMTIER_PATH` | memtier binary |
+| `VALKEY_SEARCH_PATH` | `libsearch.so` |
+| `TEST_UNDECLARED_OUTPUTS_DIR` | artifacts |
+| `TEST_TMPDIR` | working files |
 
-## Test Output and Debugging
-
-### Unit Test Output
-
-- All output: `.build-release/tests.out`
-- Per-test output during execution: `.build-release/current_test.out`
-- Use `--test-errors-stdout` to dump failed test output to the terminal
-
-### Integration Test Output
-
-- Server logs: `.build-release/integration/.valkey-test-framework/`
-- Use `--capture` flag with `integration/run.sh` to disable pytest output capture and see `print()` statements in real-time
-- Set `PYTEST_CAPTURE_DISABLED=1` environment variable for the same effect
-
-### Common Debugging Patterns
+## Debugging
 
 ```bash
-# Run a single integration test with verbose output
 cd integration && TEST_PATTERN=test_vss_basic ./run.sh --capture
-
-# Run a unit test with GTest filter and full output
 .build-release/tests/indexes_test --gtest_filter="*NumericIndex*" --gtest_print_time=1
-
-# Debug a failing test under GDB
 gdb --args .build-release/tests/core_test --gtest_filter="*SchemaManager*"
 ```
 
-## Adding a New Test
+Integration server logs: `.build-release/integration/.valkey-test-framework/`. Use `--capture` with `integration/run.sh` (or `PYTEST_CAPTURE_DISABLED=1`) for real-time `print()`.
 
-### Unit Test
+## Adding a test
 
-1. Create `testing/<component>_test.cc` (or add to an existing file in the appropriate suite)
-2. Include `testing/common.h` for test infrastructure
-3. Add the source file to the appropriate test binary in `testing/CMakeLists.txt`
-4. Link any additional libraries the test needs
-5. Verify the test passes under both normal and sanitizer builds
+### Unit
 
-### Integration Test
+1. `testing/<component>_test.cc` (or append to existing).
+2. Include `testing/common.h`.
+3. Add source to the appropriate binary in `testing/CMakeLists.txt`.
+4. Link any extra libs.
+5. Verify under normal + SAN builds.
 
-1. Create `integration/test_<feature>.py`
-2. Import from `valkey_search_test_case.py` for the base class
-3. Use `utils.py` helpers for server setup and command execution
-4. Tests are auto-discovered by pytest - no registration needed
-5. Ensure proper cleanup of server processes and temporary files
+### Integration
+
+1. `integration/test_<feature>.py`.
+2. Import from `valkey_search_test_case.py`.
+3. Use `utils.py` helpers.
+4. pytest auto-discovery (no registration).
+5. Clean up processes + temp files.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-flat.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-flat.md
@@ -1,76 +1,45 @@
-# FLAT Brute-Force Vector Index
+# FLAT brute-force vector index
 
-Use when working on the exact nearest neighbor vector index, modifying brute-force search, or understanding the FLAT index alternative to HNSW.
+Use when reasoning about exact KNN, in-place modify, or the FLAT alternative to HNSW.
 
-Source: `src/indexes/vector_flat.h`, `src/indexes/vector_flat.cc`, `src/indexes/vector_base.h`
+Source: `src/indexes/vector_flat.{h,cc}`, `src/indexes/vector_base.h`.
 
-## Class Overview
-
-`VectorFlat<T>` is the brute-force (exact) vector search index. It wraps `hnswlib::BruteforceSearch<T>` and shares the `VectorBase` parent class with `VectorHNSW<T>`. FLAT provides exact KNN results with no graph overhead - every vector is compared during search.
-
-## VectorFlat Template
+## `VectorFlat<T>`
 
 ```cpp
 template <typename T>
 class VectorFlat : public VectorBase {
   std::unique_ptr<hnswlib::BruteforceSearch<T>> algo_;
-  std::unique_ptr<hnswlib::SpaceInterface<T>> space_;
+  std::unique_ptr<hnswlib::SpaceInterface<T>>   space_;
   uint32_t block_size_;
   mutable absl::Mutex resize_mutex_;
   mutable absl::Mutex tracked_vectors_mutex_;
   absl::flat_hash_map<uint64_t, InternedStringPtr> tracked_vectors_;
 };
-// Only instantiation:
 template class VectorFlat<float>;
 ```
 
-Unlike HNSW's deque-based `tracked_vectors_`, FLAT uses a `flat_hash_map<uint64_t, InternedStringPtr>` keyed by internal ID. This enables actual deletion of tracked vectors (HNSW only tombstones them).
+Only instantiated for `float`. Shares `VectorBase` with HNSW. Differs from HNSW's `deque<InternedStringPtr>` - FLAT uses a `flat_hash_map` keyed by internal ID (enables actual deletion; HNSW only tombstones).
 
-Creation via `VectorFlat<T>::Create()`:
+Creation (`Create`): reads `dimension_count`, `distance_metric`, `flat_algorithm.block_size`, constructs `BruteforceSearch` with `initial_cap`.
 
-```cpp
-auto index = std::shared_ptr<VectorFlat<T>>(new VectorFlat<T>(
-    vector_index_proto.dimension_count(),
-    vector_index_proto.distance_metric(),
-    vector_index_proto.flat_algorithm().block_size(),
-    attribute_identifier, attribute_data_type));
-index->Init(vector_index_proto.dimension_count(),
-            vector_index_proto.distance_metric(), index->space_);
-index->algo_ = std::make_unique<hnswlib::BruteforceSearch<T>>(
-    index->space_.get(), vector_index_proto.initial_cap());
-```
+## Resize
 
-The `block_size` is read from the `FlatAlgorithm` protobuf and stored as `block_size_`. The private constructor also stores `distance_metric` via the `VectorBase` parent.
+`AddRecordImpl` catches capacity exception, calls `ResizeIfFull()`:
 
-## Block-Size Capacity Growth
+1. R-lock: compare `algo_->cur_element_count_` vs `GetCapacity()`.
+2. Full -> W-lock on `resize_mutex_` **and** `algo_->index_lock` (internal `std::mutex`).
+3. Re-check, then `algo_->resizeIndex(GetCapacity() + block_size_)`.
 
-Like HNSW, FLAT starts at `initial_cap` and grows dynamically. When `AddRecordImpl()` catches the hnswlib capacity exception, it calls `ResizeIfFull()`:
+Differences from HNSW resize:
 
-```cpp
-absl::Status VectorFlat<T>::ResizeIfFull() {
-  {
-    absl::ReaderMutexLock lock(&resize_mutex_);
-    if (algo_->cur_element_count_ < GetCapacity()) {
-      return absl::OkStatus();
-    }
-  }
-  absl::WriterMutexLock lock(&resize_mutex_);
-  std::unique_lock<std::mutex> index_lock(algo_->index_lock);
-  if (algo_->cur_element_count_ == GetCapacity()) {
-    algo_->resizeIndex(GetCapacity() + block_size_);
-  }
-  return absl::OkStatus();
-}
-```
+- Two locks taken (class mutex + hnswlib internal).
+- Block size = user-configured `block_size_` (FlatAlgorithm proto), **not** the global HNSW block size.
+- Capacity via `algo_->data_->getCapacity()` / `GetCapacity()` (not `max_elements_`).
+- No `allow_replace_deleted_` - FLAT has true deletion, no need.
+- Resize logged via `VMSDK_LOG_EVERY_N_SEC` WARNING.
 
-Key differences from HNSW resize:
-- FLAT acquires both `resize_mutex_` (writer) and `algo_->index_lock` (hnswlib internal)
-- Growth is by the user-configured `block_size_` (not the global HNSW block size)
-- Capacity is read from `algo_->data_->getCapacity()` via `GetCapacity()` rather than `algo_->max_elements_`
-- No `allow_replace_deleted_` optimization - FLAT has true deletion
-- Resize is logged at WARNING level via `VMSDK_LOG_EVERY_N_SEC`
-
-## KNN Search
+## KNN search
 
 ```cpp
 absl::StatusOr<std::vector<Neighbor>> Search(
@@ -79,92 +48,65 @@ absl::StatusOr<std::vector<Neighbor>> Search(
     std::unique_ptr<hnswlib::BaseFilterFunctor> filter = nullptr);
 ```
 
-The search flow:
-1. Validate query vector size via `IsValidSizeVector()`
-2. Normalize query if COSINE metric is configured
-3. Acquire reader lock on `resize_mutex_`
-4. Call `algo_->searchKnn()` with count capped at `algo_->cur_element_count_`
-5. Convert result via `CreateReply()`
+Flow: `IsValidSizeVector()`, normalize if COSINE, R-lock on `resize_mutex_` held for entire search, `algo_->searchKnn(count capped at cur_element_count_)`, convert via `CreateReply()`.
 
-Notable differences from HNSW search:
-- **No `ef_runtime` parameter** - brute force has no beam width to tune
-- **No `enable_partial_results`** - brute force either completes or is cancelled
-- **Count is clamped** to `min(count, cur_element_count_)` - prevents searching for more results than exist
-- The reader lock is held for the entire search, not just validation
+Differences from HNSW:
 
-The `CancelCondition` wrapper is a separate local class in `vector_flat.cc` (structurally identical to the one in `vector_hnsw.cc`) - it adapts `cancel::Token` to `hnswlib::BaseCancellationFunctor`.
+- **No `ef_runtime`** - brute force has no beam width.
+- **No `enable_partial_results`** - all-or-cancelled.
+- `count` clamped to `min(count, cur_element_count_)`.
+- R-lock held for the full search, not just validation.
 
-## Record Lifecycle
+`CancelCondition` is a structurally identical local class duplicated in `vector_flat.cc` (not shared with HNSW).
 
-**Add**: Same parent flow as HNSW. `AddRecordImpl()` calls `algo_->addPoint()`. On capacity overflow, retries after `ResizeIfFull()`. Exception counter: `flat_add_exceptions_cnt`.
+## Record lifecycle
 
-**Modify**: Unlike HNSW's mark-delete-then-add pattern, FLAT does an in-place update:
-
-```cpp
-absl::Status VectorFlat<T>::ModifyRecordImpl(uint64_t internal_id,
-                                             absl::string_view record) {
-  absl::ReaderMutexLock lock(&resize_mutex_);
-  std::unique_lock<std::mutex> index_lock(algo_->index_lock);
+- **Add**: parent flow same as HNSW. `algo_->addPoint()`, retry on overflow via `ResizeIfFull()`. Exception counter `flat_add_exceptions_cnt`.
+- **Modify** (in-place, unlike HNSW's mark-delete + re-add):
+  ```cpp
+  R-lock resize_mutex_; std::unique_lock index_lock(algo_->index_lock);
   auto found = algo_->dict_external_to_internal.find(internal_id);
-  // Direct memory copy: update label and data pointer
-  memcpy((*algo_->data_)[found->second] + algo_->data_ptr_size_,
-         &internal_id, sizeof(hnswlib::labeltype));
+  memcpy((*algo_->data_)[found->second] + algo_->data_ptr_size_, &internal_id, sizeof(hnswlib::labeltype));
   *(char**)((*algo_->data_)[found->second]) = (char*)record.data();
-  return absl::OkStatus();
-}
-```
+  ```
+  Writes directly to hnswlib internal data: updates label and interned-vector pointer.
+- **Remove**: `algo_->removePoint()` - **physical removal** (unlike HNSW tombstones). FLAT storage does not grow unboundedly with modifications. Exception counter `flat_remove_exceptions_cnt`.
 
-This writes directly to the hnswlib internal data array, updating both the label and the pointer to the interned vector data.
-
-**Remove**: `RemoveRecordImpl()` calls `algo_->removePoint()` which physically removes the entry (unlike HNSW's tombstone approach). This means FLAT's storage does not grow unboundedly with modifications. Exception counter: `flat_remove_exceptions_cnt`.
-
-## Vector Tracking
-
-FLAT tracks vectors by internal ID in a `flat_hash_map`:
+## Vector tracking
 
 ```cpp
-void TrackVector(uint64_t internal_id, const InternedStringPtr& vector) {
-  absl::MutexLock lock(&tracked_vectors_mutex_);
-  tracked_vectors_[internal_id] = vector;
-}
-
-void UnTrackVector(uint64_t internal_id) {
-  absl::MutexLock lock(&tracked_vectors_mutex_);
-  tracked_vectors_.erase(internal_id);
-}
+TrackVector(id, ptr)   -> tracked_vectors_[id] = ptr;
+UnTrackVector(id)      -> tracked_vectors_.erase(id);
+IsVectorMatch(id, v)   -> it->second->Str() == v->Str();  // parent UpdateMetadata no-op shortcut
 ```
 
-`IsVectorMatch()` compares the interned string contents via `it->second->Str() == vector->Str()`, enabling the parent `UpdateMetadata()` to detect no-op modifications and skip unnecessary work.
+Under `tracked_vectors_mutex_`.
 
-## Concurrency Model
+## Concurrency
 
-Two mutexes protect FLAT state:
+- `resize_mutex_` - R-lock for search/add, W-lock for resize.
+- `tracked_vectors_mutex_` - the tracked map.
+- Modify additionally takes `algo_->index_lock` (stricter than HNSW modify which only needs the R-lock).
+- Parent `VectorBase::key_to_metadata_mutex_` for the key-to-ID map.
 
-- `resize_mutex_` (absl::Mutex) - reader/writer lock protecting `algo_`. Search and add take reader locks. Resize takes writer lock.
-- `tracked_vectors_mutex_` - protects the tracked vectors map.
+Allocation overrides: same as HNSW - `memory_allocation_overrides.h` must be included before `bruteforce.h` / `hnswlib.h`.
 
-Modify additionally acquires `algo_->index_lock` (an internal `std::mutex`) to protect the in-place data update. This is stricter than HNSW's modify which only needs the resize reader lock.
+## RDB
 
-The parent `VectorBase::key_to_metadata_mutex_` protects the key-to-ID mapping as with HNSW.
+`SaveIndexImpl()` -> `algo_->SaveIndex(RDBChunkOutputStream)`. `LoadFromRDB()` constructs `BruteforceSearch`, `LoadIndex(RDBChunkInputStream)`.
 
-Memory allocation overrides: Same as HNSW - `memory_allocation_overrides.h` must be included before `bruteforce.h` and `hnswlib.h` to route hnswlib allocations through Valkey's allocator.
+No `ef_runtime` persistence (N/A). `block_size` persists in `FlatAlgorithm` proto. `RespondWithInfoImpl()` reports `data_type`, algorithm name, `block_size` for FT.INFO.
 
-## RDB Persistence
-
-`SaveIndexImpl()` delegates to `algo_->SaveIndex()` with `RDBChunkOutputStream`. `LoadFromRDB()` constructs a new `BruteforceSearch` and calls `LoadIndex()`.
-
-Unlike HNSW, FLAT does not persist `ef_runtime` (there is none). The `block_size` is stored in the `FlatAlgorithm` protobuf message and restored on load. `RespondWithInfoImpl()` reports `data_type`, `algorithm name`, and `block_size` for `FT.INFO`.
-
-## FLAT vs HNSW Comparison
+## FLAT vs HNSW
 
 | Aspect | FLAT | HNSW |
 |--------|------|------|
-| Search accuracy | Exact KNN | Approximate (tunable via ef_runtime) |
-| Search complexity | O(n) | O(log n) typical |
-| Deletion | Physical removal (`removePoint`) | Tombstone only (`markDelete`) |
-| Modify strategy | In-place memory update | Mark-delete + re-add |
-| Tracked vectors storage | `flat_hash_map<uint64_t, InternedStringPtr>` | `deque<InternedStringPtr>` |
-| Capacity growth | `block_size` from FlatAlgorithm proto | Global HNSW block size |
-| Tuning parameters | None (block_size is structural) | M, ef_construction, ef_runtime |
-| Search parameters | count, filter | count, filter, ef_runtime, partial results |
-| `GetMaxInternalLabel` | Not implemented (returns 0) | Iterates `label_lookup_` |
+| Accuracy | exact KNN | approximate (tunable `ef_runtime`) |
+| Complexity | O(n) | O(log n) typical |
+| Deletion | physical (`removePoint`) | tombstone (`markDelete`) |
+| Modify | in-place memory write | mark-delete + re-add |
+| Tracked vectors | `flat_hash_map<uint64_t, InternedStringPtr>` | `deque<InternedStringPtr>` |
+| Growth | `block_size` from FlatAlgorithm proto | global HNSW block size |
+| Tuning | none (block_size is structural) | M, ef_construction, ef_runtime |
+| Search args | count, filter | count, filter, ef_runtime, partial_results |
+| `GetMaxInternalLabel` | not implemented (returns 0) | iterates `label_lookup_` |

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-hnsw.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-hnsw.md
@@ -1,132 +1,76 @@
-# HNSW Vector Index
+# HNSW vector index
 
-Use when working on the approximate nearest neighbor (ANN) vector index, tuning HNSW graph parameters, modifying search or insert behavior, or understanding the hnswlib integration.
+Use when reasoning about ANN vector search, HNSW graph parameters, or hnswlib integration.
 
-Source: `src/indexes/vector_hnsw.h`, `src/indexes/vector_hnsw.cc`, `src/indexes/vector_base.h`, `src/indexes/vector_base.cc`, `third_party/hnswlib/hnswalg.h`
+Source: `src/indexes/vector_hnsw.{h,cc}`, `src/indexes/vector_base.{h,cc}`, `third_party/hnswlib/hnswalg.h`.
 
-## Contents
-
-- [Class Hierarchy](#class-hierarchy)
-- [VectorHNSW Template](#vectorhnsw-template)
-- [HNSW Parameters](#hnsw-parameters)
-- [Distance Metrics](#distance-metrics)
-- [Dynamic Resize](#dynamic-resize)
-- [Search with Inline Filtering](#search-with-inline-filtering)
-- [PrefilterEvaluator](#prefilterevaluator)
-- [Record Lifecycle](#record-lifecycle)
-- [Concurrency Model](#concurrency-model)
-- [RDB Persistence](#rdb-persistence)
-- [Key Implementation Details](#key-implementation-details)
-
-## Class Hierarchy
+## Class hierarchy
 
 ```
-IndexBase (src/indexes/index_base.h)
-  -> VectorBase (src/indexes/vector_base.h) + hnswlib::VectorTracker
-       -> VectorHNSW<T> (src/indexes/vector_hnsw.h)
+IndexBase
+  -> VectorBase + hnswlib::VectorTracker
+       -> VectorHNSW<T>  (src/indexes/vector_hnsw.h)
        -> VectorFlat<T>  (src/indexes/vector_flat.h)
 ```
 
-## VectorHNSW Template
+## `VectorHNSW<T>`
 
-`VectorHNSW<T>` is a template class instantiated only for `float` (FLOAT32). It wraps `hnswlib::HierarchicalNSW<T>` from the vendored hnswlib library.
+Template instantiated only for `float` (FLOAT32). Wraps `hnswlib::HierarchicalNSW<T>`.
 
 ```cpp
 template <typename T>
 class VectorHNSW : public VectorBase {
   std::unique_ptr<hnswlib::HierarchicalNSW<T>> algo_;
-  std::unique_ptr<hnswlib::SpaceInterface<T>> space_;
+  std::unique_ptr<hnswlib::SpaceInterface<T>>  space_;
   mutable absl::Mutex resize_mutex_;
   mutable absl::Mutex tracked_vectors_mutex_;
   std::deque<InternedStringPtr> tracked_vectors_;
 };
-// Only instantiation:
 template class VectorHNSW<float>;
 ```
 
-Creation flows through `VectorHNSW<T>::Create()` which takes a `VectorIndex` proto, extracts `dimension_count`, `distance_metric`, and the HNSW-specific parameters (`m`, `ef_construction`, `ef_runtime`) from the `hnsw_algorithm` sub-proto. The `HierarchicalNSW` constructor receives `initial_cap` as the starting capacity. `allow_replace_deleted_` is set from `options::GetHNSWAllowReplaceDeleted()`.
+`Create()` reads `dimension_count`, `distance_metric`, and `hnsw_algorithm.{m, ef_construction, ef_runtime}` from the `VectorIndex` proto. Passes `initial_cap` to the `HierarchicalNSW` constructor. `allow_replace_deleted_` set from `options::GetHNSWAllowReplaceDeleted()`.
 
-## HNSW Parameters
-
-Three parameters control the HNSW graph:
+## HNSW parameters
 
 | Parameter | Accessor | Effect |
 |-----------|----------|--------|
-| `M` | `GetM()` | Max bi-directional links per node per layer. Higher M = better recall, more memory. |
-| `ef_construction` | `GetEfConstruction()` | Search width during index build. Higher = better graph quality, slower insertion. |
-| `ef_runtime` | `GetEfRuntime()` | Search width at query time. Higher = better recall, slower queries. Adjustable post-creation. |
+| `M` | `GetM()` | max bi-directional links per node per layer; higher M = better recall, more memory |
+| `ef_construction` | `GetEfConstruction()` | search width during build; higher = better graph quality, slower insert |
+| `ef_runtime` | `GetEfRuntime()` | search width at query time; higher = better recall, slower query; adjustable post-creation |
 
-These are stored in the `HierarchicalNSW` object itself (`algo_->M_`, `algo_->ef_construction_`, `algo_->ef_`). The values come from the `HNSWAlgorithm` protobuf message and are set during `Create()`:
+Stored on `algo_` (`M_`, `ef_construction_`, `ef_`). Set at `Create()` time:
 
 ```cpp
 index->algo_ = std::make_unique<hnswlib::HierarchicalNSW<T>>(
-    index->space_.get(), vector_index_proto.initial_cap(),
+    index->space_.get(), proto.initial_cap(),
     hnsw_proto.m(), hnsw_proto.ef_construction());
 index->algo_->setEf(hnsw_proto.ef_runtime());
 ```
 
-`ef_runtime` can be overridden per-query - the `Search()` method accepts an `optional<size_t> ef_runtime` parameter.
+`ef_runtime` is per-query overridable: `Search()` takes `optional<size_t> ef_runtime`.
 
-## Distance Metrics
+## Distance metrics (`kDistanceMetricByStr`)
 
-Three distance metrics are supported (defined in `kDistanceMetricByStr` in `vector_base.h`):
+| Metric | hnswlib space | Notes |
+|--------|---------------|-------|
+| `L2` | `L2Space` | Euclidean, no normalization |
+| `IP` | `InnerProductSpace` | no normalization |
+| `COSINE` | `InnerProductSpace` | vectors normalized on insert; `normalize_ = true`; query normalized before search |
 
-| Metric | hnswlib Space | Stored in `space_` | Notes |
-|--------|---------------|--------------------|-------|
-| `L2` | `hnswlib::L2Space` | L2 (Euclidean) distance | Default, no normalization |
-| `IP` | `hnswlib::InnerProductSpace` | Inner product distance | No normalization |
-| `COSINE` | `hnswlib::InnerProductSpace` | Same space as IP | Vectors normalized before storage; `normalize_ = true` |
+Space created in `VectorBase::Init()` via local `CreateSpace<T>()`. `NormalizeEmbedding()` (free in `vector_base.cc`) computes L2 magnitude and divides via `CopyAndNormalizeEmbedding`, optionally returning the magnitude for later denormalization when reading stored vectors.
 
-The space is created in `VectorBase::Init()` via `CreateSpace<T>()` (a local function in `vector_base.cc`). COSINE is implemented as normalized inner product - vectors are normalized on insert and queries are normalized before search:
+## Dynamic resize
 
-```cpp
-// In VectorBase::Init()
-if (distance_metric == DISTANCE_METRIC_COSINE) {
-  normalize_ = true;
-}
+HNSW starts at `initial_cap`, grows on capacity overflow. `AddRecordImpl()` catches the "exceeds limit" exception and calls `ResizeIfFull()`:
 
-// In Search() - normalize query if needed
-if (normalize_) {
-  auto norm_record = NormalizeEmbedding(query, GetDataTypeSize());
-  // search with normalized query...
-}
-```
+Double-checked locking: read-lock check -> write-lock re-check -> `algo_->resizeIndex(current + block_size)`. Block size from `ValkeySearch::Instance().GetHNSWBlockSize()`.
 
-`NormalizeEmbedding()` (free function in `vector_base.cc`) computes L2 magnitude and divides each component via `CopyAndNormalizeEmbedding`. It optionally returns the magnitude for later denormalization when reading stored vectors back.
+- **hnswlib does not shrink** - capacity only grows.
+- `allow_replace_deleted_` - when true, reuse deleted slots before resize.
+- Duration logged at WARNING via `vmsdk::StopWatch`.
 
-## Dynamic Resize
-
-The HNSW index starts at `initial_cap` capacity and grows dynamically. When `AddRecordImpl()` catches the hnswlib "exceeds limit" exception, it calls `ResizeIfFull()`:
-
-```cpp
-absl::Status VectorHNSW<T>::ResizeIfFull() {
-  // Double-checked locking pattern:
-  {
-    absl::ReaderMutexLock lock(&resize_mutex_);
-    if (algo_->getCurrentElementCount() < algo_->getMaxElements() ||
-        (algo_->allow_replace_deleted_ && algo_->getDeletedCount() > 0)) {
-      return absl::OkStatus();  // Space available
-    }
-  }
-  // Exclusive lock for resize, re-check under writer lock
-  absl::WriterMutexLock lock(&resize_mutex_);
-  if (algo_->getCurrentElementCount() == algo_->getMaxElements() &&
-      (!algo_->allow_replace_deleted_ || algo_->getDeletedCount() == 0)) {
-    auto block_size = ValkeySearch::Instance().GetHNSWBlockSize();
-    algo_->resizeIndex(algo_->getMaxElements() + block_size);
-  }
-}
-```
-
-Key points:
-- Growth is by `block_size` (configurable via `ValkeySearch::GetHNSWBlockSize()`)
-- hnswlib does not support shrinking - once expanded, capacity only grows
-- `allow_replace_deleted_` is controlled by `options::GetHNSWAllowReplaceDeleted()` - when true, deleted slots can be reused before triggering resize
-- Resize duration is logged at WARNING level via `vmsdk::StopWatch`
-
-## Search with Inline Filtering
-
-`VectorHNSW::Search()` is the main query entry point:
+## Search with inline filtering
 
 ```cpp
 absl::StatusOr<std::vector<Neighbor>> Search(
@@ -137,88 +81,69 @@ absl::StatusOr<std::vector<Neighbor>> Search(
     bool enable_partial_results = false);
 ```
 
-The search flow:
-1. Validate query vector size matches `dimensions_ * GetDataTypeSize()`
-2. If `normalize_` is set, normalize the query vector
-3. Call `algo_->searchKnn()` with the optional `BaseFilterFunctor` and `CancelCondition`
-4. Convert the priority queue result to a `vector<Neighbor>` via `CreateReply()`
+Flow: validate size (`dimensions_ * data_type_size`), normalize query if `normalize_`, `algo_->searchKnn(filter, cancel_condition)`, convert result via `CreateReply()`.
 
-The `BaseFilterFunctor` enables inline (post-filter) evaluation during HNSW graph traversal. When a filter is provided, hnswlib calls `filter->operator()(label)` for each candidate, skipping non-matching nodes during the beam search.
+`BaseFilterFunctor` enables inline (post-filter) evaluation: hnswlib calls `filter(label)` on each candidate during beam search, skipping non-matches.
 
-`CancelCondition` (local class in `vector_hnsw.cc`) adapts the `cancel::Token` to hnswlib's `BaseCancellationFunctor` interface, enabling timeout-based cancellation:
+`CancelCondition` (local class in `vector_hnsw.cc`) adapts `cancel::Token` to hnswlib's `BaseCancellationFunctor`. On cancellation: `CancelledError` when `enable_partial_results=false`, partial results when true.
 
-```cpp
-class CancelCondition : public hnswlib::BaseCancellationFunctor {
-  cancel::Token& token_;
-  bool isCancelled() override { return token_->IsCancelled(); }
-};
-```
+## `PrefilterEvaluator` (`vector_base.h`)
 
-When `enable_partial_results` is false and cancellation fires, the search returns `CancelledError`. When true, partial results gathered before cancellation are returned.
-
-## PrefilterEvaluator
-
-`PrefilterEvaluator` (defined in `vector_base.h`) evaluates non-vector predicates (tag, numeric, text) against individual keys during pre-filtered vector search. It extends `query::Evaluator` and takes a `QueryOperations` bitmask at construction:
+Extends `query::Evaluator`. Evaluates non-vector predicates against individual keys during pre-filtered vector search:
 
 ```cpp
 class PrefilterEvaluator : public query::Evaluator {
   const text::TextIndex* text_index_;
   const InternedStringPtr* key_{nullptr};
-  bool Evaluate(const query::Predicate& predicate, const InternedStringPtr& key);
-  // Dispatches to per-type evaluation:
-  query::EvaluationResult EvaluateTags(const query::TagPredicate&) override;
-  query::EvaluationResult EvaluateNumeric(const query::NumericPredicate&) override;
-  query::EvaluationResult EvaluateText(const query::TextPredicate&, bool) override;
+  bool Evaluate(const query::Predicate&, const InternedStringPtr& key);
+  query::EvaluationResult EvaluateTags   (const query::TagPredicate&)      override;
+  query::EvaluationResult EvaluateNumeric(const query::NumericPredicate&)  override;
+  query::EvaluationResult EvaluateText   (const query::TextPredicate&, bool) override;
 };
 ```
 
-Each method fetches the stored value for the current key from the respective index and evaluates the predicate. For example, `EvaluateTags()` calls `predicate.GetIndex()->GetValue(*key_, case_sensitive)` to retrieve the key's tags, then `predicate.Evaluate(tags, case_sensitive)`.
+Per-method path fetches stored value from the relevant index (e.g. `predicate.GetIndex()->GetValue(*key_, case_sensitive)`), then evaluates.
 
-Pre-filtering works via `VectorBase::AddPrefilteredKey()` - instead of using hnswlib's graph search, it iterates candidate keys from scalar index results, computes distance for each via `ComputeDistanceFromRecord()`, and maintains a bounded priority queue of the top-k results.
+Pre-filter flow: `VectorBase::AddPrefilteredKey()` iterates candidate keys from scalar-index results, calls `ComputeDistanceFromRecord()` per key, maintains bounded priority queue of top-k. Skips hnswlib graph search entirely.
 
-## Record Lifecycle
+## Record lifecycle
 
-**Add**: `VectorBase::AddRecord()` -> `InternVector()` (normalize if COSINE) -> `TrackKey()` assigns sequential `inc_id_` -> `AddRecordImpl()` -> `algo_->addPoint()`. On capacity overflow, retries after `ResizeIfFull()`. On failure, `UnTrackKey()` rolls back.
+- **Add**: `VectorBase::AddRecord()` -> `InternVector()` (normalize if COSINE) -> `TrackKey()` assigns `inc_id_` -> `AddRecordImpl()` -> `algo_->addPoint()`. Overflow retries after `ResizeIfFull()`. Failure rolls back via `UnTrackKey()`.
+- **Modify**: `ModifyRecord` -> `UpdateMetadata` -> `IsVectorMatch()` (no-op shortcut) -> `ModifyRecordImpl` marks old point deleted, re-adds at same label with `allow_replace_deleted_`:
+  ```cpp
+  algo_->markDelete(internal_id);
+  algo_->addPoint(record.data(), internal_id, algo_->allow_replace_deleted_);
+  ```
+  (hnswlib has `updatePoint` but search-accuracy concerns drove the mark-delete + re-add approach.)
+- **Remove**: `RemoveRecordImpl` only calls `markDelete()` - **tombstoned, never physically removed**. `UnTrackVector` is a no-op for HNSW (FLAT erases its map).
+- **Key tracking** (`VectorBase`): bidirectional maps `key_by_internal_id_` / `tracked_metadata_by_key_`. `TrackedKeyMetadata` holds `internal_id` + `magnitude` (COSINE denormalization; `-1.0f` when not normalizing).
 
-**Modify**: `VectorBase::ModifyRecord()` calls `UpdateMetadata()` which checks `IsVectorMatch()` and short-circuits if the vector is unchanged. Then `ModifyRecordImpl()` marks the old point deleted and adds a new point at the same label with `allow_replace_deleted_`:
+## Concurrency
 
-```cpp
-algo_->markDelete(internal_id);
-algo_->addPoint((T*)record.data(), internal_id, algo_->allow_replace_deleted_);
-```
+| Mutex | Protects |
+|-------|----------|
+| `resize_mutex_` (absl) | `algo_`. R-lock for search/add/remove/modify. W-lock for resize. Prevents search from seeing partially-resized state. |
+| `tracked_vectors_mutex_` | `tracked_vectors_` deque |
+| parent `VectorBase::key_to_metadata_mutex_` | key-to-ID maps |
 
-The `updatePoint` API was considered but concerns about search accuracy led to the mark-delete-then-add approach.
+hnswlib has its own internal locks (`label_lookup_lock`, per-element mutex via `getLabelOpMutex()`). Methods annotated with `ABSL_NO_THREAD_SAFETY_ANALYSIS` operate under hnswlib's internal locks instead of class-level mutexes. `hnswlib_helpers` namespace provides `GetInternalId` (with lock) vs `GetInternalIdLockFree` / `GetInternalIdDuringSearch` wrappers.
 
-**Remove**: `RemoveRecordImpl()` only calls `markDelete()` - vectors are never physically removed from the HNSW graph, only tombstoned. `UnTrackVector()` is a no-op for HNSW (unlike FLAT which erases from its map).
+**Memory allocation**: hnswlib compiled against `vmsdk/src/memory_allocation_overrides.h` which redirects `malloc`/`free` to Valkey's allocator. **Include order is critical** - override header must precede hnswlib headers.
 
-**Key tracking**: `VectorBase` maintains bidirectional maps between external keys and internal IDs (`key_by_internal_id_`, `tracked_metadata_by_key_`). `TrackedKeyMetadata` includes `internal_id` and `magnitude` (for COSINE denormalization; -1.0f when normalization is disabled).
+## RDB persistence
 
-## Concurrency Model
+- `SaveIndexImpl()` -> `algo_->SaveIndex(RDBChunkOutputStream)` - full hnswlib binary format.
+- `LoadFromRDB()` -> construct `HierarchicalNSW`, `LoadIndex(RDBChunkInputStream)`.
+- `ef_runtime` NOT in binary - restored from proto `VectorIndex.hnsw_algorithm.ef_runtime` post-load.
+- `allow_replace_deleted_` re-applied from options post-load.
+- Tracked keys via `VectorBase::SaveTrackedKeys()` / `LoadTrackedKeys()` using `TrackedKeyMetadata` protos (key, internal_id, magnitude).
+- After load, `inc_id_` resumes from `GetMaxInternalLabel() + 1`.
 
-Two mutexes protect HNSW state:
+## Implementation notes
 
-- `resize_mutex_` (absl::Mutex) - reader/writer lock protecting `algo_`. Reads (search, add, remove, modify) take reader locks. Resize takes writer lock. This prevents search from seeing partially-resized state.
-- `tracked_vectors_mutex_` - protects the `tracked_vectors_` deque used for vector identity tracking.
-
-The parent `VectorBase` has `key_to_metadata_mutex_` protecting the key-to-ID maps.
-
-hnswlib itself has internal locking (`label_lookup_lock`, per-element mutexes via `getLabelOpMutex()`). The `ABSL_NO_THREAD_SAFETY_ANALYSIS` annotations on some methods indicate they operate under hnswlib's internal locks rather than the class-level mutexes. The `hnswlib_helpers` namespace in `vector_hnsw.cc` provides `GetInternalId` (with lock) and `GetInternalIdLockFree`/`GetInternalIdDuringSearch` (without lock) wrappers.
-
-Memory allocation: hnswlib code is compiled with `vmsdk/src/memory_allocation_overrides.h` which redirects `malloc`/`free` to Valkey's allocator. The include ordering is critical - the override header must come before hnswlib headers.
-
-## RDB Persistence
-
-`SaveIndexImpl()` delegates to `algo_->SaveIndex()` which writes the full hnswlib binary format via `RDBChunkOutputStream`. `LoadFromRDB()` constructs a new `HierarchicalNSW` and calls `LoadIndex()` from `RDBChunkInputStream`.
-
-`ef_runtime` is not persisted in the hnswlib binary - it is restored from the protobuf `VectorIndex.hnsw_algorithm.ef_runtime` field after loading. `allow_replace_deleted_` is also re-applied from options after loading.
-
-Tracked keys are saved/loaded separately via `VectorBase::SaveTrackedKeys()` / `LoadTrackedKeys()` using protobuf `TrackedKeyMetadata` messages containing key, internal_id, and magnitude. After loading, `inc_id_` is resumed from `GetMaxInternalLabel() + 1`.
-
-## Key Implementation Details
-
-- `GetMaxInternalLabel()` iterates `algo_->label_lookup_` under `label_lookup_lock` (includes tombstoned entries) to find the maximum label - used after RDB load to resume the `inc_id_` counter
-- `GetLabelCount()` returns `label_lookup_.size()` under `label_lookup_lock` - includes both active and tombstoned entries
-- `IsVectorMatch()` acquires both `resize_mutex_` and `getLabelOpMutex(internal_id)`, then compares stored vector data from `algo_->getDataByInternalId()` against the candidate - used by `UpdateMetadata()` to skip no-op modifications
-- `ComputeDistanceFromRecordImpl()` uses `algo_->fstdistfunc_` to compute distance between a query and a stored vector - used for pre-filter scoring
-- `RespondWithInfoImpl()` reports `data_type`, `algorithm name`, `m`, `ef_construction`, `ef_runtime` for `FT.INFO`
-- Exception counters: `hnsw_create_exceptions_cnt`, `hnsw_add_exceptions_cnt`, `hnsw_modify_exceptions_cnt`, `hnsw_remove_exceptions_cnt`, `hnsw_search_exceptions_cnt` in `Metrics::GetStats()`
+- `GetMaxInternalLabel()` - iterates `algo_->label_lookup_` under `label_lookup_lock` (includes tombstones); used post-load to resume `inc_id_`.
+- `GetLabelCount()` = `label_lookup_.size()` under the lock (active + tombstoned).
+- `IsVectorMatch()` - takes both `resize_mutex_` and `getLabelOpMutex(internal_id)`, compares bytes via `algo_->getDataByInternalId()`; drives `UpdateMetadata` no-op shortcut.
+- `ComputeDistanceFromRecordImpl()` uses `algo_->fstdistfunc_` for pre-filter scoring.
+- `RespondWithInfoImpl()` reports `data_type`, algorithm name, `m`, `ef_construction`, `ef_runtime` for FT.INFO.
+- Exception counters: `hnsw_{create,add,modify,remove,search}_exceptions_cnt` in `Metrics::GetStats()`.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-hnsw.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-hnsw.md
@@ -29,7 +29,7 @@ class VectorHNSW : public VectorBase {
 template class VectorHNSW<float>;
 ```
 
-`Create()` reads `dimension_count`, `distance_metric`, and `hnsw_algorithm.{m, ef_construction, ef_runtime}` from the `VectorIndex` proto. Passes `initial_cap` to the `HierarchicalNSW` constructor. `allow_replace_deleted_` set from `options::GetHNSWAllowReplaceDeleted()`.
+`Create()` reads `dimension_count`, `distance_metric`, and `hnsw_algorithm.{m, ef_construction, ef_runtime}` from the `VectorIndex` proto. Passes `initial_cap` to the `HierarchicalNSW` constructor. `allow_replace_deleted_` is **hardcoded `false`** on 1.2.0 (source TODO: "Consider making `allow_replace_deleted_` configurable") - aligns with RediSearch behavior.
 
 ## HNSW parameters
 
@@ -67,7 +67,7 @@ HNSW starts at `initial_cap`, grows on capacity overflow. `AddRecordImpl()` catc
 Double-checked locking: read-lock check -> write-lock re-check -> `algo_->resizeIndex(current + block_size)`. Block size from `ValkeySearch::Instance().GetHNSWBlockSize()`.
 
 - **hnswlib does not shrink** - capacity only grows.
-- `allow_replace_deleted_` - when true, reuse deleted slots before resize.
+- `allow_replace_deleted_` (hardcoded `false` on 1.2.0) would reuse deleted slots before resize if enabled.
 - Duration logged at WARNING via `vmsdk::StopWatch`.
 
 ## Search with inline filtering
@@ -109,7 +109,7 @@ Pre-filter flow: `VectorBase::AddPrefilteredKey()` iterates candidate keys from 
 ## Record lifecycle
 
 - **Add**: `VectorBase::AddRecord()` -> `InternVector()` (normalize if COSINE) -> `TrackKey()` assigns `inc_id_` -> `AddRecordImpl()` -> `algo_->addPoint()`. Overflow retries after `ResizeIfFull()`. Failure rolls back via `UnTrackKey()`.
-- **Modify**: `ModifyRecord` -> `UpdateMetadata` -> `IsVectorMatch()` (no-op shortcut) -> `ModifyRecordImpl` marks old point deleted, re-adds at same label with `allow_replace_deleted_`:
+- **Modify**: `ModifyRecord` -> `UpdateMetadata` -> `IsVectorMatch()` (no-op shortcut) -> `ModifyRecordImpl` marks old point deleted, re-adds at same label (passing `algo_->allow_replace_deleted_` which is hardcoded `false`):
   ```cpp
   algo_->markDelete(internal_id);
   algo_->addPoint(record.data(), internal_id, algo_->allow_replace_deleted_);
@@ -135,7 +135,7 @@ hnswlib has its own internal locks (`label_lookup_lock`, per-element mutex via `
 - `SaveIndexImpl()` -> `algo_->SaveIndex(RDBChunkOutputStream)` - full hnswlib binary format.
 - `LoadFromRDB()` -> construct `HierarchicalNSW`, `LoadIndex(RDBChunkInputStream)`.
 - `ef_runtime` NOT in binary - restored from proto `VectorIndex.hnsw_algorithm.ef_runtime` post-load.
-- `allow_replace_deleted_` re-applied from options post-load.
+- `allow_replace_deleted_` re-hardcoded to `false` post-load (on 1.2.0; when made configurable this would read from options).
 - Tracked keys via `VectorBase::SaveTrackedKeys()` / `LoadTrackedKeys()` using `TrackedKeyMetadata` protos (key, internal_id, magnitude).
 - After load, `inc_id_` resumes from `GetMaxInternalLabel() + 1`.
 

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-numeric.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-numeric.md
@@ -1,233 +1,146 @@
-# Numeric Index
+# Numeric index
 
-Use when working on numeric range queries, the BTree+SegmentTree dual data structure, adding numeric filter operations, or understanding how numeric predicates are evaluated.
+Use when reasoning about numeric range queries, the BTree+SegmentTree combo, or numeric predicate evaluation.
 
-Source: `src/indexes/numeric.h`, `src/indexes/numeric.cc`, `src/utils/segment_tree.h`
+Source: `src/indexes/numeric.{h,cc}`, `src/utils/segment_tree.h`.
 
-## Contents
-
-- [Class Overview](#class-overview)
-- [BTreeNumeric Data Structure](#btreenumeric-data-structure)
-- [SegmentTree Overlay](#segmenttree-overlay)
-- [Range Queries](#range-queries)
-- [EntriesFetcher for Result Iteration](#entriesfetcher-for-result-iteration)
-- [Record Lifecycle](#record-lifecycle)
-- [Tracked vs Untracked Keys](#tracked-vs-untracked-keys)
-- [Negated Range Queries](#negated-range-queries)
-- [Memory Overhead](#memory-overhead)
-
-## Class Overview
-
-The `Numeric` class implements `IndexBase` for numeric field indexing. It maps string keys to double values and supports efficient range queries with both forward and negated filters.
+## Shape
 
 ```cpp
 class Numeric : public IndexBase {
-  InternedStringHashMap<double> tracked_keys_;    // key -> numeric value
-  InternedStringSet untracked_keys_;              // keys without valid numeric data
-  std::unique_ptr<BTreeNumericIndex> index_;      // sorted index + range counts
+  InternedStringHashMap<double> tracked_keys_;         // key -> value
+  InternedStringSet             untracked_keys_;       // keys with no valid numeric data
+  std::unique_ptr<BTreeNumericIndex> index_;           // sorted + range counts
   mutable absl::Mutex index_mutex_;
 };
 ```
 
-Additional public APIs not present on vector indexes: `GetValue()` returns a pointer to the stored double for a key (used lock-free during the read phase of the time-sliced mutex), `GetMutationWeight()` returns `options::GetMutationWeightNumeric()`, and `SaveIndex()` is a no-op (numeric data is reconstructed from hash keys on load).
+APIs beyond `IndexBase`: `GetValue(key)` returns a pointer to the stored double (lock-free during read phase of the time-sliced mutex); `GetMutationWeight()` -> `options::GetMutationWeightNumeric()`; `SaveIndex()` is a no-op (rebuilt from hash keys on load).
 
-## BTreeNumeric Data Structure
-
-`BTreeNumeric<T>` is a template wrapping an `absl::btree_map` that maps doubles to sets of keys:
+## `BTreeNumeric<T>`
 
 ```cpp
-template <typename T, typename Hasher = absl::Hash<T>,
-          typename Equalizer = std::equal_to<T>>
+template <typename T, typename Hasher = absl::Hash<T>, typename Equalizer = std::equal_to<T>>
 class BTreeNumeric {
-  absl::btree_map<double, SetType> btree_;   // double -> flat_hash_set<T>
-  utils::SegmentTree segment_tree_;           // for O(log n) range counting
+  absl::btree_map<double, SetType> btree_;   // value -> flat_hash_set<T>
+  utils::SegmentTree               segment_tree_;
 };
+using BTreeNumericIndex = BTreeNumeric<InternedStringPtr>;
 ```
 
-The template defaults `Hasher` to `absl::Hash<T>` and `Equalizer` to `std::equal_to<T>`. The concrete instantiation is `BTreeNumeric<InternedStringPtr>` (aliased as `BTreeNumericIndex`).
+BTree maps each distinct value to the set of keys with that value (multi-key support). `absl::btree_map` is ordered -> `lower_bound` / `upper_bound` for range queries.
 
-The BTree maps each distinct numeric value to the set of `InternedStringPtr` keys that have that value. This enables:
-
-- **Ordered iteration** - `absl::btree_map` keeps values sorted, enabling `lower_bound`/`upper_bound` for range queries
-- **Multi-key support** - multiple keys can share the same numeric value
-
-Operations:
+Both structures updated in tandem per mutation:
 
 ```cpp
-void Add(const T& value, double key) {
-  btree_[key].insert(value);
-  segment_tree_.Add(key);
-}
-
-void Remove(const T& value, double key) {
-  btree_[key].erase(value);
-  if (btree_[key].empty()) btree_.erase(key);
-  segment_tree_.Remove(key);
-}
-
-void Modify(const T& value, double old_key, double new_key) {
-  Remove(value, old_key);
-  Add(value, new_key);
-}
+Add   (v, k) -> btree_[k].insert(v); segment_tree_.Add(k);
+Remove(v, k) -> btree_[k].erase (v); if empty erase slot; segment_tree_.Remove(k);
+Modify(v, old, new) -> Remove(v, old); Add(v, new);
 ```
 
-Both the BTree and SegmentTree are updated in tandem for every mutation. `GetBtree()` exposes a const reference for iteration in `Search()`.
+`GetBtree()` exposes const reference for range iteration.
 
-## SegmentTree Overlay
+## `SegmentTree` overlay
 
-The `SegmentTree` (`src/utils/segment_tree.h`) provides O(log n) range counting. It is a self-balancing binary tree (AVL-based) where each node tracks:
+`src/utils/segment_tree.h`. Self-balancing AVL-style tree, O(log n) range counting.
 
 ```cpp
 struct SegmentTreeNode {
-  uint64_t count;                           // entries in this subtree
-  uint32_t height;                          // for AVL balancing
-  double min_value, max_value;              // range covered
+  uint64_t count;
+  uint32_t height;
+  double   min_value, max_value;
   std::unique_ptr<SegmentTreeNode> left_node, right_node;
 };
 ```
 
-The key API used by `BTreeNumeric::GetCount()`:
+`Count(start, end, inclusive_start, inclusive_end)` = two `CountGreaterThan` calls with inverted inclusivity flags.
+
+AVL rotations (`RotateLeft` / `RotateRight`) fire after every `Add` / `Remove`. Leaves with count 0 collapse; remaining child promotes.
+
+Memory: ~80 bytes/entry (40 bytes/node, ~2 nodes/entry balanced). A unified structure could eliminate this overhead (not yet implemented).
+
+## Range search
 
 ```cpp
-// SegmentTree::Count() - called internally by BTreeNumeric::GetCount()
-uint64_t Count(double start, double end,
-               bool inclusive_start, bool inclusive_end) {
-  uint64_t count_greater_than_start = CountGreaterThan(start, inclusive_start);
-  uint64_t count_greater_than_end = CountGreaterThan(end, !inclusive_end);
-  return count_greater_than_start - count_greater_than_end;
-}
+std::unique_ptr<EntriesFetcher> Numeric::Search(const query::NumericPredicate&, bool negate) const;
 ```
 
-Range counting uses two `CountGreaterThan` calls with clever inclusive flag inversion to compute the count of entries in `[start, end]` with configurable boundary inclusivity.
-
-The tree self-balances via AVL rotations (`RotateLeft`, `RotateRight`) triggered after every `Add` or `Remove`. New values are inserted at leaf positions; removal of a leaf with count 0 collapses it and promotes the remaining child.
-
-Memory overhead is approximately 80 bytes per entry (40 bytes per node, roughly 2 nodes per entry in a balanced tree). A unified data structure could eliminate this overhead but is not yet implemented.
-
-## Range Queries
-
-`Numeric::Search()` returns an `EntriesFetcher` for the matching range:
+Non-negated:
 
 ```cpp
-std::unique_ptr<EntriesFetcher> Numeric::Search(
-    const query::NumericPredicate& predicate, bool negate) const;
-```
-
-For a non-negated query, the method computes iterator bounds using BTree operations:
-
-```cpp
-// Lower bound
-entries_range.first = predicate.IsStartInclusive()
-    ? btree.lower_bound(predicate.GetStart())
-    : btree.upper_bound(predicate.GetStart());
-
-// Upper bound
-entries_range.second = predicate.IsEndInclusive()
-    ? btree.upper_bound(predicate.GetEnd())
-    : btree.lower_bound(predicate.GetEnd());
-
-// Size via SegmentTree (O(log n) instead of iterating)
+entries_range.first  = start_inclusive ? btree.lower_bound(start) : btree.upper_bound(start);
+entries_range.second = end_inclusive   ? btree.upper_bound(end)   : btree.lower_bound(end);
 size_t size = index_->GetCount(start, end, start_inclusive, end_inclusive);
 ```
 
-The BTree iterators define the range of matching values, and the SegmentTree provides the count without traversal. The `EntriesFetcher` wraps this range for the query engine to iterate.
+BTree iterators delimit the matching-value range; SegmentTree yields size without traversal. `EntriesFetcher` wraps the range for the query engine.
 
-## EntriesFetcher for Result Iteration
+## Negated range search
 
-The `EntriesFetcher` / `EntriesFetcherIterator` pair provides the query engine's standard iteration interface (extending `EntriesFetcherBase` / `EntriesFetcherIteratorBase` from `index_base.h`):
+Two ranges covering everything outside the predicate, plus untracked keys:
 
 ```cpp
-class EntriesFetcher : public EntriesFetcherBase {
-  EntriesRange entries_range_;                        // primary range
-  std::optional<EntriesRange> additional_entries_range_; // for negation
-  const InternedStringSet* untracked_keys_;           // for negation
-  size_t Size() const override;
-  std::unique_ptr<EntriesFetcherIteratorBase> Begin() override;
-};
+// Range 1: (-inf, start) with inverted inclusivity
+entries_range.first  = btree.begin();
+entries_range.second = start_inclusive ? btree.lower_bound(start) : btree.upper_bound(start);
+
+// Range 2: (end, +inf) with inverted inclusivity
+additional_entries_range.first  = end_inclusive ? btree.upper_bound(end) : btree.lower_bound(end);
+additional_entries_range.second = btree.end();
 ```
 
-The iterator walks a two-level structure - the outer level iterates BTree entries (sorted by numeric value), and the inner level iterates the `flat_hash_set` of keys at each value:
+Size = two SegmentTree range counts (`numeric_limits<double>::lowest()` / `::max()` as boundaries) + `untracked_keys_.size()`. Iterator chains: primary range -> additional range -> untracked keys.
+
+## `EntriesFetcher` / `EntriesFetcherIterator`
+
+Extends `EntriesFetcherBase` from `index_base.h`. Holds primary range, optional additional range (for negation), optional `untracked_keys_` pointer.
+
+Two-level iteration - outer by BTree value, inner by `flat_hash_set` of keys at that value:
 
 ```cpp
 static bool NextKeys(const EntriesRange& range,
     BTreeNumericIndex::ConstIterator& iter,
     std::optional<InternedStringSet::const_iterator>& keys_iter) {
   while (iter != range.second) {
-    if (!keys_iter.has_value()) {
-      keys_iter = iter->second.begin();
-    } else {
-      ++keys_iter.value();
-    }
-    if (keys_iter.value() != iter->second.end()) return true;
-    ++iter;
-    keys_iter = std::nullopt;
+    keys_iter = keys_iter ? ++*keys_iter : iter->second.begin();
+    if (*keys_iter != iter->second.end()) return true;
+    ++iter; keys_iter.reset();
   }
   return false;
 }
 ```
 
-`Begin()` returns a new `EntriesFetcherIterator` and calls `Next()` to advance to the first result. For negated ranges, the iterator chains: primary range -> additional range -> untracked keys.
+`Begin()` returns a fresh iterator and advances to the first result. Negated variant chains the three sources in sequence.
 
-## Record Lifecycle
+## Record lifecycle
 
-**Add**: `AddRecord()` parses the string value to double via `ParseNumber()` (a local function using `absl::SimpleAtod`, rejecting "nan"). If parsing fails, the key goes to `untracked_keys_` and returns false. If the key already exists, returns `AlreadyExistsError`. Otherwise, inserts into `tracked_keys_` map and calls `index_->Add(key, value)`.
+- **Add**: `ParseNumber(data)` via `absl::SimpleAtod`, rejects "nan". Parse fail -> key into `untracked_keys_`, return false. Key already tracked -> `AlreadyExistsError`. Else insert `{key, value}` + `index_->Add(key, value)`.
+- **Modify**: lookup existing value in `tracked_keys_`, `index_->Modify(key, old, new)`, update tracked value. Unparseable new -> falls through to `RemoveRecord(DeletionType::kIdentifier)`. Missing tracked key -> `NotFoundError`.
+- **Remove**: `index_->Remove(key, value)` + erase from `tracked_keys_`. `DeletionType` controls untracked transition.
 
-```cpp
-auto value = ParseNumber(data);
-if (!value.has_value()) {
-  untracked_keys_.insert(key);
-  return false;
-}
-tracked_keys_.insert({key, *value});
-index_->Add(key, *value);
-```
+All mutations take `index_mutex_`.
 
-**Modify**: Looks up the existing value in `tracked_keys_`, calls `index_->Modify(key, old_value, new_value)` and updates the tracked value. If the new value is unparseable, falls through to `RemoveRecord` with `DeletionType::kIdentifier`. Returns `NotFoundError` if the key is not tracked.
+## Tracked vs untracked
 
-**Remove**: Calls `index_->Remove(key, value)` and erases from `tracked_keys_`. Deletion type determines untracked key handling.
+Mutually exclusive.
 
-All mutations hold `index_mutex_`.
+- **Tracked**: `tracked_keys_`, indexed in BTree.
+- **Untracked**: exists in schema but no parseable numeric (non-numeric string, NaN). Matters for negated queries - `NOT [10 20]` must include keys with no numeric value at all.
 
-## Tracked vs Untracked Keys
+`DeletionType` on remove:
 
-The numeric index distinguishes two key categories:
+- `kRecord` - key fully deleted; remove from untracked too.
+- `kIdentifier` / `kNone` - field removed but key exists; add to untracked.
 
-- **Tracked keys** (`tracked_keys_`) - keys with valid numeric values, indexed in the BTree
-- **Untracked keys** (`untracked_keys_`) - keys that exist in the schema but have no parseable numeric value (e.g., the field contains a non-numeric string, or NaN)
+`AddRecord` removes the key from `untracked_keys_` if it was there.
 
-These sets are mutually exclusive. On `AddRecord`, if the key was previously untracked, it is removed from `untracked_keys_`. Untracked keys are important for negated queries - a query like `NOT [10 20]` must include keys that have no numeric value at all, since they do not fall within the excluded range.
+## Memory per key
 
-`DeletionType` controls the transition:
-- `kRecord` - key is fully deleted from the store, remove from untracked
-- `kIdentifier` (or `kNone`) - field removed but key exists, add to untracked
+| Structure | Bytes |
+|-----------|-------|
+| `tracked_keys_` entry | ~48 |
+| BTree entry (in `flat_hash_set`) | ~40 amortized |
+| SegmentTree | ~80 |
+| **Total** | ~170 |
 
-## Negated Range Queries
-
-For negated searches (`negate=true`), the method constructs two BTree ranges representing everything outside the predicate range:
-
-```cpp
-// Range 1: (-inf, start) with inverted inclusivity
-entries_range.first = btree.begin();
-entries_range.second = predicate.IsStartInclusive()
-    ? btree.lower_bound(predicate.GetStart())
-    : btree.upper_bound(predicate.GetStart());
-
-// Range 2: (end, +inf) with inverted inclusivity
-additional_entries_range.first = predicate.IsEndInclusive()
-    ? btree.upper_bound(predicate.GetEnd())
-    : btree.lower_bound(predicate.GetEnd());
-additional_entries_range.second = btree.end();
-```
-
-Size is computed as the sum of two SegmentTree range counts (using `numeric_limits<double>::lowest()` and `numeric_limits<double>::max()` as boundaries) plus `untracked_keys_.size()`. The `EntriesFetcherIterator` chains all three sources in sequence.
-
-## Memory Overhead
-
-Per indexed key, the numeric index stores:
-- `tracked_keys_`: one `InternedStringHashMap` entry (~48 bytes)
-- `BTree`: one entry in the `flat_hash_set` at the value's slot (~40 bytes amortized)
-- `SegmentTree`: ~80 bytes per entry (40 bytes/node, ~2 nodes/entry)
-
-Total: approximately 170 bytes per tracked key. The `index_mutex_` is a single `absl::Mutex` protecting all mutations, info queries, and key enumeration (`ForEachTrackedKey`, `ForEachUnTrackedKey`).
-
-`RespondWithInfo()` reports `type=NUMERIC` and `size` (tracked key count) for `FT.INFO`.
+Single `index_mutex_` protects all mutations, info, and enumeration (`ForEachTrackedKey`, `ForEachUnTrackedKey`). `RespondWithInfo()` reports `type=NUMERIC`, `size = tracked_keys_.size()`.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-tag.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-tag.md
@@ -1,272 +1,160 @@
-# Tag Index
+# Tag index
 
-Use when working on tag-based filtering, the PatriciaTree storage, tag separator handling, prefix wildcard matching, or tag predicate evaluation.
+Use when reasoning about tag filtering, `PatriciaTree` storage, separator handling, or prefix wildcard matching.
 
-Source: `src/indexes/tag.h`, `src/indexes/tag.cc`, `src/utils/patricia_tree.h`
+Source: `src/indexes/tag.{h,cc}`, `src/utils/patricia_tree.h`.
 
-## Contents
-
-- [Class Overview](#class-overview)
-- [PatriciaTree Storage](#patriciatree-storage)
-- [Separator and Case Sensitivity](#separator-and-case-sensitivity)
-- [Tag Splitting](#tag-splitting)
-- [Search and Wildcard Prefix Matching](#search-and-wildcard-prefix-matching)
-- [Tag Predicate Evaluation](#tag-predicate-evaluation)
-- [EntriesFetcher Iteration](#entriesfetcher-iteration)
-- [Record Lifecycle](#record-lifecycle)
-- [Tracked vs Untracked Keys](#tracked-vs-untracked-keys)
-- [Negated Tag Queries](#negated-tag-queries)
-
-## Class Overview
-
-The `Tag` class implements `IndexBase` for categorical tag fields. Each key can have multiple tags (split on a configurable separator). Tags are stored in a Patricia tree for efficient exact and prefix matching.
+## Shape
 
 ```cpp
 class Tag : public IndexBase {
-  InternedStringHashMap<TagInfo> tracked_tags_by_keys_;  // key -> {raw_string, parsed_tags}
-  InternedStringSet untracked_keys_;       // keys without valid tag data
-  const char separator_;                   // tag delimiter (default comma)
-  const bool case_sensitive_;              // case-sensitive matching
-  PatriciaTreeIndex tree_;                 // Patricia tree: tag -> set<key>
+  InternedStringHashMap<TagInfo> tracked_tags_by_keys_; // key -> {raw, parsed}
+  InternedStringSet untracked_keys_;
+  const char separator_;                                // default ','
+  const bool case_sensitive_;
+  PatriciaTreeIndex tree_;                              // tag -> set<key>
   mutable absl::Mutex index_mutex_;
 };
-```
 
-The `TagInfo` struct stored per key:
-```cpp
 struct TagInfo {
-  InternedStringPtr raw_tag_string;            // original interned data
-  absl::flat_hash_set<absl::string_view> tags; // parsed tag views into raw_tag_string
+  InternedStringPtr raw_tag_string;
+  absl::flat_hash_set<absl::string_view> tags;          // views into raw_tag_string
 };
 ```
 
-`SaveIndex()` is a no-op - tag data is reconstructed from hash keys on load. `GetMutationWeight()` returns `options::GetMutationWeightTag()`.
+`SaveIndex()` is a no-op (rebuilt from hash keys on load). `GetMutationWeight()` -> `options::GetMutationWeightTag()`.
 
-## PatriciaTree Storage
+Constructor reads `separator()[0]` (first char) and `case_sensitive()` from `TagIndex` proto. Separator can be any single char.
 
-Tags are indexed in a `PatriciaTree<InternedStringPtr>` (`src/utils/patricia_tree.h`), aliased as `PatriciaTreeIndex`. Each node (aliased as `PatriciaNodeIndex`) can hold an optional `flat_hash_set<InternedStringPtr>` of keys that have that exact tag value.
+## `PatriciaTree<InternedStringPtr>`
 
 ```cpp
 template <typename T>
 class PatriciaNode {
   absl::flat_hash_map<std::string, std::unique_ptr<PatriciaNode>> children;
-  int64_t subtree_values_count = 0;   // count of values in entire subtree
-  std::optional<absl::flat_hash_set<T>> value;  // keys at this exact tag
+  int64_t subtree_values_count = 0;
+  std::optional<absl::flat_hash_set<T>> value;   // keys at this exact tag
 };
 ```
 
-The Patricia tree is constructed with the `case_sensitive_` flag. When case-insensitive, all lookups normalize to lowercase.
+Constructed with `case_sensitive_` - case-insensitive mode normalizes to lowercase internally.
 
-Key characteristics:
-- **Path compression** - shared prefixes are collapsed into single edges, reducing memory for tags with common prefixes
-- **subtree_values_count** - each node tracks the total number of values in its subtree, enabling O(prefix_length) size estimation for prefix queries
-- **Exact and prefix search** - `ExactMatcher(tag)` returns the node for an exact tag; `PrefixMatcher(prefix)` returns a `PrefixSubTreeIterator` over all nodes in the prefix subtree
-- **RootIterator** - `tree_.RootIterator()` returns a `PrefixSubTreeIterator` over the entire tree, used for negated queries
+- Path-compression: shared prefixes collapse into single edges.
+- `subtree_values_count` per node - O(prefix length) size estimation for prefix queries.
+- `ExactMatcher(tag)` -> node for exact tag.
+- `PrefixMatcher(prefix)` -> `PrefixSubTreeIterator` over the subtree.
+- `RootIterator()` -> iterator over the entire tree (used by negated queries).
 
-## Separator and Case Sensitivity
+Case sensitivity applies to both storage and search matching.
 
-Both are configured at index creation from the `TagIndex` protobuf:
+## Tag splitting
+
+### `ParseRecordTags` (static)
 
 ```cpp
-Tag::Tag(const data_model::TagIndex& tag_index_proto)
-    : IndexBase(IndexerType::kTag),
-      separator_(tag_index_proto.separator()[0]),
-      case_sensitive_(tag_index_proto.case_sensitive()),
-      tree_(case_sensitive_) {}
+// Whitespace-stripped, empty-dropped
+for (part : absl::StrSplit(data, separator))
+    if (tag = StripAsciiWhitespace(part); !tag.empty()) insert;
 ```
 
-The separator defaults to comma (`,`) but can be any single character. The `GetSeparator()` and `IsCaseSensitive()` accessors expose these for query evaluation.
+### `ParseSearchTags` (static, `StatusOr`)
 
-Case sensitivity applies both to storage in the Patricia tree and to search matching. The tree itself handles case normalization internally when `case_sensitive_` is false.
+Extra rules over `ParseRecordTags`:
 
-`RespondWithInfo()` reports `type=TAG`, `SEPARATOR`, `CASESENSITIVE`, and `size` (tracked key count) for `FT.INFO`.
+- Escape: `\<sep>` is a literal, not a delimiter.
+- Trailing `*` -> prefix match (`elec*` matches `electronics`, `electrical`).
+- Prefix length `<= options::GetTagMinPrefixLength()` -> `InvalidArgumentError`.
+- `tag**` (double wildcard) -> error via `IsValidPrefix()`.
 
-## Tag Splitting
+`UnescapeTag()` (static) converts escapes to literals at the predicate level.
 
-Two parsing modes exist for different contexts:
-
-**Record tags** (`ParseRecordTags`) - static method, splits data on separator via `absl::StrSplit`, strips whitespace:
+## Search (`Tag::Search`)
 
 ```cpp
-static absl::flat_hash_set<absl::string_view> ParseRecordTags(
-    absl::string_view data, char separator) {
-  absl::flat_hash_set<absl::string_view> parsed_tags;
-  for (const auto& part : absl::StrSplit(data, separator)) {
-    auto tag = absl::StripAsciiWhitespace(part);
-    if (!tag.empty()) parsed_tags.insert(tag);
-  }
-  return parsed_tags;
-}
+std::unique_ptr<EntriesFetcher> Tag::Search(const query::TagPredicate&, bool negate) const;
 ```
 
-**Search tags** (`ParseSearchTags`) - static method returning `StatusOr`, additionally handles:
-- Escape sequences: `\<separator>` is a literal separator, not a delimiter
-- Prefix wildcards: trailing `*` enables prefix matching (e.g., `elec*` matches `electronics`, `electrical`)
-- Minimum prefix length: prefixes shorter than or equal to `options::GetTagMinPrefixLength()` are rejected with `InvalidArgumentError`
-- Double wildcard rejection: `tag**` is an error (validated by `IsValidPrefix()`)
+Non-negated: for each tag in the predicate:
+
+- Trailing `*` -> `tree_.PrefixMatcher(prefix)` iterates the subtree; insert each non-null node.
+- Exact -> `tree_.ExactMatcher(tag)`; insert if not null.
+
+Entry set deduplicated via `flat_hash_set<PatriciaNodeIndex*>`. `size` accumulates from each freshly-inserted node's value set. Multiple tags -> union. Suffix/infix search not yet implemented.
+
+## Pre-filter evaluation (`vector_base.cc`)
 
 ```cpp
-// Escape-aware parsing loop
-for (size_t i = 0; i < data.size(); ++i) {
-  if (data[i] == '\\' && i + 1 < data.size()) {
-    ++i;  // Skip escaped character
-  } else if (data[i] == separator) {
-    InsertTag(data.substr(tag_start, i - tag_start));
-    tag_start = i + 1;
-  }
-}
-```
-
-`UnescapeTag()` (static method) converts escaped sequences to literal characters at the predicate level.
-
-## Search and Wildcard Prefix Matching
-
-`Tag::Search()` evaluates a `TagPredicate` against the Patricia tree:
-
-```cpp
-std::unique_ptr<Tag::EntriesFetcher> Tag::Search(
-    const query::TagPredicate& predicate, bool negate) const {
-  absl::flat_hash_set<PatriciaNodeIndex*> entries;
-  size_t size = 0;
-  for (const auto& tag : predicate.GetTags()) {
-    if (tag.back() == '*') {
-      // Prefix matching - iterate all nodes under the prefix
-      auto prefix_tag = tag.substr(0, tag.length() - 1);
-      for (auto it = tree_.PrefixMatcher(prefix_tag); !it.Done(); it.Next()) {
-        PatriciaNodeIndex* node = it.Value();
-        if (node != nullptr) {
-          auto res = entries.insert(node);
-          if (res.second && node->value.has_value()) {
-            size += node->value.value().size();
-          }
-        }
-      }
-    } else {
-      // Exact matching - direct Patricia tree lookup
-      PatriciaNodeIndex* node = tree_.ExactMatcher(tag);
-      if (node != nullptr) {
-        auto res = entries.insert(node);
-        if (res.second && node->value.has_value()) {
-          size += node->value.value().size();
-        }
-      }
-    }
-  }
-  // ...
-}
-```
-
-Multiple tags in a single predicate produce a union - `entries` collects unique nodes from all tag lookups (deduplication via `flat_hash_set`). Suffix and infix search support is planned but not yet implemented.
-
-## Tag Predicate Evaluation
-
-Tags also participate in vector pre-filtering via `PrefilterEvaluator::EvaluateTags()` (in `vector_base.cc`):
-
-```cpp
-query::EvaluationResult PrefilterEvaluator::EvaluateTags(
-    const query::TagPredicate& predicate) {
+EvaluationResult PrefilterEvaluator::EvaluateTags(const TagPredicate& predicate) {
   bool case_sensitive = true;
   auto tags = predicate.GetIndex()->GetValue(*key_, case_sensitive);
   return predicate.Evaluate(tags, case_sensitive);
 }
 ```
 
-`GetValue()` retrieves the parsed tag set for a key and sets the `case_sensitive` output parameter. It operates without locking (safe during read phase of the time-sliced mutex). The predicate's `Evaluate()` method checks whether any of the query tags match the key's stored tags.
+`GetValue(key, &case_sensitive)` retrieves the parsed tag set and sets the out flag. Lock-free - safe during the time-sliced-mutex read phase. `GetRawValue()` returns the original `InternedStringPtr` for result responses.
 
-`GetRawValue()` returns the original `InternedStringPtr` for a key, used when returning tag values in search results.
+## `EntriesFetcher` / iterator
 
-## EntriesFetcher Iteration
-
-The `EntriesFetcher` / `EntriesFetcherIterator` pair provides the standard iteration interface (extending `EntriesFetcherBase` / `EntriesFetcherIteratorBase` from `index_base.h`):
+Non-negated walk - outer over collected Patricia nodes, inner over each node's value set:
 
 ```cpp
-class EntriesFetcher : public EntriesFetcherBase {
-  const PatriciaTreeIndex& tree_;
-  absl::flat_hash_set<PatriciaNodeIndex*> entries_;  // matching Patricia nodes
-  bool negate_;
-  const InternedStringSet& untracked_keys_;
-};
-```
-
-For non-negated queries, the iterator walks through the collected Patricia nodes, yielding each key from each node's value set:
-
-```cpp
-void Tag::EntriesFetcherIterator::Next() {
-  if (next_node_) {
-    ++next_iter_;
-    if (next_iter_ != next_node_->value.value().end()) return;
-  }
+void EntriesFetcherIterator::Next() {
+  if (next_node_ && ++next_iter_ != next_node_->value->end()) return;
   while (!entries_.empty()) {
-    auto itr = entries_.begin();
-    next_node_ = *itr;
-    entries_.erase(itr);
-    if (next_node_->value.has_value() && !next_node_->value.value().empty()) {
-      next_iter_ = next_node_->value.value().begin();
-      return;
+    next_node_ = *entries_.begin();  entries_.erase(entries_.begin());
+    if (next_node_->value && !next_node_->value->empty()) {
+      next_iter_ = next_node_->value->begin();  return;
     }
   }
   next_node_ = nullptr;
 }
 ```
 
-`Begin()` returns a new `EntriesFetcherIterator` and calls `Next()` to advance to the first result.
+`Begin()` constructs and calls `Next()` once.
 
-## Record Lifecycle
+## Record lifecycle
 
-**Add**: `AddRecord()` interns the data string via `StringInternStore::Intern()`, parses tags via `ParseRecordTags()`. If no tags are found, the key goes to `untracked_keys_`. If the key already exists, returns `AlreadyExistsError`. Otherwise, inserts into `tracked_tags_by_keys_` (with both raw string and parsed tags) and adds each tag to the Patricia tree:
+- **Add**: intern data via `StringInternStore::Intern()`, `ParseRecordTags()`. No tags -> `untracked_keys_`. Existing tracked -> `AlreadyExistsError`. Else insert into `tracked_tags_by_keys_`, then `tree_.AddKeyValue(tag, key)` per tag.
+- **Modify**: intern new data, parse. Empty result -> fall through to `Remove(DeletionType::kIdentifier)`. Else differential update:
+  ```cpp
+  for (tag : new_tags)   if (!old.contains(tag)) tree_.AddKeyValue(tag, key);
+  for (tag : old_tags)   if (!new.contains(tag)) tree_.Remove(tag, key);
+  ```
+  Avoids full remove-then-add. Untracked key -> `NotFoundError`.
+- **Remove**: remove each tag from the tree, erase from `tracked_tags_by_keys_`.
 
-```cpp
-for (const auto& tag : parsed_tags) {
-  tree_.AddKeyValue(tag, key);
-}
-```
+## Tracked vs untracked
 
-**Modify**: `ModifyRecord()` interns the new data, parses new tags. If the new tag set is empty, falls through to `RemoveRecord` with `DeletionType::kIdentifier`. Otherwise, computes the diff between old and new tag sets, adding new tags and removing stale ones:
+Mutually exclusive - `CHECK` in `UnTrack()`. `AddRecord` removes from untracked on the success path.
 
-```cpp
-// Insert new tags not in old set
-for (const auto& tag : new_parsed_tags) {
-  if (!tag_info.tags.contains(tag)) tree_.AddKeyValue(tag, key);
-}
-// Remove old tags not in new set
-for (const auto& tag : tag_info.tags) {
-  if (!new_parsed_tags.contains(tag)) tree_.Remove(tag, key);
-}
-```
+| `DeletionType` | Effect |
+|----------------|--------|
+| `kRecord` | remove from untracked too |
+| `kIdentifier` / `kNone` | add to untracked |
 
-This differential update avoids a full remove-then-add cycle, minimizing Patricia tree mutations. Returns `NotFoundError` if the key is not tracked.
+Relevant for negated queries - untracked keys must be included.
 
-**Remove**: Removes all of the key's tags from the Patricia tree, then erases from `tracked_tags_by_keys_`.
+## Negated search
 
-## Tracked vs Untracked Keys
-
-Same pattern as the Numeric index:
-- **Tracked** - keys with at least one parseable tag, stored in `tracked_tags_by_keys_`
-- **Untracked** - keys that exist in the schema but whose tag field is empty or missing
-
-These sets are mutually exclusive (enforced by `CHECK` in `UnTrack()`). On `AddRecord`, if the key was previously untracked, it is removed from `untracked_keys_`.
-
-`DeletionType::kRecord` removes from untracked; `DeletionType::kIdentifier` (or `kNone`) adds to untracked. Important for negated queries where untracked keys must be included.
-
-## Negated Tag Queries
-
-For negated search (`negate=true`), the iterator walks the entire Patricia tree via `tree_.RootIterator()`, skipping nodes that are in the matched `entries_` set:
+Walks entire tree via `tree_.RootIterator()`, skipping nodes in matched `entries_`:
 
 ```cpp
-void Tag::EntriesFetcherIterator::NextNegate() {
+void EntriesFetcherIterator::NextNegate() {
   while (!tree_iter_.Done()) {
     next_node_ = tree_iter_.Value();
     if (next_node_ && !entries_.contains(next_node_) &&
-        next_node_->value.has_value() && !next_node_->value.value().empty()) {
-      next_iter_ = next_node_->value.value().begin();
-      return;
+        next_node_->value && !next_node_->value->empty()) {
+      next_iter_ = next_node_->value->begin(); return;
     }
     tree_iter_.Next();
   }
-  // After tree exhaustion, yield untracked keys
+  // ... then yield untracked keys
   next_node_ = nullptr;
-  // iterate untracked_keys_...
 }
 ```
 
-Size estimation for negated queries: `tracked_tags_by_keys_.size() - matched_size + untracked_keys_.size()` (clamped to avoid underflow when matched_size exceeds tracked count).
+Size estimate: `max(0, tracked_count - matched_size) + untracked_keys_.size()`.
+
+## FT.INFO
+
+`RespondWithInfo()` reports `type=TAG`, `SEPARATOR`, `CASESENSITIVE`, `size` (tracked count).

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-text.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/indexes-text.md
@@ -1,273 +1,196 @@
-# Full-Text Search Index
+# Full-text search index
 
-Use when working on full-text search, the prefix/suffix Rax tree, postings lists, stemming, proximity/phrase matching, the tokenization pipeline, or fuzzy matching.
+Use when reasoning about full-text search, prefix/suffix Rax trees, postings, stemming, proximity/phrase matching, tokenization, or fuzzy matching.
 
-Source: `src/indexes/text.h`, `src/indexes/text.cc`, `src/indexes/text/` directory
+Source: `src/indexes/text.{h,cc}`, `src/indexes/text/` directory.
 
-## Contents
+## Two-level architecture
 
-- [Architecture Overview](#architecture-overview)
-- [TextIndexSchema and Per-Field Text](#textindexschema-and-per-field-text)
-- [Rax Prefix Tree](#rax-prefix-tree)
-- [Optional Suffix Tree](#optional-suffix-tree)
-- [Stem Tree](#stem-tree)
-- [Postings Lists with Position Maps](#postings-lists-with-position-maps)
-- [Proximity and Phrase Matching](#proximity-and-phrase-matching)
-- [Lexer Pipeline](#lexer-pipeline)
-- [Fuzzy Matching](#fuzzy-matching)
-- [Record Lifecycle](#record-lifecycle)
-- [Concurrency Model](#concurrency-model)
+- **`TextIndexSchema`** (`text_index.h`) - schema-level shared state, one per `FT.CREATE`. Owns Rax trees (prefix, suffix, stem), lexer, per-key text indexes, staging areas.
+- **`Text`** (`text.h`) - per-field index. Field-specific settings (`weight`, `no_stem`, `with_suffix_trie`) plus `text_field_number_` (bit position in field masks). Delegates indexing to the shared schema.
 
-## Architecture Overview
+Separation exists because full-text is inherently cross-field - a single Rax tree indexes words from all text fields; field masks distinguish which fields contain each word.
 
-Full-text search has a two-level architecture:
-
-1. **TextIndexSchema** (`text_index.h`) - schema-level shared state. One per `FT.CREATE` index. Owns the main Rax trees (prefix, suffix, stem), the lexer, per-key text indexes, and staging areas for in-progress mutations.
-
-2. **Text** (`text.h`) - per-field index. One per TEXT attribute in the schema. Holds field-specific settings (`weight`, `no_stem`, `with_suffix_trie`) and a `text_field_number_` used as a bit position in field masks. Delegates indexing to the shared `TextIndexSchema`.
-
-This separation exists because full-text search is inherently cross-field - a single Rax tree indexes words from all text fields, with field masks distinguishing which fields contain each word.
-
-## TextIndexSchema and Per-Field Text
+## `TextIndexSchema`
 
 ```cpp
 class TextIndexSchema {
-  std::shared_ptr<TextIndex> text_index_;    // main prefix + optional suffix tree
-  Rax stem_tree_;                            // stem root -> parent words
-  Lexer lexer_;                              // stateless tokenizer
-  TextIndexMetadata metadata_;               // FT.INFO counters + memory pools
-  absl::node_hash_map<Key, TextIndex> per_key_text_indexes_;  // per-key reverse index
-  absl::node_hash_map<Key, TokenPositions> in_progress_key_updates_;  // staging
+  std::shared_ptr<TextIndex> text_index_;             // prefix + optional suffix
+  Rax stem_tree_;                                     // stem -> parent words
+  Lexer lexer_;
+  TextIndexMetadata metadata_;                        // FT.INFO counters + pools
+  absl::node_hash_map<Key, TextIndex>       per_key_text_indexes_;
+  absl::node_hash_map<Key, TokenPositions>  in_progress_key_updates_;
   absl::node_hash_map<Key, InProgressStemMap> in_progress_stem_mappings_;
-  RaxTargetMutexPool rax_target_mutex_pool_; // per-word bucket locks
-  uint8_t num_text_fields_ = 0;             // max 64 fields (field mask is uint64_t)
-  bool with_offsets_;                        // store position offsets for phrase queries
-  uint32_t min_stem_size_;                   // minimum word length for stemming
-  uint64_t stem_text_field_mask_ = 0;        // bitmask of fields with stemming enabled
+  RaxTargetMutexPool rax_target_mutex_pool_;          // per-word bucket locks
+  uint8_t  num_text_fields_ = 0;                      // MAX 64 (field mask is uint64_t)
+  bool     with_offsets_;                             // store position offsets (phrase queries)
+  uint32_t min_stem_size_;
+  uint64_t stem_text_field_mask_ = 0;
 };
 ```
 
-Each Text attribute registers itself via `AllocateTextFieldNumber()`, receiving a unique bit position. If the field has `with_suffix_trie_` enabled, it calls `TextIndexSchema::EnableSuffix()` which recreates the shared `TextIndex` with suffix support.
+`AllocateTextFieldNumber()` - each `Text` attribute registers for a unique bit position. `EnableSuffix()` recreates the shared `TextIndex` with a suffix tree if any field has `WITHSUFFIXTRIE`.
 
-The `FieldMask` struct (`posting.h`) is a 16-byte struct (enforced by `static_assert`) that stores field presence as a 64-bit bitmask:
+`FieldMask` (`posting.h`) is a 16-byte struct (enforced by `static_assert`):
 
 ```cpp
 struct FieldMask {
   uint64_t mask_{0};
-  uint8_t num_fields_{0};
+  uint8_t  num_fields_{0};
   void SetField(size_t field_index);
   uint64_t GetMask() const;
 };
 ```
 
-`FieldMaskPredicate` is a `uint64_t` type alias used for field-level filtering during queries.
+`FieldMaskPredicate` is a `uint64_t` alias used for field-level filtering.
 
-Per-field configuration (stored in `Text` class):
-- `weight_` - relevance weight for scoring (default 1.0)
-- `no_stem_` - disables stemming for this field
-- `with_suffix_trie_` - enables suffix/contains queries for this field
+Per-field config (on `Text`): `weight_` (default 1.0), `no_stem_`, `with_suffix_trie_`. `tracked_keys_` / `untracked_keys_` (`InternedStringSet`) mainly drive `FT.INFO` metrics.
 
-The `Text` class also maintains `tracked_keys_` and `untracked_keys_` (`InternedStringSet`) for per-field tracking - currently used mainly for `FT.INFO` metrics.
-
-## Rax Prefix Tree
-
-The primary data structure maps words to `Postings` objects. The `Rax` wrapper (`rax_wrapper.h`) encapsulates the C `rax` library from Valkey's core, providing C++ iterator APIs.
+## Rax prefix tree
 
 ```cpp
 class TextIndex {
-  Rax prefix_tree_;                          // word -> Postings (always present)
-  std::unique_ptr<Rax> suffix_tree_;         // reversed_word -> Postings (optional)
+  Rax prefix_tree_;                       // word -> Postings (always present)
+  std::unique_ptr<Rax> suffix_tree_;      // reversed_word -> Postings (optional)
 };
 ```
 
-The prefix tree is a memory-efficient radix tree with path compression. Key APIs:
+`Rax` wrapper (`rax_wrapper.h`) encapsulates Valkey core's C `rax` library with C++ iterator APIs. Memory-efficient radix tree with path compression. `InvasivePtr<Postings>` for reference-counted targets.
 
-- `GetWordIterator(prefix)` - iterates all words with the given prefix in lexical order, returning `Postings` targets. Used for prefix search (`hello*`) and exact term lookup.
-- `MutateTarget(word, fn, op)` - applies a mutation function to a word's target, with optional `item_count_op` for subtree count tracking
-- `GetSubtreeItemCount(prefix)` - O(prefix_length) count of entries under a prefix, used for query planning (only tracked when `track_subtree_item_counts_` is enabled - happens when the schema has a HNSW field)
+Key APIs:
 
-Words are stored lowercase. The Rax wraps the same `rax` C structure used in Valkey's core but with a C++ ownership model using `InvasivePtr<Postings>` for reference-counted targets.
+- `GetWordIterator(prefix)` - all words with prefix, lexical order, yields `Postings`. Used for prefix search (`hello*`) and exact term lookup.
+- `MutateTarget(word, fn, op)` - applies mutation; optional `item_count_op` updates subtree counts.
+- `GetSubtreeItemCount(prefix)` - O(prefix length) count under a prefix (query planning). Only tracked when `track_subtree_item_counts_` is enabled - happens when the schema has a HNSW field.
 
-The `RadixTree<Target>` template (`radix_tree.h`) is an alternative pure-C++ implementation available but the production code uses the Rax wrapper for its memory efficiency.
+Words stored lowercase. `RadixTree<Target>` (`radix_tree.h`) is a pure-C++ alternative available, but production uses Rax for memory.
 
-## Optional Suffix Tree
+## Suffix tree
 
-When any TEXT field has `WITHSUFFIXTRIE` enabled, `EnableSuffix()` recreates the `TextIndex` with a second Rax tree that stores reversed words:
-
-```cpp
-TextIndex::TextIndex(bool suffix)
-    : prefix_tree_(FreePostingsCallback),
-      suffix_tree_(suffix ? std::make_unique<Rax>(FreePostingsCallback)
-                          : nullptr) {}
-```
-
-Both trees point to the same `Postings` objects - `TextIndex::MutateTarget()` updates both atomically:
+`TextIndex::TextIndex(bool suffix)`: both trees reference the same `Postings` objects. `MutateTarget()` updates both atomically:
 
 ```cpp
-void TextIndex::MutateTarget(absl::string_view word,
-                             const InvasivePtr<Postings>& target,
-                             const std::optional<std::string>& reverse_word,
-                             item_count_op op) {
+void TextIndex::MutateTarget(word, target, reverse_word, op) {
   auto target_set_fn = CreateTargetSetFn(target);
   prefix_tree_.MutateTarget(word, target_set_fn, op);
-  if (suffix_tree_ && reverse_word.has_value()) {
-    suffix_tree_->MutateTarget(*reverse_word, target_set_fn, op);
-  }
+  if (suffix_tree_ && reverse_word) suffix_tree_->MutateTarget(*reverse_word, target_set_fn, op);
 }
 ```
 
-Suffix search (`SuffixPredicate::BuildTextIterator`) reverses the query string and does a prefix search on the suffix tree. For example, searching for `*tion` reverses to `noit` and prefix-matches in the suffix tree.
+`SuffixPredicate::BuildTextIterator` reverses the query string and prefix-searches the suffix tree. E.g., `*tion` reverses to `noit` and prefix-matches.
 
-## Stem Tree
+## Stem tree
 
-The stem tree maps stemmed forms to their original words, enabling stem-aware search:
+Rax: `stemmed_word -> StemParents (vector<string>)`. Example: `"happi" -> {"happy", "happiness", "happily"}`.
 
-```cpp
-// Rax stem_tree_: stemmed_word -> StemParents (vector<string>)
-// Example: "happi" -> {"happy", "happiness", "happily"}
-```
+**Indexing** (`CommitKeyData`): `in_progress_stem_mappings_` (populated by lexer's `UpdateStemMap()`) is committed under `stem_tree_mutex_`.
 
-During indexing (`CommitKeyData`), stem mappings collected in `in_progress_stem_mappings_` by the lexer's `UpdateStemMap()` are committed to the stem tree under `stem_tree_mutex_`.
-
-During search (`GetAllStemVariants`), a query term is stemmed and the stem tree is consulted:
+**Search** (`GetAllStemVariants`): stem the query term, look up in stem tree, expand to all parents.
 
 ```cpp
-std::string stemmed(search_term);
 lexer_.StemWordInPlace(stemmed, lexer_.GetStemmer(), min_stem_size_);
 auto stem_iter = stem_tree_.GetWordIterator(stemmed);
-// If exact match found, collect all parent words
-if (!stem_iter.Done() && stem_iter.GetWord() == stemmed) {
-  for (const auto& parent : *parents_ptr) {
-    words_to_search.push_back(parent);
-  }
-}
+if (!stem_iter.Done() && stem_iter.GetWord() == stemmed)
+    for (const auto& parent : *parents_ptr) words_to_search.push_back(parent);
 ```
 
-Queries for "happy" also match documents containing "happiness" or "happily", since they all share the stem "happi". Stem expansion uses `stem_text_field_mask_` to only expand stems for fields that have stemming enabled.
+Expansion gated by `stem_text_field_mask_` - only fields with stemming enabled get expanded.
 
-## Postings Lists with Position Maps
-
-`Postings` (`posting.h`) is the inverted index entry for a single word. It maps keys to their position/field information:
+## Postings
 
 ```cpp
 struct Postings {
   absl::btree_map<Key, FlatPositionMap*> key_to_positions_;
-  void InsertKey(const Key& key, FlatPositionMap* flat_map);
-  void RemoveKey(const Key& key, TextIndexMetadata* metadata);
+  void InsertKey(const Key&, FlatPositionMap*);
+  void RemoveKey(const Key&, TextIndexMetadata*);
   size_t GetKeyCount() const;
   KeyIterator GetKeyIterator() const;
 };
 ```
 
-Each `FlatPositionMap` (`flat_position_map.h`) stores a compact representation of positions and their field masks for a single key. Positions are stored when `with_offsets_` is true, enabling phrase and proximity queries.
+`FlatPositionMap` (`flat_position_map.h`) - compact positions + field masks per key. Positions stored when `with_offsets_ == true`.
 
-The `KeyIterator` provides ordered iteration over keys within a word's postings:
+`KeyIterator`:
 
 ```cpp
 struct Postings::KeyIterator {
-  bool IsValid() const;
-  void NextKey();
-  bool SkipForwardKey(const Key& key);  // seek for merge joins
-  const Key& GetKey() const;
-  bool ContainsFields(uint64_t field_mask) const;  // field-level filtering
-  PositionIterator GetPositionIterator() const;
+  bool IsValid(); void NextKey();
+  bool SkipForwardKey(const Key&);           // merge-join seek
+  const Key& GetKey();
+  bool ContainsFields(uint64_t field_mask);
+  PositionIterator GetPositionIterator();
 };
 ```
 
-`SkipForwardKey` enables efficient merge-join across multiple postings lists - critical for multi-term queries where the intersection of key sets must be found.
+`SkipForwardKey` drives multi-term merge-join. `PositionIterator` yields positions ascending with field masks for proximity.
 
-The `PositionIterator` (from `FlatPositionMap`) yields positions in ascending order with their field masks, enabling proximity checking.
-
-## Proximity and Phrase Matching
-
-`ProximityIterator` (`proximity.h`) coordinates multiple `TextIterator` instances to find documents where terms appear within a specified distance:
+## Proximity / phrase
 
 ```cpp
 class ProximityIterator : public TextIterator {
-  absl::InlinedVector<std::unique_ptr<TextIterator>,
-                      kProximityTermsInlineCapacity> iters_;
-  std::optional<uint32_t> slop_;   // max word distance between terms
-  bool in_order_;                  // require terms to appear in query order
-  bool skip_positional_checks_;    // AND without positional constraints
+  absl::InlinedVector<std::unique_ptr<TextIterator>, kProximityTermsInlineCapacity> iters_;
+  std::optional<uint32_t> slop_;
+  bool in_order_;
+  bool skip_positional_checks_;   // AND without positional constraints
 };
 ```
 
-The `TextIterator` interface (`text_iterator.h`) provides a two-level iteration contract: key-level (`NextKey`, `SeekForwardKey`, `DoneKeys`) and position-level (`NextPosition`, `SeekForwardPosition`, `DonePositions`, `CurrentFieldMask`).
+`TextIterator` (`text_iterator.h`) is a two-level contract: key (`NextKey`, `SeekForwardKey`, `DoneKeys`) and position (`NextPosition`, `SeekForwardPosition`, `DonePositions`, `CurrentFieldMask`).
 
-The algorithm:
-1. `FindCommonKey()` - advances all iterators to find a key present in all postings lists (merge-join using `SeekForwardKey`)
-2. For each common key, check positional constraints:
-   - Collect current positions from all iterators
-   - Sort by position
-   - Verify slop constraint: max(positions) - min(positions) - (num_terms - 1) <= slop
-   - If `in_order_` is set, verify positions are monotonically increasing
-3. `FindViolatingIterator()` returns a `ViolationInfo` struct identifying which iterator to advance and an optional seek target position
+Algorithm:
 
-Exact phrase matching is a special case with `slop=0` and `in_order=true`.
+1. `FindCommonKey()` - merge-join all iterators via `SeekForwardKey`.
+2. Per common key: collect positions, sort, verify `max - min - (num_terms - 1) <= slop`. If `in_order_`, verify monotonically increasing.
+3. `FindViolatingIterator()` returns which iterator to advance and an optional seek target.
 
-`skip_positional_checks_` is set for AND operations without positional constraints - in this case only key intersection is verified, not positions.
+Exact phrase = `slop=0, in_order=true`. `skip_positional_checks_` = AND without positional constraints (key intersection only).
 
-`ProximityIterator` can contain nested `ProximityIterator` instances - this occurs when a ProximityOR term appears inside a ProximityAND term. The `OrProximityIterator` (`orproximity.h`) handles the OR case.
+Nested `ProximityIterator`s supported (ProximityOR inside ProximityAND). `OrProximityIterator` (`orproximity.h`) handles OR.
 
-## Lexer Pipeline
-
-The `Lexer` (`lexer.h`) is a stateless tokenizer configured per schema:
+## Lexer
 
 ```cpp
 struct Lexer {
-  data_model::Language language_;          // for stemmer selection
-  std::bitset<256> punct_bitmap_;          // fast punctuation check
+  data_model::Language language_;
+  std::bitset<256> punct_bitmap_;
   absl::flat_hash_set<std::string> stop_words_set_;
 };
 ```
 
-Tokenization pipeline (`Tokenize()`):
+`Tokenize()` pipeline:
 
-1. **UTF-8 validation** - `IsValidUtf8()` rejects invalid input (returns `kInvalidArgument` -> `hash_indexing_failures`)
-2. **Split on punctuation** - characters in `punct_bitmap_` are treated as delimiters
-3. **Unicode normalization** - `NormalizeLowerCaseInPlace()` lowercases using ICU-aware normalization (`unicode_normalizer.h`)
-4. **Stop word removal** - tokens in `stop_words_set_` are filtered out (checked via `IsStopWord()`)
-5. **Stemming** - if enabled and word length >= `min_stem_size`, apply Snowball stemmer via `StemWordInPlace()`
+1. **UTF-8 validation** - `IsValidUtf8()` rejects invalid (bumps `hash_indexing_failures`).
+2. **Split on punctuation** - chars in `punct_bitmap_` are delimiters.
+3. **Unicode lowercase** - `NormalizeLowerCaseInPlace()` (ICU-aware, `unicode_normalizer.h`).
+4. **Stop words** - `IsStopWord()` filter.
+5. **Stem** - if enabled and `length >= min_stem_size`, `StemWordInPlace(word, stemmer, min_stem_size)` via Snowball (`libstemmer`).
 
-Stemming uses the `libstemmer` library (Snowball):
+`GetStemmer()` picks stemmer from schema's `language`. `UpdateStemMap()` records original-to-stem into `InProgressStemMap` for later stem tree commit. Stop words configurable per schema (language-defaulted).
 
-```cpp
-void Lexer::StemWordInPlace(std::string& word, sb_stemmer* stemmer,
-                            uint32_t min_stem_size) const;
-```
+## Fuzzy
 
-The stemmer is obtained via `GetStemmer()` based on the schema's `language` field. `UpdateStemMap()` records the original-to-stem mapping into an `InProgressStemMap` for later stem tree updates.
+`FuzzySearch` (`fuzzy.h`) - Damerau-Levenshtein over the Rax prefix tree: `Search(tree, pattern, max_distance, max_words)`. Recursive traversal with DP over 4 ops (deletion, insertion, substitution, transposition). Prunes branches where min DP row exceeds `max_distance`. Bounded by `max_words` (default `options::GetMaxTermExpansions()`). `FuzzyPredicate::BuildTextIterator` wraps results in a `TermIterator`.
 
-Stop words are configurable per schema. The default set depends on the language.
+## Record lifecycle
 
-## Fuzzy Matching
+- **Add**: `Text::AddRecord()` -> `TextIndexSchema::StageAttributeData()` tokenizes into `TokenPositions` (`token -> (PositionMap, suffix_eligible)`, `PositionMap = btree_map<Position, FieldMask>`). Each token at each position sets its field bit. Stages in `in_progress_key_updates_`.
+- **Commit** (`CommitKeyData`): after all attributes have staged. Per token: look up / create `Postings`, insert key with `FlatPositionMap`, update per-key text index, commit stem mappings. Per-word bucket locks (`RaxTargetMutexPool`); `text_index_mutex_` for structural changes.
+- **Modify**: `ModifyRecord()` - old data was already removed by `DeleteKeyData()`, so just stages new data.
+- **Delete** (`DeleteKeyData`): iterate all words the key was under, remove from each word's postings, clean empty postings, remove stem entries when last word with a given stem is gone.
 
-`FuzzySearch` (`fuzzy.h`) implements Damerau-Levenshtein distance matching on the Rax prefix tree via `Search(tree, pattern, max_distance, max_words)`. The algorithm uses recursive tree traversal with dynamic programming over four edit operations (deletion, insertion, substitution, transposition). Subtree pruning skips branches where the minimum DP row value exceeds `max_distance`. Each child branch saves and restores DP rows for independent evaluation. Results are bounded by `max_words` (from `options::GetMaxTermExpansions()`). `FuzzyPredicate::BuildTextIterator` wraps results in a `TermIterator`.
-
-## Record Lifecycle
-
-**Add**: `Text::AddRecord()` delegates to `TextIndexSchema::StageAttributeData()` which tokenizes the text and builds a `TokenPositions` map (`token -> (PositionMap, suffix_eligible)` where `PositionMap` is `absl::btree_map<Position, FieldMask>`). Each token at each position gets a field mask bit set for the current text field. This is staged in `in_progress_key_updates_`.
-
-**Commit (CommitKeyData)**: Called after all attributes have staged their data. For each token: look up or create a `Postings` object in the prefix tree, insert the key with its `FlatPositionMap`, update the per-key text index, and commit stem mappings. Uses per-word bucket locks (`RaxTargetMutexPool`) for fine-grained concurrency, with `text_index_mutex_` for tree structural changes.
-
-**Modify**: `Text::ModifyRecord()` - the old key value has already been removed via `TextIndexSchema::DeleteKeyData()`, so it simply stages new data via `StageAttributeData`.
-
-**Delete (DeleteKeyData)**: Iterates all words the key was indexed under, removes the key from each word's postings, cleans up empty postings from the tree, and removes stem tree entries when the last word with a given stem is removed.
-
-## Concurrency Model
-
-Multiple locking levels:
+## Concurrency
 
 | Lock | Type | Protects |
 |------|------|----------|
-| `text_index_mutex_` | absl::Mutex | Rax tree structural changes (node insert/delete) |
-| `rax_target_mutex_pool_` | `RaxTargetMutexPool` (pool of absl::Mutex) | Per-word postings mutations (bucket hashed) |
-| `stem_tree_mutex_` | absl::Mutex | Stem tree structural changes |
-| `per_key_text_indexes_mutex_` | std::mutex | Per-key text index map |
-| `in_progress_key_updates_mutex_` | std::mutex | Staging area for key updates |
-| `in_progress_stem_mappings_mutex_` | std::mutex | Staging area for stem mappings |
-| `index_mutex_` (Text class) | absl::Mutex | Per-field `tracked_keys_` / `untracked_keys_` |
+| `text_index_mutex_` | `absl::Mutex` | Rax structural changes |
+| `rax_target_mutex_pool_` | pool of `absl::Mutex` | per-word postings mutations (hashed bucket) |
+| `stem_tree_mutex_` | `absl::Mutex` | stem tree structural changes |
+| `per_key_text_indexes_mutex_` | `std::mutex` | per-key text index map |
+| `in_progress_key_updates_mutex_` | `std::mutex` | staging for key updates |
+| `in_progress_stem_mappings_mutex_` | `std::mutex` | staging for stem mappings |
+| `Text::index_mutex_` | `absl::Mutex` | per-field `tracked_keys_` / `untracked_keys_` |
 
-The design separates tree structure locks from target mutation locks. Reading the Rax tree during search takes `text_index_mutex_` as a reader lock, while target mutations only need the per-word bucket lock. This allows high concurrency for queries that touch different words.
+Structure locks are separate from target mutation locks. Search takes `text_index_mutex_` as reader; target mutations only need the per-word bucket lock. High concurrency across different words.
 
-`Text::EntriesFetcher` bridges to the `TextIterator` hierarchy - `Begin()` calls `predicate_->BuildTextIterator()` and wraps it in a `TextFetcher` adapter (`text_fetcher.h`). `TextIteratorFetcher` (in `text.h`) provides the same bridge for composed AND queries where a `TextIterator` is already built.
+`Text::EntriesFetcher::Begin()` calls `predicate_->BuildTextIterator()` and wraps in `TextFetcher` (`text_fetcher.h`). `TextIteratorFetcher` bridges composed AND queries where a `TextIterator` is already built.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/query-execution.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/query-execution.md
@@ -1,210 +1,152 @@
-# Search Execution Flow
+# Search execution
 
-Use when understanding how queries execute, the prefilter vs inline filtering decision, async dispatch, content resolution, or contention checking.
+Use when reasoning about how queries execute, prefilter vs inline filtering, async dispatch, content resolution, or contention checking.
 
-Source: `src/query/search.h`, `src/query/search.cc`, `src/query/planner.h`, `src/query/planner.cc`, `src/query/content_resolution.h`
+Source: `src/query/search.{h,cc}`, `src/query/planner.{h,cc}`, `src/query/content_resolution.h`.
 
-## Contents
+## Thread split
 
-- Execution Overview (line 24)
-- Entry Points (line 30)
-- Non-Vector Query Flow (line 47)
-- Vector Query Flow (line 59)
-- Prefilter vs Inline Decision (line 79)
-- Prefilter Path (line 100)
-- Inline Filter Path (line 113)
-- EvaluateFilterAsPrimary (line 124)
-- Async Dispatch and Threading (line 138)
-- Content Resolution on Main Thread (line 163)
-- ContentProcessing Modes (line 177)
-- Contention Checking (line 189)
-- Result Trimming and Serialization (line 200)
+Index data reads fine on background threads. **Document content fetch requires the main thread** (Valkey keyspace is single-threaded).
 
-## Execution Overview
+`SearchParameters` carries state through the pipeline: parsed filter, index schema, limit/offset, timeout, cancellation token, eventual `SearchResult`.
 
-Search execution starts on the main thread (command handler), dispatches to a reader thread pool for the actual search, and may return to the main thread for content resolution. Index data can be read on background threads, but fetching document content from Valkey's keyspace requires the main thread.
-
-The `SearchParameters` struct (in `search.h`) carries all state through the pipeline: parsed filter, index schema reference, limit/offset, timeout, cancellation token, and the eventual `SearchResult`.
-
-## Entry Points
-
-Two entry points in `search.h`:
+## Entry points
 
 ```cpp
-// Synchronous - runs search and populates parameters.search_result
-absl::Status Search(SearchParameters& parameters, SearchMode search_mode);
-
-// Async - schedules search on thread pool, calls QueryComplete* when done
-absl::Status SearchAsync(unique_ptr<SearchParameters> parameters,
-                         ThreadPool* thread_pool, SearchMode search_mode);
+absl::Status Search(SearchParameters&, SearchMode);
+absl::Status SearchAsync(unique_ptr<SearchParameters>, ThreadPool*, SearchMode);
 ```
 
-`SearchAsync` is the normal path for FT.SEARCH and FT.AGGREGATE commands. The `QueryCommand::Execute` method blocks the client, creates a cancellation token with timeout, and calls `SearchAsync`. `SearchMode` distinguishes `kLocal` (direct query) from `kRemote` (coordinator-dispatched shard query, which checks OOM).
+`SearchAsync` is normal for FT.SEARCH / FT.AGGREGATE. `QueryCommand::Execute` blocks the client, builds a cancel token with timeout, calls `SearchAsync`. `SearchMode`: `kLocal` (direct) vs `kRemote` (coordinator-dispatched shard query - checks OOM).
 
-Both paths call `DoSearch()` internally, which acquires a `ReaderMutexLock` on the index schema's time-sliced mutex. This lock allows concurrent reads but coordinates with write mutations.
+Both call `DoSearch()`, which takes `ReaderMutexLock` on the index's time-sliced mutex.
 
-## Non-Vector Query Flow
+## Non-vector flow (`SearchNonVectorQuery`)
 
-When `parameters.IsNonVectorQuery()` is true (no vector attribute alias), `DoSearch()` calls `SearchNonVectorQuery()`:
+1. `EvaluateFilterAsPrimary()` walks predicate tree, builds `EntriesFetcherBase` objects from each leaf's index.
+2. `IsUnsolvedQuery()` - true when AND combines numeric/tag OR when negation is present.
+3. **Simple path** (no prefilter needed): iterate fetchers directly, collect matching keys as `Neighbor`s (distance 0), dedupe if OR/tag/negation.
+4. **Complex path**: `EvaluatePrefilteredKeys()` iterates and evaluates the full predicate against each key via `PrefilterEvaluator`.
+5. `max-nonvector-search-results-fetched` (default 100000) caps collected keys; overflow bumps `nonvector_results_fetched_limited_count`.
 
-1. **Build entry fetchers** - `EvaluateFilterAsPrimary()` walks the predicate tree and creates `EntriesFetcherBase` objects from each leaf predicate's index (tag, numeric, or text)
-2. **Check if prefilter evaluation needed** - `IsUnsolvedQuery()` returns true when the query combines AND with numeric/tag predicates or uses negation
-3. **Simple path** (no prefilter needed) - iterate fetchers directly, collect matching keys into a `Neighbor` vector, deduplicate if needed (OR/tag/negation)
-4. **Complex path** (prefilter needed) - call `EvaluatePrefilteredKeys()` which iterates fetcher results and evaluates the full predicate tree against each key using `PrefilterEvaluator`
-5. **Fetch limit** - `max-nonvector-search-results-fetched` config (default 100000) caps how many keys are accumulated. When exceeded, iteration stops early and the `nonvector_results_fetched_limited_count` metric increments
+`MaybeAddIndexedContent()` populates attributes from index data where possible (tag values, numeric values, vector blobs) to skip main-thread fetches.
 
-Results are `Neighbor` structs with `distance = 0.0f` (no vector score). The `MaybeAddIndexedContent()` step attempts to populate attribute content from index data directly (tag values, numeric values, vector blobs) to avoid main-thread content fetches where possible.
+## Vector flow
 
-## Vector Query Flow
+1. Resolve vector attribute -> `indexes::VectorBase*` (`VectorHNSW<float>` or `VectorFlat<float>`).
+2. No filter (bare `*`) -> `PerformVectorSearch()` without filter.
+3. With filter -> `EvaluateFilterAsPrimary()` + consult planner for prefilter vs inline.
 
-When the query includes a vector attribute (KNN clause), `DoSearch()` follows this path:
+`PerformVectorSearch()` dispatches:
 
-1. **Look up vector index** - resolves `attribute_alias` to an `indexes::VectorBase*` (either `VectorHNSW<float>` or `VectorFlat<float>`)
-2. **No filter** - if `root_predicate` is null (bare `*` or no filter expression), call `PerformVectorSearch()` directly with no filter functor
-3. **With filter** - build entry fetchers via `EvaluateFilterAsPrimary()`, then consult the query planner
+- HNSW: `VectorHNSW::Search(query_vec, K, cancel, filter?, ef_runtime?)`.
+- FLAT: `VectorFlat::Search(query_vec, K, cancel, filter?)`.
 
-The planner decides between two strategies:
+Returns `StatusOr<vector<Neighbor>>`, distance-sorted.
 
-- **Prefilter** - reduce the candidate set first, then do exact nearest-neighbor on the reduced set
-- **Inline** - run the full vector search (HNSW graph walk or flat scan) with a filter callback that evaluates each candidate
+## Prefilter vs inline (`planner.cc::UsePreFiltering`)
 
-`PerformVectorSearch()` handles both HNSW and FLAT index types:
+- **FLAT**: always prefilter. Flat is O(N * log K); prefilter reduces to O(n * log K) where n << N - always a win.
+- **HNSW**: prefilter when `estimated_num_of_keys <= GetPrefilteringThresholdRatio() * vector_index->GetTrackedKeyCount()`.
 
-- **HNSW** - calls `VectorHNSW::Search()` with the query vector, K, cancellation token, optional inline filter, and optional `ef_runtime` override
-- **FLAT** - calls `VectorFlat::Search()` with query vector, K, cancellation token, optional inline filter
+Threshold is `prefiltering-threshold-ratio` config. Very selective filter -> prefilter avoids graph walk. Broad filter -> inline lets HNSW guide.
 
-Both return `StatusOr<vector<Neighbor>>` with neighbors sorted by distance.
+Metrics: `query_prefiltering_requests_cnt` vs `query_inline_filtering_requests_cnt`.
 
-## Prefilter vs Inline Decision
+## Prefilter path
 
-`UsePreFiltering()` in `planner.cc` makes the decision based on heuristics:
+1. `CalcBestMatchingPrefilteredKeys()` iterates entry fetchers.
+2. Per candidate: `PrefilterEvaluator` evaluates full predicate tree.
+3. Matching keys: `vector_index->AddPrefilteredKey()` - max-heap of K best `(key, distance)`.
+4. Heap -> `vector<Neighbor>` via `vector_index->CreateReply()`.
 
-```cpp
-bool UsePreFiltering(size_t estimated_num_of_keys,
-                     indexes::VectorBase* vector_index);
-```
+**Exact** nearest-neighbor on the filtered subset (no HNSW approximation). Expensive on large filtered sets - hence the planner threshold.
 
-**FLAT index** - always prefilter. Rationale: flat search is O(N * log(K)). With prefiltering the reduced space is O(n * log(K)) where n << N, so prefiltering is always beneficial.
+Dedup uses `flat_hash_set<const char*>` on interned pointers. `NeedsDeduplication()` = OR/tag/non-text-negation.
 
-**HNSW index** - prefilter when the estimated filtered key count is below a threshold ratio of the total index size:
+## Inline path
 
-```cpp
-estimated_num_of_keys <= GetPrefilteringThresholdRatio() * N
-```
+1. `PerformVectorSearch()` creates `InlineVectorFilter` functor.
+2. Functor implements `hnswlib::BaseFilterFunctor::operator()(labeltype id)`.
+3. Per candidate during HNSW walk: `vector_index->GetKeyDuringSearch(id)`, per-key text index lookup if needed, `PrefilterEvaluator::Evaluate`.
+4. Filter fails -> HNSW skips the candidate.
 
-Where `N = vector_index->GetTrackedKeyCount()` (actual vectors in the index, not capacity). The threshold ratio is configurable via `prefiltering-threshold-ratio`. When the filter is very selective (few candidates), prefiltering avoids traversing the HNSW graph. When the filter is broad, inline filtering lets the HNSW graph guide the search.
+`lock.SetMayProlong()` before inline search warns the time-sliced mutex (longer than usual; adjusts contention behavior).
 
-Metrics track which path was taken: `query_prefiltering_requests_cnt` vs `query_inline_filtering_requests_cnt`.
+## `EvaluateFilterAsPrimary`
 
-## Prefilter Path
+Builds the "primary" scan path.
 
-When prefiltering is chosen for vector queries:
+- **Composed AND** - try a combined `TextIterator` via `BuildTextIterator()`; success wraps in `TextIteratorFetcher`. Else recurse and pick child with smallest estimated size (smallest index = fastest scan).
+- **Composed OR** - recurse all children, concatenate fetcher queues. Size = sum.
+- **Tag / numeric leaf** - `index->Search(predicate, negate)`.
+- **Text leaf** - `indexes::Text::EntriesFetcher` with estimated size + field mask.
+- **Negate** - recurse with flipped flag. Special: text + negate -> `UniversalSetFetcher` over all schema keys (can't be efficient from postings).
 
-1. `CalcBestMatchingPrefilteredKeys()` iterates all entry fetchers
-2. For each candidate key from the fetchers, `PrefilterEvaluator` evaluates the full predicate tree
-3. Matching keys are scored against the query vector via `vector_index->AddPrefilteredKey()`, which maintains a max-heap of K best (key, distance) pairs
-4. The heap result is converted to `vector<Neighbor>` via `vector_index->CreateReply()`
-
-This path does exact nearest-neighbor search on the filtered subset - no HNSW approximation. For large filtered sets this can be expensive, which is why the planner only chooses it when the estimated set is small relative to the total.
-
-Deduplication during prefilter evaluation uses a `flat_hash_set<const char*>` of interned string pointers. The `NeedsDeduplication()` helper checks if OR, tag, or non-text negation operations are present.
-
-## Inline Filter Path
-
-When inline filtering is chosen:
-
-1. `PerformVectorSearch()` creates an `InlineVectorFilter` functor
-2. The functor implements `hnswlib::BaseFilterFunctor::operator()(labeltype id)`
-3. For each candidate during the HNSW graph walk, it resolves the key via `vector_index->GetKeyDuringSearch(id)`, looks up the per-key text index if needed, and creates a `PrefilterEvaluator` to evaluate the full predicate tree
-4. Candidates failing the filter are skipped by the HNSW algorithm
-
-The `lock.SetMayProlong()` call before inline search warns the time-sliced mutex that this operation may take longer than usual, adjusting contention behavior.
-
-## EvaluateFilterAsPrimary
-
-This function walks the predicate tree to build `EntriesFetcherBase` queues - the "primary" scan path that determines which keys to examine:
-
-**Composed AND** - first tries to build a combined `TextIterator` via `BuildTextIterator()`. If successful, wraps it in a `TextIteratorFetcher`. Otherwise, recursively evaluates each child and picks the one with the smallest estimated size (smallest index = fastest scan).
-
-**Composed OR** - recursively evaluates all children and concatenates their fetcher queues. Total estimated size is the sum of children.
-
-**Tag/Numeric leaf** - calls `index->Search(predicate, negate)` to get a fetcher from the inverted index.
-
-**Text leaf** - creates an `indexes::Text::EntriesFetcher` with estimated size and field mask.
-
-**Negate** - recurses with the `negate` flag flipped. Special case: text + negate queries use a `UniversalSetFetcher` that iterates all keys in the schema, since negated text cannot be efficiently fetched from postings lists.
-
-## Async Dispatch and Threading
-
-`SearchAsync` schedules work on the reader thread pool at high priority:
+## Async dispatch
 
 ```
-Main Thread                    Reader Thread Pool
-  |                                |
-  +-- SearchAsync() ------------> Schedule(lambda)
-  |   (blocks client)              |
-  |                                +-- Search()
-  |                                |   +-- DoSearch() [holds ReaderMutexLock]
-  |                                |   +-- MaybeAddIndexedContent()
-  |                                |
-  |                                +-- Check ContentProcessing
-  |                                |   kNoContent -> QueryCompleteBackground()
-  |                                |   kContentRequired -> RunByMain(ResolveContent)
-  |                                |
-  +-- ResolveContent() <---------- RunByMain callback
-  |   +-- ProcessNeighborsForReply()
-  |   +-- QueryCompleteMainThread()
-  |   +-- Unblock client
+Main                                  Reader pool
+ |                                     |
+ SearchAsync --------------------> Schedule(lambda)
+ |   (block client)                    |
+ |                                     DoSearch  [ReaderMutexLock]
+ |                                     MaybeAddIndexedContent
+ |                                     |
+ |                                     kNoContent    -> QueryCompleteBackground
+ |                                     kContentReq   -> RunByMain(ResolveContent)
+ |                                     |
+ ResolveContent <----------------------  (RunByMain)
+ |   ProcessNeighborsForReply
+ |   QueryCompleteMainThread
+ |   unblock client
 ```
 
-The `cancel::Token` is checked periodically during search to enforce the timeout. Cancellation is cooperative - long-running operations (HNSW walk, fetcher iteration) check the token.
+`cancel::Token` checked periodically; cancellation cooperative (HNSW walk, fetcher iteration poll the token).
 
-## Content Resolution on Main Thread
+## Content resolution (main thread)
 
-After background search completes, if content is needed (document attributes to return to the client), execution returns to the main thread via `ResolveContent()`:
+`ProcessNeighborsForReply()` (`response_generator.h`):
 
-`ProcessNeighborsForReply()` (in `response_generator.h`) fetches document content from Valkey's keyspace for each neighbor. This requires the main thread because Valkey key access is single-threaded. The function:
+1. For each neighbor, fetch Hash/JSON from keyspace.
+2. Populate `attribute_contents`.
+3. Drop neighbors whose keys no longer exist (deleted mid-search).
+4. Validate against in-flight mutations.
 
-1. Iterates neighbors
-2. For each neighbor, fetches the hash/JSON document from Valkey
-3. Populates `attribute_contents` on each `Neighbor` struct
-4. Removes neighbors whose keys no longer exist (deleted between search and content fetch)
-5. Validates against contention with in-flight mutations
+Neighbors already populated by `MaybeAddIndexedContent()` on the background thread are skipped.
 
-Neighbors that already have `attribute_contents` populated (from `MaybeAddIndexedContent()` on the background thread) are skipped.
+## `ContentProcessing` modes
 
-## ContentProcessing Modes
-
-`SearchParameters::GetContentProcessing()` determines what happens after the background search:
+`SearchParameters::GetContentProcessing()`:
 
 | Mode | When | Completion |
 |------|------|------------|
-| `kNoContent` | NOCONTENT flag, or all content sourced from indexes | `QueryCompleteBackground()` - stays on reader thread |
-| `kContentRequired` | Need keyspace access but no contention risk | `QueryCompleteMainThread()` via `RunByMain` |
-| `kContentionCheckRequired` | Need keyspace access and mutations may be in flight | `ResolveContent()` via `RunByMain` with sequence number checks |
+| `kNoContent` | NOCONTENT, or all content from indexes | `QueryCompleteBackground()` (stays on reader) |
+| `kContentRequired` | keyspace needed, no contention | `QueryCompleteMainThread()` via `RunByMain` |
+| `kContentionCheckRequired` | keyspace needed + mutations possibly in flight | `ResolveContent()` via `RunByMain` with seq checks |
 
-The `kContentAvailable` mode is reserved for future use where all needed content can be sourced directly from indexes without main-thread access.
+`kContentAvailable` reserved - all content sourced from indexes, no main-thread hop.
 
-## Contention Checking
+## Contention check
 
-Between the background search and main-thread content fetch, mutations may have modified or deleted documents. The contention checking mechanism uses sequence numbers:
+Sequence-number based:
 
-1. `PopulateIndexMutationSequenceNumbers()` records the current mutation sequence number for each neighbor's key during the search phase
-2. On the main thread, `ResolveContent()` checks if any key's sequence number has advanced
-3. If contention is detected, the content fetch may need to re-validate results
-4. `content_resolution_blocked_` tracks how many times a query was blocked during this process
+1. `PopulateIndexMutationSequenceNumbers()` records current seq per neighbor key during search.
+2. Main thread `ResolveContent()` checks for advances.
+3. Advanced -> re-validate content fetch.
+4. `content_resolution_blocked_` counts block events.
 
-The final response reflects a consistent snapshot - if a document was modified after the search but before content fetch, the system detects and handles it.
+Final response is a consistent snapshot - mid-path modifications are detected.
 
-## Result Trimming and Serialization
+## Result trimming
 
-`SearchResult` handles result trimming in the background thread when possible:
+`SearchResult` trims on the background thread when possible:
 
-- `TrimResults()` applies LIMIT offset/count with a configurable buffer multiplier (`search-result-buffer-multiplier`)
-- In standalone mode, trimming from the front (offset) happens immediately
-- In cluster mode, shard results keep the full set for the coordinator to merge; the coordinator trims after merging
-- `GetSerializationRange()` computes the final `[start_index, end_index)` range for response serialization
+- `TrimResults()` applies LIMIT offset/count with `search-result-buffer-multiplier`.
+- Standalone: trim-from-front (offset) immediately.
+- Cluster: shards keep full set for coordinator merge; coordinator trims after merge.
+- `GetSerializationRange()` -> final `[start, end)`.
 
-`ShouldReturnNoResults()` short-circuits when `limit.number == 0` or vector queries with `limit.first_index >= k`.
+`ShouldReturnNoResults()` short-circuits when `limit.number == 0` or vector with `limit.first_index >= k`.
 
-Default timeout is 50 seconds (`kTimeoutMS`), maximum 60 seconds (`kMaxTimeoutMs`). Default LIMIT is offset 0, count 10.
+Timeouts: default `kTimeoutMS = 50s`, max `kMaxTimeoutMs = 60s`. Default LIMIT: offset 0, count 10.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/query-ft-aggregate.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/query-ft-aggregate.md
@@ -1,29 +1,10 @@
-# FT.AGGREGATE Pipeline
+# FT.AGGREGATE pipeline
 
-Use when working on the FT.AGGREGATE command, aggregation stages, the expression engine, reducers, or the Record/RecordSet data model.
+Use when reasoning about FT.AGGREGATE stages, reducers, the expression engine, or the Record / RecordSet data model.
 
-Source: `src/commands/ft_aggregate.cc`, `src/commands/ft_aggregate_parser.cc`, `src/commands/ft_aggregate_parser.h`, `src/commands/ft_aggregate_exec.cc`, `src/commands/ft_aggregate_exec.h`, `src/expr/expr.h`, `src/expr/value.h`
+Source: `src/commands/ft_aggregate{,_parser,_exec}.{h,cc}`, `src/expr/expr.h`, `src/expr/value.h`.
 
-## Contents
-
-- Command Overview (line 25)
-- Command Handler (line 41)
-- AggregateParameters Class (line 55)
-- Pipeline Stages (line 78)
-- GROUPBY + REDUCE Stage (line 98)
-- Reducers (line 118)
-- APPLY Stage (line 143)
-- SORTBY Stage (line 163)
-- LIMIT Stage (line 180)
-- FILTER Stage (line 194)
-- LOAD Clause (line 213)
-- Expression Engine (line 231)
-- Record and RecordSet Types (line 241)
-- Response Generation (line 263)
-
-## Command Overview
-
-`FT.AGGREGATE` runs a pipeline of transformation stages on search results. Syntax:
+## Syntax
 
 ```
 FT.AGGREGATE index query
@@ -37,98 +18,72 @@ FT.AGGREGATE index query
   [VERBATIM] [SLOP n] [INORDER] [ADDSCORES]
 ```
 
-## Command Handler
-
-Entry point: `FTAggregateCmd()` in `ft_aggregate.cc`:
+## Handler
 
 ```cpp
-absl::Status FTAggregateCmd(ValkeyModuleCtx* ctx, ValkeyModuleString** argv, int argc) {
+absl::Status FTAggregateCmd(ctx, argv, argc) {
   return QueryCommand::Execute(ctx, argv, argc,
-    unique_ptr<QueryCommand>(
-        new aggregate::AggregateParameters(ValkeyModule_GetSelectedDb(ctx))));
+      std::make_unique<aggregate::AggregateParameters>(ValkeyModule_GetSelectedDb(ctx)));
 }
 ```
 
-Like FT.SEARCH, it goes through `QueryCommand::Execute()` for index lookup, query string extraction, parameter parsing, client blocking, and async dispatch.
+Same `QueryCommand::Execute` path as FT.SEARCH.
 
-## AggregateParameters Class
+## `AggregateParameters`
 
-`AggregateParameters` (in `ft_aggregate_parser.h`) extends both `QueryCommand` and `expr::Expression::CompileContext`:
+Extends both `QueryCommand` and `expr::Expression::CompileContext`:
 
 ```cpp
-struct AggregateParameters : public expr::Expression::CompileContext,
-                             public QueryCommand {
+struct AggregateParameters : public expr::Expression::CompileContext, public QueryCommand {
   bool loadall_{false};
-  vector<string> loads_;
+  std::vector<std::string> loads_;
   bool load_key{false};
   bool addscores_{false};
-  vector<unique_ptr<Stage>> stages_;
-  // Record schema tracking:
-  flat_hash_map<string, size_t> record_indexes_by_identifier_;
-  flat_hash_map<string, size_t> record_indexes_by_alias_;
-  vector<AttributeRecordInfo> record_info_by_index_;
+  std::vector<std::unique_ptr<Stage>> stages_;
+  absl::flat_hash_map<std::string, size_t> record_indexes_by_identifier_;
+  absl::flat_hash_map<std::string, size_t> record_indexes_by_alias_;
+  std::vector<AttributeRecordInfo>         record_info_by_index_;
 };
 ```
 
-Key design: `AggregateParameters` acts as the `CompileContext` for the expression compiler, providing `MakeReference()` to resolve field names to record indexes and `GetParam()` for `$param` substitution. This means field references in APPLY, FILTER, SORTBY, and REDUCE expressions are compiled against the evolving record schema.
+Dual role: `AggregateParameters` is the `CompileContext` for the expression compiler - provides `MakeReference()` (`@field` -> record index) and `GetParam()` (`$param`). Expression compilation in APPLY / FILTER / SORTBY / REDUCE is against the evolving record schema.
 
-`AddRecordAttribute()` assigns a new index to each unique (identifier, alias) pair. The `__key` pseudo-field (index 0) and score field (index 1) are always registered first.
+`AddRecordAttribute()` assigns an index per unique `(identifier, alias)`. Pseudo-fields `__key` (index 0) and score (index 1) always registered first.
 
-## Pipeline Stages
-
-Stages are parsed in command order and stored in `stages_`. Each stage implements the `Stage` interface:
+## Stages
 
 ```cpp
 class Stage {
   virtual absl::Status Execute(RecordSet& records) const = 0;
-  virtual optional<query::SerializationRange> GetSerializationRange() const = 0;
+  virtual std::optional<query::SerializationRange> GetSerializationRange() const = 0;
 };
 ```
 
-`GetSerializationRange()` returns the range of input records needed. The first LIMIT stage's range determines how many search results are fetched. Stages returning `SerializationRange::All()` (GROUPBY, APPLY, FILTER, SORTBY) require the full search result set.
+`GetSerializationRange()` determines how many search results are fetched. First LIMIT stage's range drives it. GROUPBY / APPLY / FILTER / SORTBY return `SerializationRange::All()` - full set required.
 
-Execution order in `SendReplyInner()`:
-1. Process search results into `RecordSet` via `CreateRecordsFromNeighbors()`
-2. Execute each stage sequentially via `ExecuteAggregationStages()`
-3. Generate response via `GenerateResponse()`
+Execution in `SendReplyInner()`:
 
-Cancellation is checked between stages via the cancellation token.
+1. `CreateRecordsFromNeighbors()` -> `RecordSet`.
+2. `ExecuteAggregationStages()` runs each sequentially.
+3. `GenerateResponse()` serializes.
 
-## GROUPBY + REDUCE Stage
+Cancellation token checked between stages.
 
-The GROUPBY stage (class `GroupBy`) groups records by one or more fields and applies reducer functions to each group.
+## GROUPBY + REDUCE
 
-Parsing (`ConstructGroupByParser()`):
-1. Parse field count, then `@field` references (must start with `@`)
-2. Parse zero or more `REDUCE func nargs arg... [AS name]` clauses
-3. Each REDUCE references a function from the static `reducerTable`
-4. Arguments are compiled as expressions via `Expression::Compile()`
+Parse (`ConstructGroupByParser`): field count + `@field` refs (must start with `@`), then zero or more `REDUCE func nargs arg... [AS name]`. Each REDUCE references a function from `GroupBy::reducerTable`. Args compiled via `Expression::Compile()`.
 
-Execution (`GroupBy::Execute()`):
-1. Build a `flat_hash_map<GroupKey, vector<ReducerInstance>>` mapping group keys to reducer state
-2. For each input record, compute the `GroupKey` from group field values
-3. For new keys, instantiate fresh `ReducerInstance` objects
-4. Call `ProcessRecord(args)` on each reducer with evaluated argument values
-5. After all input records are consumed, create one output record per group
-6. Output record fields are set from the group key values and `GetResult()` from each reducer
+Execution (`GroupBy::Execute`):
 
-`GroupKey` is an `InlinedVector<expr::Value, 4>` with hash and equality support, enabling use as a `flat_hash_map` key.
+1. `flat_hash_map<GroupKey, vector<ReducerInstance>>`.
+2. Per input: compute `GroupKey` from group field values.
+3. New key -> instantiate `ReducerInstance`s.
+4. Per reducer: `ProcessRecord(args)` with evaluated arg values.
+5. After input: one output record per group - fields from group-key values + each reducer's `GetResult()`.
 
-## Reducers
+`GroupKey` = `InlinedVector<expr::Value, 4>` with hash/equality (hash-map key).
 
-Available reducers (registered in `GroupBy::reducerTable`):
-
-| Reducer | Args | Description |
-|---------|------|-------------|
-| `COUNT` | 0 | Count records in each group |
-| `SUM` | 1 | Sum of numeric values |
-| `MIN` | 1 | Minimum value |
-| `MAX` | 1 | Maximum value |
-| `AVG` | 1 | Average of numeric values |
-| `STDDEV` | 1 | Sample standard deviation (using N-1 formula) |
-| `COUNT_DISTINCT` | 1 | Count of unique values (using `flat_hash_set<Value>`) |
-
-Each reducer is a subclass of `ReducerInstance`:
+### Reducers
 
 ```cpp
 struct ReducerInstance {
@@ -137,141 +92,112 @@ struct ReducerInstance {
 };
 ```
 
-Nil values are skipped by all reducers except COUNT. Numeric reducers (`SUM`, `AVG`, `STDDEV`) call `AsDouble()` and skip non-numeric values. `COUNT_DISTINCT` uses `Value` hash/equality for deduplication.
+| Reducer | Args | Notes |
+|---------|------|-------|
+| `COUNT` | 0 | counts records |
+| `SUM` | 1 | numeric |
+| `MIN` / `MAX` | 1 | |
+| `AVG` | 1 | numeric |
+| `STDDEV` | 1 | sample (N-1) |
+| `COUNT_DISTINCT` | 1 | `flat_hash_set<Value>` |
 
-## APPLY Stage
+Nil skipped by all except COUNT. Numeric reducers call `AsDouble()` and skip non-numeric.
 
-The APPLY stage (class `Apply`) computes a new field from an expression:
+## APPLY
 
-```
-APPLY "expr" AS name
-```
-
-Parsing: the expression string is compiled via `Expression::Compile()`, and the output field is resolved via `MakeReference(name, true)` (creating a new record slot if needed).
-
-Execution: for each record, evaluate the expression and set the output field:
-
-```cpp
-for (auto& r : records) {
-  SetField(*r, *name_, expr_->Evaluate(ctx, *r));
-}
-```
-
-APPLY processes all records (returns `SerializationRange::All()`). It can reference any previously defined field - from LOAD, from earlier APPLY stages, or from GROUPBY outputs.
-
-## SORTBY Stage
-
-The SORTBY stage (class `SortBy`) sorts records by one or more expressions with direction:
-
-```
-SORTBY nargs @field1 ASC @field2 DESC [MAX n]
-```
-
-Parsing: each field is compiled as an expression. Direction defaults to ASC. The optional MAX clause limits the output (default 10).
-
-Execution uses two strategies based on record count vs MAX:
-
-- **When records > MAX** - uses a `std::priority_queue<Record*>` (heap-based top-N) to avoid full sort. This is O(N * log(MAX)) instead of O(N * log(N))
-- **When records <= MAX** - uses `std::stable_sort` on the full set
-
-The sort comparator (`SortFunctor`) evaluates each sort key expression on both records and uses `expr::Compare()` for ordering. `Ordering::kEQUAL` and `kUNORDERED` continue to the next sort key; `kLESS`/`kGREATER` return based on the direction.
-
-## LIMIT Stage
-
-The LIMIT stage (class `Limit`) applies offset and count:
-
-```
-LIMIT offset count
-```
-
-Execution:
-1. Pop `offset` records from the front
-2. Pop excess records from the back until `size <= count`
-
-LIMIT is the only stage that can reduce the search result fetch count - its `GetSerializationRange()` returns `{offset, offset + limit}`, which is used during command parsing to set the search parameters so the search engine only fetches the needed range.
-
-## FILTER Stage
-
-The FILTER stage (class `Filter`) removes records that don't match an expression:
-
-```
-FILTER "expr"
-```
-
-Execution: evaluate the expression for each record. Keep only records where the result `IsTrue()`:
+`APPLY "expr" AS name`. Expr compiled via `Expression::Compile()`; output via `MakeReference(name, /*create=*/true)`.
 
 ```cpp
-auto result = expr_->Evaluate(ctx, *r);
-if (result.IsTrue()) {
-  filtered.push_back(std::move(r));
-}
+for (auto& r : records) SetField(*r, *name_, expr_->Evaluate(ctx, *r));
 ```
 
-FILTER requires all input records (`SerializationRange::All()`).
+Processes all records. Can reference anything defined earlier - LOAD, earlier APPLY, GROUPBY outputs.
 
-## LOAD Clause
+## SORTBY
 
-LOAD is not a pipeline stage - it's parsed before stages and controls which document fields are fetched during the search phase.
+`SORTBY nargs @f1 ASC @f2 DESC [MAX n]`. Each field compiled as expression, ASC default. MAX default 10.
 
+Two strategies:
+
+- `records > MAX`: `std::priority_queue<Record*>` - O(N log MAX) top-N.
+- `records <= MAX`: `std::stable_sort`.
+
+`SortFunctor` evaluates each sort key on both records via `expr::Compare()`. `kEQUAL` / `kUNORDERED` continue to next key; `kLESS` / `kGREATER` return per direction.
+
+## LIMIT
+
+`LIMIT offset count`. Pop `offset` from front, pop from back until `size <= count`.
+
+**Only stage that can reduce fetch count** - `GetSerializationRange()` returns `{offset, offset + limit}`, read during command parsing to constrain the search range.
+
+## FILTER
+
+`FILTER "expr"`. Evaluate per record, keep where `IsTrue()`:
+
+```cpp
+if (expr_->Evaluate(ctx, *r).IsTrue()) filtered.push_back(std::move(r));
 ```
-LOAD count @field1 @field2 ...  # Load specific fields
-LOAD *                          # Load all fields
-```
 
-Processing in `ManipulateReturnsClause()`:
-1. If `LOAD *` (`loadall_`), return all document attributes
-2. Otherwise, for each load field, look up its index schema and add to `return_attributes`
-3. The special `__key` field sets `load_key = true` (makes the document key available in records)
-4. Score field references are skipped (always available)
-5. If no content fields are requested, set `no_content = true`
+Requires all input records (`SerializationRange::All()`).
 
-Each LOAD field also calls `AddRecordAttribute()` to register it in the record schema so expressions can reference it.
+## LOAD (not a stage)
 
-## Expression Engine
+Parsed before stages, controls which document fields are fetched during search.
 
-The expression engine (`src/expr/expr.h`, `src/expr/value.h`) provides compilation and evaluation of expressions used in APPLY, FILTER, SORTBY, and REDUCE arguments.
+- `LOAD *` -> all attributes (`loadall_ = true`).
+- `LOAD count @f1 @f2 ...` -> lookup per field in schema, push to `return_attributes`.
+- `__key` field -> `load_key = true`.
+- Score field references skipped (always available).
+- No content fields requested -> `no_content = true`.
 
-`Expression::Compile(CompileContext&, string_view)` parses an expression string into an AST. `Evaluate(EvalContext&, Record&)` runs it against a record. `CompileContext` provides `MakeReference()` (resolve `@field` to a record index) and `GetParam()` (resolve `$param`). `AggregateParameters` implements `CompileContext`.
+Each LOAD field also calls `AddRecordAttribute()` so expressions can reference it.
 
-`expr::Value` is a variant: nil, double, or string. Supports `IsTrue()`/`IsNil()`, `AsDouble()`, `AsStringView()`, comparison via `Compare()` (returns `kLESS`/`kGREATER`/`kEQUAL`/`kUNORDERED`), and hash/equality for use in containers.
+## Expression engine
 
-During compilation, `@field` references become `Attribute` objects (in `ft_aggregate_parser.h`) storing a `record_index_` into `Record::fields_`. `GetValue()` indexes into the record's fields vector. The `create` flag in `MakeReference()` controls whether unknown fields create new record slots (outputs like APPLY AS) or must already exist (inputs like GROUPBY fields).
+`src/expr/expr.h`, `src/expr/value.h`.
 
-## Record and RecordSet Types
+- `Expression::Compile(CompileContext&, string_view)` - parse to AST.
+- `Evaluate(EvalContext&, Record&)` - run on a record.
+- `CompileContext` -> `MakeReference(name, create)` resolves `@field`; `GetParam(name)` resolves `$param`. `AggregateParameters` implements it.
 
-`Record` (in `ft_aggregate_exec.h`) extends `Expression::Record`:
+`expr::Value`: variant of nil / double / string. `IsTrue()`, `IsNil()`, `AsDouble()`, `AsStringView()`, `Compare()` -> `Ordering::{kLESS, kGREATER, kEQUAL, kUNORDERED}`. Hash/equality for containers.
+
+`@field` references compile to `Attribute` (in `ft_aggregate_parser.h`) with a `record_index_` into `Record::fields_`. `MakeReference(name, /*create=*/true)` creates a new slot (APPLY outputs); `false` requires it to exist (GROUPBY inputs).
+
+## Record / RecordSet
 
 ```cpp
 class Record : public expr::Expression::Record {
-  vector<expr::Value> fields_;               // Indexed by record schema
-  vector<pair<string, expr::Value>> extra_fields_;  // Unregistered fields
+  std::vector<expr::Value> fields_;                       // by record schema index
+  std::vector<std::pair<std::string, expr::Value>> extra_fields_;  // unregistered
 };
 ```
 
-Fields are positionally indexed - `fields_[i]` corresponds to the `AttributeRecordInfo` at index `i` in `AggregateParameters::record_info_by_index_`. Extra fields come from document attributes not in the record schema.
+`fields_[i]` aligns with `AggregateParameters::record_info_by_index_[i]`. `extra_fields_` holds document attributes outside the schema.
 
-`RecordSet` extends `deque<unique_ptr<Record>>` with custom `pop_front()`/`pop_back()` that return ownership. Stages consume and produce `RecordSet` in place.
+`RecordSet` extends `deque<unique_ptr<Record>>` with custom `pop_front()` / `pop_back()` returning ownership.
 
-`CreateRecordsFromNeighbors()` converts search `Neighbor` results into records:
-1. Set `__key` field if `load_key` is true
-2. Set score field for vector queries
-3. For each attribute content, look up by alias then identifier in the record index maps
-4. Numeric fields are converted to `Value(double)`, text/tag fields to `Value(string)`
-5. JSON values are unquoted. Records with unquotable JSON values are dropped
+`CreateRecordsFromNeighbors()`:
 
-## Response Generation
+1. Set `__key` if `load_key`.
+2. Set score for vector queries.
+3. Each attribute content: look up by alias, then identifier.
+4. Numeric -> `Value(double)`; text/tag -> `Value(string)`.
+5. JSON values unquoted; records with unquotable JSON are dropped.
 
-`GenerateResponse()` serializes the final `RecordSet`:
+## Response
+
+`GenerateResponse()` -> RESP array:
 
 ```
 1) record_count
-2) [field_name, field_value, field_name, field_value, ...]
+2) [name, value, name, value, ...]
 3) [...]
-...
 ```
 
-For each record, iterate both `fields_` and `extra_fields_`, calling `ReplyWithValue()` for each non-nil value. The function handles HASH vs JSON data types and dialect-specific formatting:
-- Dialect 2: values are returned as plain strings
-- Dialect 3/4: values are wrapped in brackets (`[value]`)
+Per record: iterate both `fields_` and `extra_fields_`, `ReplyWithValue()` on non-nil. Dialect-specific:
 
-Numeric values are formatted with `%.11g` precision. Nil values are skipped entirely (no field name or value emitted).
+- Dialect 2: plain strings.
+- Dialect 3/4: wrapped (`[value]`).
+
+Numeric formatting `%.11g`. Nil skipped (no name/value emitted).

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/query-ft-search.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/query-ft-search.md
@@ -1,215 +1,167 @@
-# FT.SEARCH Internals
+# FT.SEARCH internals
 
-Use when working on FT.SEARCH command handling, parameter parsing, query validation, response serialization, or the SearchCommand class.
+Use when reasoning about FT.SEARCH command handling, parameter parsing, validation, or response serialization.
 
-Source: `src/commands/ft_search.cc`, `src/commands/ft_search_parser.cc`, `src/commands/ft_search_parser.h`, `src/commands/commands.h`, `src/query/response_generator.h`
+Source: `src/commands/ft_search.cc`, `src/commands/ft_search_parser.{h,cc}`, `src/commands/commands.h`, `src/query/response_generator.h`.
 
-## Contents
-
-- Command Overview (line 23)
-- Command Handler (line 35)
-- QueryCommand Base Class (line 54)
-- SearchCommand Class (line 74)
-- Parameter Parsing (line 92)
-- Supported Parameters (line 103)
-- PARAMS Substitution (line 126)
-- Validation (line 137)
-- Response Generation (line 152)
-- Vector Query Responses (line 166)
-- Non-Vector Query Responses (line 182)
-- SORTBY Processing (line 205)
-
-## Command Overview
-
-`FT.SEARCH` is the primary query command. Syntax:
+## Syntax
 
 ```
-FT.SEARCH index query [RETURN count field [AS alias] ...]
-  [LIMIT offset count] [NOCONTENT] [SORTBY field [ASC|DESC]]
+FT.SEARCH index query
+  [RETURN count field [AS alias] ...] [LIMIT offset count] [NOCONTENT]
+  [SORTBY field [ASC|DESC]] [WITHSORTKEYS]
   [PARAMS nargs name value ...] [TIMEOUT ms] [DIALECT version]
   [CONSISTENT|INCONSISTENT] [LOCALONLY|ALLSHARDS|SOMESHARDS]
-  [VERBATIM] [SLOP n] [INORDER] [WITHSORTKEYS]
+  [VERBATIM] [SLOP n] [INORDER]
 ```
 
-## Command Handler
-
-Entry point: `FTSearchCmd()` in `ft_search.cc`:
+## Handler
 
 ```cpp
-absl::Status FTSearchCmd(ValkeyModuleCtx* ctx, ValkeyModuleString** argv, int argc) {
+absl::Status FTSearchCmd(ctx, argv, argc) {
   return QueryCommand::Execute(ctx, argv, argc,
-    unique_ptr<QueryCommand>(new SearchCommand(ValkeyModule_GetSelectedDb(ctx))));
+      std::make_unique<SearchCommand>(ValkeyModule_GetSelectedDb(ctx)));
 }
 ```
 
-`QueryCommand::Execute()` (in `commands.h`) is shared by FT.SEARCH and FT.AGGREGATE. It:
+`QueryCommand::Execute` (`commands.h`) is shared with FT.AGGREGATE:
 
-1. Parses argv[1] as the index name, looks up the `IndexSchema` via `SchemaManager`
-2. Extracts argv[2] as the query string
-3. Calls `cmd->ParseCommand(itr)` for command-specific parameter parsing
-4. Blocks the client via `ValkeyModule_BlockClient` with timeout/free callbacks
-5. Calls `SearchAsync()` to dispatch to the reader thread pool
+1. Parse `argv[1]` as index name, resolve `IndexSchema` via `SchemaManager`.
+2. `argv[2]` is the query string.
+3. `cmd->ParseCommand(iter)` - command-specific params.
+4. `ValkeyModule_BlockClient` with timeout/free callbacks.
+5. `SearchAsync` -> reader pool.
 
-## QueryCommand Base Class
-
-`QueryCommand` (in `commands.h`) extends `SearchParameters` with command lifecycle methods:
+## `QueryCommand` base (`commands.h`)
 
 ```cpp
 struct QueryCommand : public query::SearchParameters {
-  static absl::Status Execute(ValkeyModuleCtx*, ValkeyModuleString**, int,
-                               unique_ptr<QueryCommand>);
+  static absl::Status Execute(...);
   virtual absl::Status ParseCommand(vmsdk::ArgsIterator&) = 0;
   virtual void SendReply(ValkeyModuleCtx*, query::SearchResult&) = 0;
   virtual bool RequiresCompleteResults() const = 0;
-
   void QueryCompleteBackground(unique_ptr<SearchParameters>) override;
   void QueryCompleteMainThread(unique_ptr<SearchParameters>) override;
-  optional<vmsdk::BlockedClient> blocked_client;
+  std::optional<vmsdk::BlockedClient> blocked_client;
 };
 ```
 
-The completion callbacks unblock the client and invoke `SendReply()`. Background completion schedules the unblock directly; main-thread completion runs after content resolution. The `blocked_client` holds the `ValkeyModule_BlockClient` handle.
+Completions unblock the client and call `SendReply()`. Background completion schedules unblock directly; main-thread completion runs after content resolution.
 
-## SearchCommand Class
-
-`SearchCommand` (in `ft_search_parser.h`) extends `QueryCommand`:
+## `SearchCommand`
 
 ```cpp
 struct SearchCommand : public QueryCommand {
   absl::Status ParseCommand(vmsdk::ArgsIterator&) override;
-  void SendReply(ValkeyModuleCtx*, query::SearchResult&) override;
+  void SendReply(...) override;
   absl::Status PostParseQueryString() override;
   bool RequiresCompleteResults() const override { return sortby.has_value(); }
-
-  optional<query::SortByParameter> sortby;
+  std::optional<query::SortByParameter> sortby;
   bool with_sort_keys{false};
 };
 ```
 
-`RequiresCompleteResults()` returns true only when SORTBY is present. Without sorting, results can be trimmed early in the background thread via LIMIT-based optimization.
+`RequiresCompleteResults() = true` only when SORTBY - disables background trimming.
 
-## Parameter Parsing
+## Parse flow
 
-`SearchCommand::ParseCommand()` uses a `KeyValueParser<SearchCommand>` - a table-driven parser from vmsdk. The parser is created once (static) by `CreateSearchParser()` and handles all keyword parameters.
+`ParseCommand()` uses a static `KeyValueParser<SearchCommand>` (`CreateSearchParser()`). Sequence:
 
-Parse sequence:
-1. `SearchParser.Parse(*this, itr)` - table-driven keyword parsing
-2. Check no unparsed arguments remain
-3. `PreParseQueryString()` - extract vector KNN clause from query string, parse filter expression via `FilterParser`
-4. `PostParseQueryString()` - validate SORTBY field exists in schema
-5. `VerifyQueryString()` - validate KNN K, EF_RUNTIME, timeout, dialect, unused params
+1. `SearchParser.Parse(*this, iter)` - table-driven keyword parsing.
+2. Check no unparsed arguments remain.
+3. `PreParseQueryString()` - extract KNN clause from query, parse filter via `FilterParser`.
+4. `PostParseQueryString()` - validate SORTBY field exists in schema.
+5. `VerifyQueryString()` - KNN K / EF_RUNTIME / timeout / dialect / unused params.
 
-## Supported Parameters
+## Parameters
 
-| Parameter | Field | Parser | Description |
-|-----------|-------|--------|-------------|
-| `LIMIT` | `limit.first_index`, `limit.number` | Custom | Pagination offset and count (default: 0, 10) |
-| `NOCONTENT` | `no_content` | Flag | Return only document IDs, skip content |
-| `RETURN` | `return_attributes` | Custom | Select specific fields to return. Count 0 = NOCONTENT. Supports `AS alias` |
-| `SORTBY` | `sortby` | Custom | Sort by field with optional ASC/DESC (default ASC) |
-| `WITHSORTKEYS` | `with_sort_keys` | Flag | Include sort key values in response (prefixed with `#`) |
-| `PARAMS` | `parse_vars.params` | Custom | Named parameter map for `$param` substitution. Count must be even |
-| `TIMEOUT` | `timeout_ms` | Value | Query timeout in milliseconds (max 60000) |
-| `DIALECT` | `dialect` | Value | Protocol dialect (supported: 2, 3, 4) |
-| `VERBATIM` | `verbatim` | Flag | Disable stemming in text search |
-| `SLOP` | `slop` | Value | Proximity window for multi-term text queries |
-| `INORDER` | `inorder` | Flag | Require terms to appear in order |
-| `LOCALONLY` | `local_only` | Flag | Search only the local node |
-| `ALLSHARDS` | `enable_partial_results=false` | Negative flag | Require results from all shards |
-| `SOMESHARDS` | `enable_partial_results=true` | Flag | Accept partial results if some shards fail |
-| `CONSISTENT` | `enable_consistency=true` | Flag | Prefer consistent reads |
-| `INCONSISTENT` | `enable_consistency=false` | Negative flag | Allow stale reads |
+| Keyword | Field | Notes |
+|---------|-------|-------|
+| `LIMIT` | `limit.first_index`, `limit.number` | default 0, 10 |
+| `NOCONTENT` | `no_content` | IDs only |
+| `RETURN` | `return_attributes` | count 0 = NOCONTENT; `AS alias` supported |
+| `SORTBY` | `sortby` | field [ASC\|DESC], ASC default |
+| `WITHSORTKEYS` | `with_sort_keys` | include sort key value (`#<value>`) |
+| `PARAMS` | `parse_vars.params` | even-count key/value pairs |
+| `TIMEOUT` | `timeout_ms` | max 60000 |
+| `DIALECT` | `dialect` | 2, 3, or 4 |
+| `VERBATIM` | `verbatim` | disable stemming |
+| `SLOP` | `slop` | proximity window |
+| `INORDER` | `inorder` | require term order |
+| `LOCALONLY` | `local_only` | local node only |
+| `ALLSHARDS` | `enable_partial_results = false` | |
+| `SOMESHARDS` | `enable_partial_results = true` | |
+| `CONSISTENT` | `enable_consistency = true` | |
+| `INCONSISTENT` | `enable_consistency = false` | |
 
-Config-driven defaults: `enable_partial_results` defaults from `prefer-partial-results`, `enable_consistency` defaults from `prefer-consistent-results`.
+Defaults come from config: `enable_partial_results` from `prefer-partial-results`, `enable_consistency` from `prefer-consistent-results`.
 
-## PARAMS Substitution
+## PARAMS substitution
 
-The PARAMS clause provides named parameters for `$param` references in the query string and KNN clause. Parameters are stored in `parse_vars.params` as `{name -> (ref_count, value)}` pairs.
+Stored as `{name -> (ref_count, value)}`. `SubstituteParam()` (`search.cc`): `$`-prefixed strings look up in the map, bump `ref_count`. `VerifyQueryString()` enforces all params referenced at least once.
 
-Substitution happens in `SubstituteParam()` (in `search.cc`): if a string starts with `$`, the rest is looked up in the params map and the ref_count is incremented. During validation, `VerifyQueryString()` checks that all parameters were used at least once - unused parameters produce a `NotFoundError`.
+Typical:
 
-Common use: passing the vector blob as `$BLOB`:
 ```
 FT.SEARCH idx "*=>[KNN 10 @vec $BLOB]" PARAMS 2 BLOB "\x12\xa9..."
 ```
 
-## Validation
-
-`VerifyQueryString()` (shared between FT.SEARCH and FT.AGGREGATE) enforces:
+## `VerifyQueryString`
 
 | Check | Constraint |
 |-------|-----------|
-| KNN K | 1 to `max-vector-knn` (default 10000, max 100000) |
-| EF_RUNTIME | 1 to `max-ef-runtime` config value |
-| Timeout | 0 to 60000 ms |
-| Dialect | 2, 3, or 4 |
-| Unused params | All PARAMS entries must be referenced at least once |
-| Vector query | Must have a non-empty query string |
+| KNN K | 1 .. `max-vector-knn` (default 10000, max 100000) |
+| EF_RUNTIME | 1 .. `max-ef-runtime` |
+| Timeout | 0 .. 60000 |
+| Dialect | 2, 3, 4 |
+| Unused PARAMS | all referenced at least once |
+| Vector query | non-empty query string |
 
-`SearchCommand::PostParseQueryString()` additionally validates that the SORTBY field exists as a known attribute in the index schema.
+`PostParseQueryString()` additionally checks SORTBY field is a known schema attribute.
 
-## Response Generation
+## `SendReply`
 
-`SearchCommand::SendReply()` runs on the main thread after search completes. The flow:
+Main thread, post-search:
 
-1. Increment `query_successful_requests_cnt`
-2. **Early reply check** via `HandleEarlyReplyScenarios()`:
-   - `ShouldReturnNoResults()` true -> reply with just the total count
-   - `no_content` true -> `SendReplyNoContent()` (IDs only)
-3. `ProcessNeighborsForQuery()` - fetch document content, filter invalid neighbors
-4. `ApplySorting()` - if SORTBY present, sort neighbors by attribute value
-5. Serialize based on query type: `SerializeNeighbors()` (vector) or `SerializeNonVectorNeighbors()` (non-vector)
+1. Bump `query_successful_requests_cnt`.
+2. `HandleEarlyReplyScenarios()`: `ShouldReturnNoResults()` -> just total count; `no_content` -> `SendReplyNoContent()` (IDs only).
+3. `ProcessNeighborsForQuery()` - fetch content, drop invalid neighbors.
+4. `ApplySorting()` if SORTBY present.
+5. Serialize - `SerializeNeighbors()` (vector) or `SerializeNonVectorNeighbors()` (non-vector).
 
-Errors during processing increment `query_failed_requests_cnt` and reply with an error.
+Errors bump `query_failed_requests_cnt` + error reply.
 
-## Vector Query Responses
+## Response shape
 
-Response format for vector queries (array):
+### Vector
+
 ```
-1) total_count (capped at K)
+1) total (capped at K)
 2) key_1
-3) [field_name, field_value, ..., score_as, score_value]
-4) key_2
-5) [...]
+3) [field_name, field_value, ..., score_alias, score_value]
 ...
 ```
 
-When RETURN is specified, only requested fields are included. The score field (named by the `AS` clause in the KNN expression, e.g., `AS score`) is formatted as `%.12g`.
+RETURN filters returned fields. Score (from `AS` in KNN clause) formatted `%.12g`. Empty RETURN = all stored attributes + score. Explicit RETURN = only listed fields; score included only if its alias is in RETURN.
 
-When RETURN is empty (default), all stored attributes are returned plus the score. When RETURN lists specific fields, only those fields appear, and the score is included only if its alias is in the RETURN list.
+### Non-vector
 
-## Non-Vector Query Responses
-
-Response format for non-vector queries (array):
 ```
-1) total_count
+1) total
 2) key_1
 3) [field_name, field_value, ...]
-4) key_2
-5) [...]
 ...
 ```
 
-When `WITHSORTKEYS` is set, each result gets an extra element - the sort key value prefixed with `#`:
-```
-1) total_count
-2) key_1
-3) "#sort_value"
-4) [field_name, field_value, ...]
-...
-```
+WITHSORTKEYS adds a `#<value>` element before each content block. `GetSortKeyValue()` extracts the sort field from `attribute_contents`.
 
-`GetSortKeyValue()` extracts the sort field value from `attribute_contents`.
+## SORTBY (`ApplySorting`)
 
-## SORTBY Processing
+1. Check sort field is a declared numeric attribute.
+2. Numeric: sort parsed doubles via `expr::Value`.
+3. Else string: `expr::Compare`.
+4. `partial_sort` when subset needed (offset + count < total), else `stable_sort`.
 
-`ApplySorting()` in `ft_search.cc` sorts the neighbors vector after content resolution:
+ASC/DESC respected. Missing-field docs pushed to end. `expr::Compare` returns `Ordering::{kLESS, kGREATER, kEQUAL, kUNORDERED}`.
 
-1. Checks if the sort field is a declared numeric attribute in the schema
-2. For numeric fields, sorts by parsed double value using `expr::Value` comparison
-3. For non-numeric fields, sorts by string value using `expr::Compare`
-4. Uses `partial_sort` when only a subset is needed (LIMIT offset + count < total), otherwise `stable_sort`
-
-The sort respects ASC/DESC order from the SORTBY clause. Documents missing the sort field are pushed to the end. The `expr::Compare` function returns `Ordering::kLESS`, `kGREATER`, `kEQUAL`, or `kUNORDERED`.
-
-SORTBY requires `RequiresCompleteResults() = true`, which disables background trimming - the full result set must be available for sorting.
+SORTBY forces `RequiresCompleteResults() = true` - full set required before sort.

--- a/skills/valkey-search-dev/skills/valkey-search-dev/reference/query-parsing.md
+++ b/skills/valkey-search-dev/skills/valkey-search-dev/reference/query-parsing.md
@@ -1,208 +1,158 @@
-# Filter Expression Parser
+# Filter expression parser
 
-Use when working on query string parsing, the predicate AST, filter expression syntax, or adding new predicate types.
+Use when reasoning about query parsing, the predicate AST, or adding new predicate types.
 
-Source: `src/commands/filter_parser.h`, `src/commands/filter_parser.cc`, `src/query/predicate.h`
+Source: `src/commands/filter_parser.{h,cc}`, `src/query/predicate.h`.
 
-## Contents
+## `FilterParser`
 
-- FilterParser Overview (line 22)
-- Parsing Entry Point (line 32)
-- Recursive Descent Structure (line 41)
-- Predicate Type Hierarchy (line 59)
-- TextPredicate Variants (line 89)
-- ComposedPredicate (N-ary Tree) (line 108)
-- NegatePredicate (line 131)
-- QueryOperations Bitmask (line 141)
-- Evaluator Interface (line 167)
-- Safety Limits (line 185)
-- TextParsingOptions (line 199)
-
-## FilterParser Overview
-
-`FilterParser` is a recursive descent parser that converts FT.SEARCH/FT.AGGREGATE query strings into a predicate AST. It lives in namespace `valkey_search` and takes an `IndexSchema` reference to validate field names and types at parse time.
-
-The parser produces a `FilterParseResults` struct containing:
-
-- `root_predicate` - the root of the predicate tree (`unique_ptr<query::Predicate>`)
-- `filter_identifiers` - set of schema identifier strings referenced by the filter
-- `query_operations` - bitmask describing which operation types appear in the query
-
-## Parsing Entry Point
+Recursive-descent parser in namespace `valkey_search`. Takes an `IndexSchema` reference for field-name/type validation at parse time.
 
 ```cpp
 FilterParser parser(index_schema, expression, text_options);
 absl::StatusOr<FilterParseResults> result = parser.Parse();
 ```
 
-`Parse()` is called from `SearchParameters::PreParseQueryString()` during command parsing. For vector queries, the query string before the `=>` delimiter is the filter expression; the KNN clause follows after it. For non-vector queries, the entire query string is the filter expression. A `*` expression matches all documents.
+Called from `SearchParameters::PreParseQueryString()`. For vector queries, the part **before** `=>` is the filter; the KNN clause follows. `*` matches all documents.
 
-## Recursive Descent Structure
+Result fields:
 
-The parser maintains position state (`pos_`) and walks the expression character by character. Key private methods:
+- `root_predicate` - `unique_ptr<query::Predicate>`.
+- `filter_identifiers` - schema identifiers referenced.
+- `query_operations` - bitmask (see below).
+
+## Recursive descent
+
+Tracks position `pos_`. Key private methods:
 
 | Method | Purpose |
 |--------|---------|
-| `ParseExpression(level)` | Top-level recursive entry, handles AND/OR/negate at a nesting level |
-| `ParseFieldName()` | Expects `@field:` syntax, returns the field alias |
-| `ParseNumericPredicate(alias)` | Parses `[start end]` range with inclusive `[` or exclusive `(` bounds |
-| `ParseTagPredicate(alias)` | Parses `{tag1\|tag2}` tag sets |
-| `ParseTextPredicate(field)` | Parses full-text search terms against a text field |
-| `ParseTextTokens(field)` | Parses sequences of text tokens (terms, prefix, suffix, fuzzy) |
-| `ParseQuotedTextToken(...)` | Handles `"exact phrase"` tokens |
-| `ParseUnquotedTextToken(...)` | Handles bare word tokens, prefix (`word*`), suffix (`*word`), infix (`*word*`), fuzzy (`%%word%%`) |
-| `WrapPredicate(...)` | Combines predicates with logical operators, building N-ary trees |
+| `ParseExpression(level)` | top-level, handles AND/OR/negate at a nesting level |
+| `ParseFieldName()` | `@field:` syntax, returns alias |
+| `ParseNumericPredicate(alias)` | `[start end]` (or `(` exclusive) ranges |
+| `ParseTagPredicate(alias)` | `{tag1\|tag2}` sets |
+| `ParseTextPredicate(field)` | full-text against a text field |
+| `ParseTextTokens(field)` | term, prefix, suffix, fuzzy sequences |
+| `ParseQuotedTextToken(...)` | `"exact phrase"` |
+| `ParseUnquotedTextToken(...)` | bare words, prefix `word*`, suffix `*word`, infix `*word*`, fuzzy `%%word%%` |
+| `WrapPredicate(...)` | combines predicates with logical ops, builds N-ary trees |
 
-Boolean operators: implicit AND (space between predicates), explicit `|` for OR, `-` prefix for negation. Parentheses `()` control grouping. The parser tracks `node_count_` against the configured maximum at each node creation.
+Operators: implicit AND (space), explicit `|` for OR, `-` prefix for negation. `()` groups. `node_count_` checked against the configured max at each node creation.
 
-## Predicate Type Hierarchy
-
-All predicates inherit from `query::Predicate` (namespace `valkey_search::query`):
+## Predicate hierarchy (`query::Predicate`)
 
 ```
 Predicate (abstract)
-  +-- NumericPredicate      kNumeric
-  +-- TagPredicate          kTag
-  +-- TextPredicate         kText (abstract)
-  |     +-- TermPredicate
-  |     +-- PrefixPredicate
-  |     +-- SuffixPredicate
-  |     +-- InfixPredicate
-  |     +-- FuzzyPredicate
-  +-- ComposedPredicate     kComposedAnd / kComposedOr
-  +-- NegatePredicate       kNegate
+  +-- NumericPredicate       kNumeric
+  +-- TagPredicate           kTag
+  +-- TextPredicate          kText (abstract)
+  |     +-- TermPredicate / PrefixPredicate / SuffixPredicate / InfixPredicate / FuzzyPredicate
+  +-- ComposedPredicate      kComposedAnd / kComposedOr
+  +-- NegatePredicate        kNegate
 ```
 
-The `PredicateType` enum distinguishes: `kTag`, `kNumeric`, `kComposedAnd`, `kComposedOr`, `kNegate`, `kText`, `kNone`.
+`PredicateType` enum: `kTag`, `kNumeric`, `kComposedAnd`, `kComposedOr`, `kNegate`, `kText`, `kNone`.
 
-Every predicate implements `Evaluate(Evaluator&)` for filter evaluation. The `Evaluator` abstract class dispatches to type-specific evaluation methods (`EvaluateText`, `EvaluateTags`, `EvaluateNumeric`).
+Every predicate implements `Evaluate(Evaluator&)`. The `Evaluator` dispatches to `EvaluateText` / `EvaluateTags` / `EvaluateNumeric`.
 
-### NumericPredicate
+## `NumericPredicate`
 
-Stores a range `[start, end]` with inclusive/exclusive flags. Holds a pointer to the `indexes::Numeric` index and the field identifier. Supports `+inf`/`-inf` bounds (mapped to `double::max()`/`double::lowest()` under clang with `-ffast-math`). The `Evaluate(const double* value)` overload allows direct value comparison without going through the Evaluator.
+Range `[start, end]` + inclusive/exclusive flags. Holds pointer to `indexes::Numeric` + field identifier. `+inf` / `-inf` -> `double::max()` / `double::lowest()` (under clang `-ffast-math`). `Evaluate(const double*)` overload for direct value comparison.
 
-### TagPredicate
+## `TagPredicate`
 
-Stores the raw tag string plus a parsed `flat_hash_set<string>` of individual tag values. Tag query syntax uses `|` as separator regardless of the index's configured separator. Holds a pointer to the `indexes::Tag` index. The `Evaluate(const flat_hash_set<string_view>*, bool case_sensitive)` overload supports direct tag-set matching.
+Raw tag string + parsed `flat_hash_set<string>`. Query separator is **always `|`** regardless of index separator. `Evaluate(const flat_hash_set<string_view>*, bool case_sensitive)` overload for direct set matching.
 
-## TextPredicate Variants
+## `TextPredicate` variants
 
-`TextPredicate` is abstract with five concrete subclasses. All share:
+Shared fields: `text_index_schema_`, `field_mask_` (uint64_t, up to 64 fields), `BuildTextIterator(...)`, `EstimateSize(is_vec_query)`.
 
-- `text_index_schema_` - shared pointer to the schema's text index configuration
-- `field_mask_` - a `uint64_t` bitmask selecting which text fields to search (up to 64 fields)
-- `BuildTextIterator(...)` - creates a `TextIterator` for postings-list traversal
-- `EstimateSize(is_vec_query)` - estimates result count for planner decisions
+| Subclass | Syntax | Notes |
+|----------|--------|-------|
+| `TermPredicate` | `word` or `"word"` | exact or stemmed; `exact_` flag controls stemming |
+| `PrefixPredicate` | `word*` | |
+| `SuffixPredicate` | `*word` | |
+| `InfixPredicate` | `*word*` | |
+| `FuzzyPredicate` | `%%word%%` | `distance_` = edit distance (1-3 `%` pairs = distance 1-3) |
 
-| Subclass | Query Syntax | Description |
-|----------|-------------|-------------|
-| `TermPredicate` | `word` or `"word"` | Exact or stemmed term match. `exact_` flag controls stemming |
-| `PrefixPredicate` | `word*` | Matches terms starting with the prefix |
-| `SuffixPredicate` | `*word` | Matches terms ending with the suffix |
-| `InfixPredicate` | `*word*` | Matches terms containing the substring |
-| `FuzzyPredicate` | `%%word%%` | Levenshtein edit-distance match. `distance_` stores the max edit distance (1-3 `%` pairs = distance 1-3) |
+`SetupTextFieldConfiguration()` sets the field mask. `@field:`-scoped = only that bit. Unscoped = all indexed text fields.
 
-The field mask is set up by `SetupTextFieldConfiguration()`. When a text predicate is scoped to a specific field via `@field:`, only that field's bit is set. Without a field scope, all indexed text fields are included in the mask.
+## `ComposedPredicate`
 
-## ComposedPredicate (N-ary Tree)
-
-`ComposedPredicate` is an N-ary logical operator node storing a vector of child predicates. The logical operator is encoded in the `PredicateType`: `kComposedAnd` or `kComposedOr`.
+N-ary (not binary):
 
 ```cpp
-ComposedPredicate(LogicalOperator logical_op,
-                  vector<unique_ptr<Predicate>> children,
-                  optional<uint32_t> slop = nullopt,
-                  bool inorder = false);
+ComposedPredicate(LogicalOperator op, vector<unique_ptr<Predicate>> children,
+                  optional<uint32_t> slop = nullopt, bool inorder = false);
 ```
 
-Key properties:
+`WrapPredicate()` flattens nested compositions of the same type - three ANDed terms become one `ComposedPredicate(kComposedAnd, [A, B, C])`, not nested binary.
 
-- `children_` - vector of child predicates (N-ary, not binary)
-- `slop_` - optional proximity window for SLOP queries
-- `inorder_` - whether terms must appear in order (INORDER queries)
-- `AddChild()` - appends a child predicate during tree construction
-- `ReleaseChildren()` - transfers ownership of children out
+`FlagNestedComposedPredicate()` sets `kContainsNestedComposed` on nested composed predicates (planner uses for optimization).
 
-During parsing, `WrapPredicate()` flattens nested compositions of the same type into a single N-ary node. For example, three ANDed terms become one `ComposedPredicate(kComposedAnd, [A, B, C])` rather than nested binary nodes.
+`slop_` / `inorder_` fields carry SLOP / INORDER settings for proximity evaluation.
 
-`FlagNestedComposedPredicate()` sets `kContainsNestedComposed` in `query_operations_` when a composed predicate is nested inside another, which the planner uses for optimization decisions.
+## `NegatePredicate`
 
-## NegatePredicate
+Single child, inverted result. Created by `-` prefix. Presence forces prefilter evaluation and possibly a universal-set fetcher.
 
-Wraps a single child predicate and inverts its evaluation result:
+## `QueryOperations` bitmask
 
-```cpp
-NegatePredicate(unique_ptr<Predicate> predicate);
-```
+`uint64_t` with bitwise ops. Set during parse, drives planner and execution.
 
-Created when the parser encounters the `-` prefix operator. The negation affects planner decisions - queries containing negation always require prefilter evaluation and may use a universal set fetcher.
+| Flag | Bit | Set when |
+|------|-----|----------|
+| `kNone` | 0 | empty |
+| `kContainsOr` | 1<<0 | `\|` present |
+| `kContainsAnd` | 1<<1 | AND present |
+| `kContainsNumeric` | 1<<2 | numeric field referenced |
+| `kContainsTag` | 1<<3 | tag field referenced |
+| `kContainsNegate` | 1<<4 | `-` present |
+| `kContainsText` | 1<<5 | text field referenced |
+| `kContainsProximity` | 1<<6 | SLOP/INORDER |
+| `kContainsNestedComposed` | 1<<7 | composed inside composed |
+| `kContainsTextTerm` | 1<<8 | exact/stemmed term |
+| `kContainsTextPrefix` | 1<<9 | prefix search |
+| `kContainsTextSuffix` | 1<<10 | suffix search |
+| `kContainsTextFuzzy` | 1<<11 | fuzzy search |
 
-## QueryOperations Bitmask
+Downstream (`search.cc`): `IsUnsolvedQuery()` (prefilter needed), `NeedsDeduplication()` (OR/tag/non-text-negation), `IncrementQueryOperationMetrics()`.
 
-`QueryOperations` is a `uint64_t` enum with bitwise operations. The parser sets flags as it encounters different predicate types. The bitmask drives planner and execution decisions.
-
-| Flag | Value | Set When |
-|------|-------|----------|
-| `kNone` | `0` | Default, empty query |
-| `kContainsOr` | `1 << 0` | Query has OR (`\|`) operators |
-| `kContainsAnd` | `1 << 1` | Query has AND (implicit or explicit) |
-| `kContainsNumeric` | `1 << 2` | Query references a numeric field |
-| `kContainsTag` | `1 << 3` | Query references a tag field |
-| `kContainsNegate` | `1 << 4` | Query uses negation (`-`) |
-| `kContainsText` | `1 << 5` | Query references a text field |
-| `kContainsProximity` | `1 << 6` | Query uses SLOP/INORDER proximity |
-| `kContainsNestedComposed` | `1 << 7` | Composed predicate nested inside another |
-| `kContainsTextTerm` | `1 << 8` | Contains an exact/stemmed term |
-| `kContainsTextPrefix` | `1 << 9` | Contains a prefix search |
-| `kContainsTextSuffix` | `1 << 10` | Contains a suffix search |
-| `kContainsTextFuzzy` | `1 << 11` | Contains a fuzzy search |
-
-Downstream usage in `search.cc`:
-
-- `IsUnsolvedQuery()` - checks if prefilter evaluation is needed (AND with numeric/tag, or negation)
-- `NeedsDeduplication()` - checks if OR, tag, or non-text negation requires dedup
-- `IncrementQueryOperationMetrics()` - records counters per operation type
-
-## Evaluator Interface
-
-The `Evaluator` abstract class (in `predicate.h`) provides the visitor pattern for predicate evaluation:
+## `Evaluator` interface (`predicate.h`)
 
 ```cpp
 class Evaluator {
-  virtual EvaluationResult EvaluateText(const TextPredicate&, bool require_positions) = 0;
-  virtual EvaluationResult EvaluateTags(const TagPredicate&) = 0;
+  virtual EvaluationResult EvaluateText   (const TextPredicate&, bool require_positions) = 0;
+  virtual EvaluationResult EvaluateTags   (const TagPredicate&) = 0;
   virtual EvaluationResult EvaluateNumeric(const NumericPredicate&) = 0;
   virtual const InternedStringPtr& GetTargetKey() const = 0;
   virtual bool IsPrefilterEvaluator() const { return false; }
 };
 ```
 
-`EvaluationResult` carries a `bool matches` and an optional `TextIterator` for position-aware text matching. The iterator is used by proximity/SLOP evaluation in `ComposedPredicate::EvaluateWithContext()`.
+`EvaluationResult`: `bool matches` + optional `TextIterator` for position-aware matching (used by proximity/SLOP in `ComposedPredicate::EvaluateWithContext`).
 
-The main implementation is `indexes::PrefilterEvaluator` (in `src/indexes/vector_base.h`), used during both inline and prefilter evaluation paths. It looks up values in the per-key indexes for tag and numeric fields, and uses the per-key `TextIndex` for text predicates.
+Main impl: `indexes::PrefilterEvaluator` in `src/indexes/vector_base.h` (inline and prefilter paths). Tag/numeric values via per-key indexes; text via per-key `TextIndex`.
 
-## Safety Limits
-
-The parser enforces configurable limits to prevent resource exhaustion from adversarial queries:
+## Safety limits
 
 | Config | Default | Max | Purpose |
 |--------|---------|-----|---------|
-| `query-string-depth` | 1000 | UINT_MAX | Maximum nesting depth of parentheses |
-| `query-string-terms-count` | 1000 | 10000 | Maximum number of predicate nodes in the tree |
-| `fuzzy-max-distance` | 3 | 50 | Maximum Levenshtein distance for `%%` fuzzy queries |
+| `query-string-depth` | 1000 | UINT_MAX | paren nesting depth |
+| `query-string-terms-count` | 1000 | 10 000 | predicate nodes total |
+| `fuzzy-max-distance` | 3 | 50 | max Levenshtein edit distance |
+| `max-vector-knn` | 10 000 | 100 000 | K parameter for vector queries |
 
-The `level` parameter in `ParseExpression(level)` is checked against `query-string-depth`. The `node_count_` member is incremented at each predicate creation and checked against `query-string-terms-count`. Both return `InvalidArgumentError` when exceeded.
+`ParseExpression(level)` checks `level` against `query-string-depth`. `node_count_` checked against `query-string-terms-count` at each creation. Violations -> `InvalidArgumentError`.
 
-For vector queries, `max-vector-knn` limits the K parameter (default 10000, max 100000).
-
-## TextParsingOptions
+## `TextParsingOptions`
 
 ```cpp
 struct TextParsingOptions {
-  bool verbatim = false;   // Skip stemming
-  bool inorder = false;    // Require term order (INORDER flag)
-  optional<uint32_t> slop; // Proximity window (SLOP flag)
+  bool verbatim = false;    // skip stemming
+  bool inorder = false;     // INORDER flag
+  std::optional<uint32_t> slop;  // SLOP flag
 };
 ```
 
-These options are set from the FT.SEARCH/FT.AGGREGATE command-level VERBATIM, INORDER, and SLOP parameters and passed to `FilterParser` at construction. They affect how `ComposedPredicate` nodes are created - when SLOP or INORDER is set, the top-level AND node carries those values for proximity evaluation.
+Set from command-level VERBATIM / INORDER / SLOP. Top-level AND node carries these for proximity evaluation.


### PR DESCRIPTION
## Summary

- Per-file trim: 4692 -> 3303 lines (30% reduction across 20 reference files), all 112-203 lines each.
- Stripped "Contents" anchor-link TOCs from every file (skill-writing-rules).
- Removed line-number citations from the 7 files that still had them.
- Compressed verbose C++ code extracts to dense prose/tables.
- Kept all valkey-search-specific divergence and gotchas.

## Phase 4 validation (against `valkey-search` tag `1.2.0`)

Verified in source:

- `kModuleVersion = ValkeyVersion(1, 2, 0)`, `kMinimumServerVersion = ValkeyVersion(9, 0, 1)`.
- Module name `"search"`, module type (for aux RDB) `"Vk-Search"`.
- `kCurrentEncVer = 1`.
- `kCoordinatorPortOffset = 20294`, +1 for TLS port 6378.
- `kMaxTextFieldsCount = 64`.
- `kHNSWDefaultBlockSize = 10240`.
- FT.INFO default timeouts: `kDefaultFTInfoTimeoutMs = 5000`, `kDefaultFTInfoRpcTimeoutMs = 2500`.
- `kDefaultQueryStringBytes = 10240`, `kDefaultMaxTermExpansions = 200`, `kDefaultTagMinPrefixLength = 2`, `kDefaultPrefilteringThresholdRatio = "0.001"`.
- All 8 registered commands: FT.CREATE, FT.DROPINDEX, FT.INFO, FT._LIST, FT.SEARCH, FT.AGGREGATE, FT._DEBUG, FT.INTERNAL_UPDATE.

## Local agnix

```
Validating: skills/valkey-search-dev
No issues found
```

## Test plan

- [ ] All 20 reference files + SKILL.md present.
- [ ] Router table matches reference directory.
- [ ] No line-number citations remain.
- [ ] No "Contents" TOCs remain.
- [ ] Grep hazards section present in SKILL.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (skill/reference markdown) with no runtime code impact; risk is limited to potential confusion if any refreshed constants or behaviors are inaccurately described.
> 
> **Overview**
> Refreshes the `valkey-search-dev` skill documentation to align with `valkey-search` v1.2.0 and reduce rule violations, including a skill version bump to `2.0.0`.
> 
> Rewrites `SKILL.md` into a concise router + quick-start with an expanded *grep hazards* section, and heavily trims/reformats multiple reference docs by removing per-file TOCs/line-number citations and compressing long code excerpts into shorter tables and step lists while preserving key implementation gotchas (threading/fork behavior, coordinator, RDB/replication, metrics, build/CI, and code structure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd5ba6b66f716c6e4d7aff0d2b97e9006b800fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->