### PR TITLE
glide-dev: validate against v2.3.1, fix core fabrications, add grep hazards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,103 +93,10 @@ Skills were written and verified against these versions. Update when new release
 
 Last full review: 2026-04-11
 
-## Critical Rules
+## Ground rules
 
-1. **Plain text output** - No emojis, no ASCII art.
-2. **Source-verified** - Reference docs must be verified against actual source code, not just web research.
-3. **No unnecessary files** - Don't create summary files, plan files, audit files, or temp docs.
-4. **Use single dash for em-dashes** - In prose, use ` - ` (single dash with spaces), never ` -- `.
+Always write plain text - no emojis, no ASCII art. Always verify reference docs against actual source code rather than relying on web research. Keep the repo tidy: avoid summary files, plan files, audit files, and temp docs. For em-dashes in prose, use a single dash with spaces ` - ` rather than ` -- `.
 
-## Skill-Writing Rules (accumulated from validation passes)
+## Skill-writing rules
 
-These rules were learned while validating valkey, valkey-dev, valkey-ops, valkey-bloom-dev, valkey-search-dev, and glide-dev against source. Apply to every skill edit in this repo.
-
-### Audience: agents already trained on the ecosystem baseline
-
-An LLM trained on public Redis/Valkey source already knows standard structures, stock RESP, stock cmake, `processCommand → call → cmd->proc`, jemalloc defaults, etc. Same for Rust/Cargo basics, PyO3/NAPI/JNI mechanics, standard Tokio runtime patterns. Restating these burns context. Only keep:
-
-1. **Divergence** - where this component behaves differently from the baseline an agent already knows.
-2. **Novel subsystems** - net-new files, ABIs, or mechanisms that don't exist in the baseline.
-3. **Non-obvious invariants / gotchas** - ownership rules, aliasing, hidden state, pausepoint discipline.
-4. **Non-standard pieces** - JSON-generated code, TCL-plus-sanitizer test frameworks, vendored forks.
-
-POC test before writing any line: "would a trained agent know this if asked?" If yes, cut.
-
-### Cut these without regret
-
-- File maps of standard subsystems (agent already knows `src/ae.c` is the reactor)
-- Overview files that just redirect to other files - fold pointers into SKILL.md router
-- "Standard X, same as Redis" framing - if it's the same, delete the topic entirely
-- Code snippets agents can read from struct definitions themselves
-- Marketing numbers ("40% faster", "1B RPS", "4.6x speedup") unless source-verifiable
-- Version annotations like `(Valkey 8.0+)` when the baseline is `unstable` - they decay
-- "Renamed from X" history - agents don't need the rename story, just the current name
-- Version-history tables inside reference docs - decay-prone, not actionable for contributors
-- "Contents" / TOC blocks at the top of merged files - agents grep `## Heading` directly
-
-### No line-number citations
-
-Line numbers drift on every edit. Path + symbol/function name stays stable.
-
-- Write `src/rdb.c` with function name or unique grep string
-- Never `file:lineno`, `file:a-b`, or `(line N)` in headings
-
-### Grep-hazards block is the highest-leverage content
-
-Renamed symbols, vendored-vs-native code, module-name-vs-type-name confusion are the single most valuable content in a contributor skill. Maintain a "grep hazards" section in every SKILL.md. Examples proven valuable:
-
-- valkey-search-dev: module `"search"` vs dummy type `"Vk-Search"`, `kCoordinatorPortOffset=20294`, `FT._DEBUG` off unless in debug mode
-- valkey-bloom-dev: module `bf` vs ACL `bloom` vs type `bloomfltr`, `BLOOM_OBJECT_VERSION` vs `BLOOM_TYPE_ENCODING_VERSION`, Vec-defrag counter bug
-- valkey-dev: `events-per-io-thread` deprecation, dict-is-now-hashtable
-- glide-dev: multiplexer-not-pool, cluster-not-pool-of-standalones, `glide-core/redis-rs/` is vendored-not-GLIDE, UDS is in-process IPC
-
-### Validation: always run two passes
-
-One pass catches ~60% of factual errors. Second pass with a narrower correctness lens catches the rest. Real examples of bugs only caught on pass 2:
-
-- valkey-search-dev pass 2: `coordinator-query-timeout-secs` default was 25 in skill, actual is 120
-- valkey-search-dev pass 2: `hnsw-allow-replace-deleted` config doesn't exist on 1.2.0 (TODO in source, hardcoded false)
-
-**Pass-2 pattern for config tables:** every config must be verified to exist as a real `config::*Builder` registration (or equivalent per-ecosystem), not just referenced in code or TODO comments. `git grep -nE '"<config-name>"' <tag> -- src/` must return a real registration.
-
-### Baseline targeting per skill
-
-- `valkey` (app-dev): 9.0.3 - stable reference for users building apps
-- `valkey-dev` (contributor): `origin/unstable` - what contributors actually touch
-- `valkey-ops`: 9.0.3 (operator perspective)
-- `valkey-bloom-dev`: tag `1.0.1`
-- `valkey-search-dev`: tag `1.2.0`
-- `glide-dev`: tag `v2.3.1` (GLIDE cuts unified tags across languages; `-java`-suffixed tags are supplementary Java-only releases)
-- Per-language GLIDE skills: baseline 2.3.1
-- Spring Data Valkey: 1.0
-- If unclear, ask
-
-When working on the `unstable` baseline, stop adding version annotations - they will decay. The CURRENT BEHAVIOR is what matters.
-
-### When caught faking, stop and fix
-
-If validating turns up a fabrication introduced earlier in the session (e.g., hash-tag co-location claim, pool-language creep), fix it at the source before continuing. Don't assume the downstream prompt caught it. Add the caught fabrication to `memory/valkey_fabrications_caught.md` as a regression guard for future passes.
-
-### Don't commit to version specifics that may shift
-
-For fast-moving components (GLIDE in particular), describe capabilities conceptually or link to the repo. Don't say "GLIDE 2.x does X" unless the specific release IS the point of the section.
-
-### GLIDE-specific correctness rules (for glide-dev and per-language skills)
-
-Captured from maintainer corrections. These mistakes recur because agents pattern-match from typical clients (jedis, redis-py, node-redis) that work differently.
-
-1. **GLIDE is a multiplexer, not a connection pool.** One multiplexed connection, many in-flight requests tagged with IDs. Never say "pool size", "connection pool", "checkout connection" about the core client. If a skill says "pool" referring to the core, that's a bug.
-
-2. **Cluster client and standalone client are two different animals.** Not one wrapping the other, not a pool of standalones. Distinct implementations with different state machines, routing, and reconnection. `ClientWrapper` is an enum with separate variants, not a wrapper hierarchy.
-
-3. **UDS is in-process IPC, not network.** Python-async and Node bindings use a Unix domain socket for message passing between the language layer and the Rust core **within the same process**. Not a remote connection, no network hop, Rust core is not a separate process.
-
-4. **Two client categories by FFI mechanism:**
-   - **UDS clients**: Python async, Node.js (in-process message passing)
-   - **FFI clients**: Python sync, Go, Java (JNI), PHP, C#, Ruby (direct C ABI calls)
-
-5. **`glide-core/redis-rs/` is vendored redis-rs - treat as inheritance, not GLIDE.** Lots of code there is not wired. Before claiming "the core does X" based on reading a function in `glide-core/redis-rs/**`, verify the call graph from `glide-core/src/**` outward. `glide-core/src/client/` is the real GLIDE client code (`standalone_client.rs` + `reconnecting_connection.rs` + the wrapper in `mod.rs`).
-
-6. **Cross-language blast radius.** A change in `glide-core/` or `ffi/` affects ALL language bindings AND both FFI modes. Before recommending a core change, think through impact on UDS path, FFI path, each language wrapper, each language's test suite.
-
-7. **HA/reliability and performance are both top priorities - never risk either.** HA/reliability is arbitrated first when tradeoffs force a choice, but performance is not "secondary". Every core change must be measured and validated for both. No change ships if it regresses reconnect/failover behavior OR throughput/latency. An "optimization" that reduces reliability in any reconnect/failover scenario is not an optimization - and a reliability change that silently tanks throughput is also a regression.
+Detailed rules for editing skills (audience framing, cut lists, grep hazards, 2-pass validation, GLIDE correctness) live in [docs/SKILL_WRITING_RULES.md](docs/SKILL_WRITING_RULES.md). Read that doc before editing any SKILL.md or reference file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,3 +99,97 @@ Last full review: 2026-04-11
 2. **Source-verified** - Reference docs must be verified against actual source code, not just web research.
 3. **No unnecessary files** - Don't create summary files, plan files, audit files, or temp docs.
 4. **Use single dash for em-dashes** - In prose, use ` - ` (single dash with spaces), never ` -- `.
+
+## Skill-Writing Rules (accumulated from validation passes)
+
+These rules were learned while validating valkey, valkey-dev, valkey-ops, valkey-bloom-dev, valkey-search-dev, and glide-dev against source. Apply to every skill edit in this repo.
+
+### Audience: agents already trained on the ecosystem baseline
+
+An LLM trained on public Redis/Valkey source already knows standard structures, stock RESP, stock cmake, `processCommand → call → cmd->proc`, jemalloc defaults, etc. Same for Rust/Cargo basics, PyO3/NAPI/JNI mechanics, standard Tokio runtime patterns. Restating these burns context. Only keep:
+
+1. **Divergence** - where this component behaves differently from the baseline an agent already knows.
+2. **Novel subsystems** - net-new files, ABIs, or mechanisms that don't exist in the baseline.
+3. **Non-obvious invariants / gotchas** - ownership rules, aliasing, hidden state, pausepoint discipline.
+4. **Non-standard pieces** - JSON-generated code, TCL-plus-sanitizer test frameworks, vendored forks.
+
+POC test before writing any line: "would a trained agent know this if asked?" If yes, cut.
+
+### Cut these without regret
+
+- File maps of standard subsystems (agent already knows `src/ae.c` is the reactor)
+- Overview files that just redirect to other files - fold pointers into SKILL.md router
+- "Standard X, same as Redis" framing - if it's the same, delete the topic entirely
+- Code snippets agents can read from struct definitions themselves
+- Marketing numbers ("40% faster", "1B RPS", "4.6x speedup") unless source-verifiable
+- Version annotations like `(Valkey 8.0+)` when the baseline is `unstable` - they decay
+- "Renamed from X" history - agents don't need the rename story, just the current name
+- Version-history tables inside reference docs - decay-prone, not actionable for contributors
+- "Contents" / TOC blocks at the top of merged files - agents grep `## Heading` directly
+
+### No line-number citations
+
+Line numbers drift on every edit. Path + symbol/function name stays stable.
+
+- Write `src/rdb.c` with function name or unique grep string
+- Never `file:lineno`, `file:a-b`, or `(line N)` in headings
+
+### Grep-hazards block is the highest-leverage content
+
+Renamed symbols, vendored-vs-native code, module-name-vs-type-name confusion are the single most valuable content in a contributor skill. Maintain a "grep hazards" section in every SKILL.md. Examples proven valuable:
+
+- valkey-search-dev: module `"search"` vs dummy type `"Vk-Search"`, `kCoordinatorPortOffset=20294`, `FT._DEBUG` off unless in debug mode
+- valkey-bloom-dev: module `bf` vs ACL `bloom` vs type `bloomfltr`, `BLOOM_OBJECT_VERSION` vs `BLOOM_TYPE_ENCODING_VERSION`, Vec-defrag counter bug
+- valkey-dev: `events-per-io-thread` deprecation, dict-is-now-hashtable
+- glide-dev: multiplexer-not-pool, cluster-not-pool-of-standalones, `glide-core/redis-rs/` is vendored-not-GLIDE, UDS is in-process IPC
+
+### Validation: always run two passes
+
+One pass catches ~60% of factual errors. Second pass with a narrower correctness lens catches the rest. Real examples of bugs only caught on pass 2:
+
+- valkey-search-dev pass 2: `coordinator-query-timeout-secs` default was 25 in skill, actual is 120
+- valkey-search-dev pass 2: `hnsw-allow-replace-deleted` config doesn't exist on 1.2.0 (TODO in source, hardcoded false)
+
+**Pass-2 pattern for config tables:** every config must be verified to exist as a real `config::*Builder` registration (or equivalent per-ecosystem), not just referenced in code or TODO comments. `git grep -nE '"<config-name>"' <tag> -- src/` must return a real registration.
+
+### Baseline targeting per skill
+
+- `valkey` (app-dev): 9.0.3 - stable reference for users building apps
+- `valkey-dev` (contributor): `origin/unstable` - what contributors actually touch
+- `valkey-ops`: 9.0.3 (operator perspective)
+- `valkey-bloom-dev`: tag `1.0.1`
+- `valkey-search-dev`: tag `1.2.0`
+- `glide-dev`: tag `v2.3.1` (GLIDE cuts unified tags across languages; `-java`-suffixed tags are supplementary Java-only releases)
+- Per-language GLIDE skills: baseline 2.3.1
+- Spring Data Valkey: 1.0
+- If unclear, ask
+
+When working on the `unstable` baseline, stop adding version annotations - they will decay. The CURRENT BEHAVIOR is what matters.
+
+### When caught faking, stop and fix
+
+If validating turns up a fabrication introduced earlier in the session (e.g., hash-tag co-location claim, pool-language creep), fix it at the source before continuing. Don't assume the downstream prompt caught it. Add the caught fabrication to `memory/valkey_fabrications_caught.md` as a regression guard for future passes.
+
+### Don't commit to version specifics that may shift
+
+For fast-moving components (GLIDE in particular), describe capabilities conceptually or link to the repo. Don't say "GLIDE 2.x does X" unless the specific release IS the point of the section.
+
+### GLIDE-specific correctness rules (for glide-dev and per-language skills)
+
+Captured from maintainer corrections. These mistakes recur because agents pattern-match from typical clients (jedis, redis-py, node-redis) that work differently.
+
+1. **GLIDE is a multiplexer, not a connection pool.** One multiplexed connection, many in-flight requests tagged with IDs. Never say "pool size", "connection pool", "checkout connection" about the core client. If a skill says "pool" referring to the core, that's a bug.
+
+2. **Cluster client and standalone client are two different animals.** Not one wrapping the other, not a pool of standalones. Distinct implementations with different state machines, routing, and reconnection. `ClientWrapper` is an enum with separate variants, not a wrapper hierarchy.
+
+3. **UDS is in-process IPC, not network.** Python-async and Node bindings use a Unix domain socket for message passing between the language layer and the Rust core **within the same process**. Not a remote connection, no network hop, Rust core is not a separate process.
+
+4. **Two client categories by FFI mechanism:**
+   - **UDS clients**: Python async, Node.js (in-process message passing)
+   - **FFI clients**: Python sync, Go, Java (JNI), PHP, C#, Ruby (direct C ABI calls)
+
+5. **`glide-core/redis-rs/` is vendored redis-rs - treat as inheritance, not GLIDE.** Lots of code there is not wired. Before claiming "the core does X" based on reading a function in `glide-core/redis-rs/**`, verify the call graph from `glide-core/src/**` outward. `glide-core/src/client/` is the real GLIDE client code (`standalone_client.rs` + `reconnecting_connection.rs` + the wrapper in `mod.rs`).
+
+6. **Cross-language blast radius.** A change in `glide-core/` or `ffi/` affects ALL language bindings AND both FFI modes. Before recommending a core change, think through impact on UDS path, FFI path, each language wrapper, each language's test suite.
+
+7. **HA/reliability and performance are both top priorities - never risk either.** HA/reliability is arbitrated first when tradeoffs force a choice, but performance is not "secondary". Every core change must be measured and validated for both. No change ships if it regresses reconnect/failover behavior OR throughput/latency. An "optimization" that reduces reliability in any reconnect/failover scenario is not an optimization - and a reliability change that silently tanks throughput is also a regression.

--- a/docs/SKILL_WRITING_RULES.md
+++ b/docs/SKILL_WRITING_RULES.md
@@ -1,0 +1,95 @@
+# Skill-writing rules (accumulated from validation passes)
+
+Rules learned while validating valkey, valkey-dev, valkey-ops, valkey-bloom-dev, valkey-search-dev, and glide-dev against source. Apply to every skill edit in this repo.
+
+## Audience: agents already trained on the ecosystem baseline
+
+A trained LLM already knows standard Redis/Valkey structures, stock RESP, stock cmake, `processCommand -> call -> cmd->proc`, jemalloc defaults. Same for Rust/Cargo basics, PyO3/NAPI/JNI mechanics, standard Tokio runtime patterns. Restating these burns context.
+
+Only write:
+
+1. **Divergence** - where this component behaves differently from the baseline an agent already knows.
+2. **Novel subsystems** - net-new files, ABIs, or mechanisms that don't exist in the baseline.
+3. **Non-obvious invariants / gotchas** - ownership rules, aliasing, hidden state, pausepoint discipline.
+4. **Non-standard pieces** - JSON-generated code, TCL-plus-sanitizer test frameworks, vendored forks.
+
+POC test before writing any line: "would a trained agent know this if asked?" If yes, cut.
+
+## Cut without regret
+
+- File maps of standard subsystems (agent already knows `src/ae.c` is the reactor)
+- Overview files that just redirect to other files - fold pointers into SKILL.md router
+- "Standard X, same as Redis" framing - if it's the same, drop the topic entirely
+- Code snippets agents can read from struct definitions themselves
+- Marketing numbers ("40% faster", "1B RPS") unless source-verifiable
+- Version annotations like `(Valkey 8.0+)` when the baseline is `unstable` - they decay
+- "Renamed from X" history - agents need the current name, not the rename story
+- Version-history tables in reference docs - decay-prone, not actionable
+- "Contents" / TOC blocks at the top of merged files - agents grep `## Heading` directly
+
+## Paths and symbols, not line numbers
+
+Line numbers drift on every edit. Always prefer path + function name or unique grep string.
+
+Write `src/rdb.c` with the function name. Avoid `file:lineno`, `file:a-b`, or `(line N)` in headings.
+
+## Grep-hazards block is the highest-leverage content
+
+Renamed symbols, vendored-vs-native code, module-name vs type-name confusion - this is the single most valuable content in a contributor skill. Every SKILL.md should carry a "grep hazards" section. Examples proven valuable:
+
+- valkey-search-dev: module `"search"` vs dummy type `"Vk-Search"`, `kCoordinatorPortOffset=20294`, `FT._DEBUG` off unless in debug mode
+- valkey-bloom-dev: module `bf` vs ACL `bloom` vs type `bloomfltr`, `BLOOM_OBJECT_VERSION` vs `BLOOM_TYPE_ENCODING_VERSION`, Vec-defrag counter bug
+- valkey-dev: `events-per-io-thread` deprecation, dict-is-now-hashtable
+- glide-dev: multiplexer-not-pool, cluster-not-pool-of-standalones, `glide-core/redis-rs/` is vendored-not-GLIDE, UDS is in-process IPC
+
+## Always run two validation passes
+
+One pass catches ~60% of factual errors. A second pass with a narrower correctness lens catches the rest. Real examples caught only on pass 2:
+
+- valkey-search-dev pass 2: `coordinator-query-timeout-secs` default was 25 in skill, actual is 120
+- valkey-search-dev pass 2: `hnsw-allow-replace-deleted` config doesn't exist on 1.2.0 (TODO in source, hardcoded false)
+- glide-dev pass 2: Java `process_command_for_compression` duplicate (fabrication); retry-field `retryServerError`/`retryConnectionError` was camelCase wrapper-API name in a section describing the Rust core struct
+
+**Pass-2 pattern for config tables:** every config must be verified to exist as a real `config::*Builder` registration (or equivalent per-ecosystem), not just referenced in code or TODO comments. Run `git grep -nE '"<config-name>"' <tag> -- src/` and require a real registration hit.
+
+## Baseline targeting per skill
+
+- `valkey` (app-dev): 9.0.3 - stable reference for users building apps
+- `valkey-dev` (contributor): `origin/unstable` - what contributors actually touch
+- `valkey-ops`: 9.0.3 (operator perspective)
+- `valkey-bloom-dev`: tag `1.0.1`
+- `valkey-search-dev`: tag `1.2.0`
+- `glide-dev`: tag `v2.3.1` (GLIDE cuts unified tags across languages; `-java`-suffixed tags are supplementary Java-only releases)
+- Per-language GLIDE skills: baseline 2.3.1
+- Spring Data Valkey: 1.0
+- If unclear, ask
+
+When working on the `unstable` baseline, stop adding version annotations - they decay. Describe CURRENT behavior.
+
+## When a fabrication turns up, fix at the source
+
+If validating surfaces a fabrication from an earlier session (e.g., hash-tag co-location claim, pool-language creep), correct the skill file immediately and add the caught pattern to `memory/valkey_fabrications_caught.md` as a regression guard for future passes. Don't assume later prompts caught it.
+
+## Don't commit to version specifics that may shift
+
+For fast-moving components (GLIDE in particular), describe capabilities conceptually or link to the repo. Avoid "GLIDE 2.x does X" unless the specific release IS the point of the section.
+
+## GLIDE-specific correctness rules
+
+Captured from maintainer corrections. These recur because agents pattern-match from typical clients (jedis, redis-py, node-redis) that work differently.
+
+1. **GLIDE is a multiplexer.** One multiplexed connection, many in-flight requests tagged with IDs. Always write "multiplexer" when describing the core client. Call the concurrency cap "inflight limit" (`DEFAULT_MAX_INFLIGHT_REQUESTS = 1000`), not "pool size". Avoid "connection pool", "pool of clients", "checkout connection" for the core.
+
+2. **Cluster client and standalone client are two distinct implementations.** Keep them separate in prose. `ClientWrapper` is an enum with separate variants (`Standalone(StandaloneClient)` vs `Cluster { client: ClusterConnection }`). Describe each with its own state machine, routing, and reconnection logic. Cluster is NOT "a pool of standalones" or "a wrapper around standalone".
+
+3. **UDS is in-process IPC.** Python-async and Node bindings pass messages between the language layer and the Rust core over a Unix domain socket within the same process. Always say "in-process" when describing UDS. The Rust core is not a separate process; no network hop.
+
+4. **Two client categories by FFI mechanism:**
+   - UDS clients: Python async, Node.js (in-process message passing)
+   - FFI clients: Python sync, Go, Java (JNI), PHP, C#, Ruby (direct C ABI calls)
+
+5. **`glide-core/redis-rs/` is vendored redis-rs - treat as inheritance, not GLIDE.** Lots of code there is not wired. Always trace call graphs from `glide-core/src/**` outward before attributing behavior. `glide-core/src/client/` holds the real GLIDE client code (`mod.rs`, `standalone_client.rs`, `reconnecting_connection.rs`). Avoid claims that `glide-core/redis-rs/**` "is GLIDE".
+
+6. **Cross-language blast radius.** A change in `glide-core/` or `ffi/` affects all language bindings AND both FFI modes. Before recommending a core change, walk through impact on: UDS path, FFI path, each language wrapper, each language's tests. List the languages affected explicitly.
+
+7. **HA/reliability and performance are both top priorities - never risk either.** HA/reliability is arbitrated first when tradeoffs force a choice, but performance is not secondary. Every core change must be measured and validated for both. Block any change that regresses reconnect/failover behavior OR throughput/latency. An "optimization" that reduces reliability is a regression - and a reliability change that silently tanks throughput is also a regression.

--- a/skills/glide-dev/.claude-plugin/plugin.json
+++ b/skills/glide-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "glide-dev",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use when contributing to the GLIDE client - Rust core internals, language bindings (PyO3/JNI/NAPI/CGO/FFI), protocol layer, PubSub synchronizer, cluster topology, and build system. For using GLIDE in apps, see valkey-glide instead.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/glide-dev/skills/glide-dev/SKILL.md
+++ b/skills/glide-dev/skills/glide-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: glide-dev
 description: "Use when contributing to the GLIDE client - Rust core internals, language bindings (PyO3/JNI/NAPI/CGO/FFI), protocol layer, PubSub synchronizer, cluster topology, and build system. For using GLIDE in apps, see valkey-glide instead."
-version: 1.0.0
+version: 1.1.0
 argument-hint: "[language binding or core component]"
 ---
 
@@ -22,19 +22,32 @@ argument-hint: "[language binding or core component]"
 ## Repository Structure
 
 ```
-glide-core/     # Rust core - connection, protocol, clustering, PubSub sync
-  src/client/   # Client implementation, connection pool
-  src/pubsub/   # PubSub synchronizer (desired vs actual state)
-  src/protobuf/ # Protobuf definitions for IPC
-ffi/            # C FFI layer for Python sync and Go
-logger_core/    # Rust logging infrastructure
-python/         # Python wrappers (async via PyO3, sync via CFFI)
-java/           # Java wrappers via JNI
-node/           # Node.js wrappers via NAPI v2
-go/             # Go wrappers via CGO + FFI
-utils/          # Test utilities, cluster management scripts
-benchmarks/     # Performance benchmarks
+glide-core/
+  src/            # Real GLIDE core (what this skill describes)
+    client/       # Client impl - multiplexer, not a pool
+    pubsub/       # PubSub synchronizer (desired vs actual state)
+    protobuf/     # Protobuf definitions for IPC
+  redis-rs/       # Vendored redis-rs fork - inheritance, NOT GLIDE code
+ffi/              # C FFI surface (Python sync, Go, Java JNI, PHP, C#, Ruby)
+logger_core/      # Rust logging
+python/           # glide-async (UDS + PyO3) and glide-sync (FFI + CFFI)
+java/             # JNI wrappers (migrated from UDS to direct JNI in 2.2)
+node/             # NAPI v2 wrappers, UDS-backed
+go/               # CGO against ffi/
+utils/            # Test utilities, cluster scripts
 ```
+
+## Grep hazards (read before editing core)
+
+These are the recurring agent mistakes. Every change touching `glide-core/` or `ffi/` should be checked against this list.
+
+1. **GLIDE is a multiplexer, not a connection pool.** One multiplexed connection, many in-flight requests tagged with IDs. `DEFAULT_MAX_INFLIGHT_REQUESTS = 1000` is the inflight cap, not a pool size. Never say "connection pool" about the core client.
+2. **Cluster client is NOT a pool of standalone clients.** `ClientWrapper` is an enum: `Standalone(StandaloneClient)` vs `Cluster { client: ClusterConnection }` - two separate types with different state machines. Cluster does not wrap standalone.
+3. **`glide-core/redis-rs/` is vendored redis-rs, NOT GLIDE.** Lots of code there is inherited and not wired. Before claiming "the core does X" from `glide-core/redis-rs/**`, trace the call graph from `glide-core/src/**` outward. The real GLIDE client code is `glide-core/src/client/` (3 files: `mod.rs`, `standalone_client.rs`, `reconnecting_connection.rs`).
+4. **UDS is in-process IPC, not network.** Python-async and Node talk to the Rust core over a Unix socket within the same process - just a message-passing mechanism between the language layer and the Rust runtime. Not a separate process, not a remote connection.
+5. **HA/reliability and performance are both top priorities - never risk either.** HA/reliability is arbitrated first when tradeoffs force a choice, but performance is not "secondary". Every core change is measured and validated for both. No change ships if it regresses reconnect/failover behavior OR throughput/latency.
+6. **Cross-language blast radius.** `glide-core/` or `ffi/` changes affect every wrapper (Python async + sync, Node, Java, Go, PHP, C#, Ruby) and both FFI modes. Validate across the matrix.
+7. **Routing lives in `redis::cluster_routing` (vendored), not `request_type.rs`.** `request_type.rs` is a command-name → enum mapping, nothing more. Routing decisions come from `RoutingInfo::for_routable()` and user-specified overrides.
 
 ## Core Architecture
 

--- a/skills/glide-dev/skills/glide-dev/SKILL.md
+++ b/skills/glide-dev/skills/glide-dev/SKILL.md
@@ -48,6 +48,7 @@ These are the recurring agent mistakes. Every change touching `glide-core/` or `
 5. **HA/reliability and performance are both top priorities - never risk either.** HA/reliability is arbitrated first when tradeoffs force a choice, but performance is not "secondary". Every core change is measured and validated for both. No change ships if it regresses reconnect/failover behavior OR throughput/latency.
 6. **Cross-language blast radius.** `glide-core/` or `ffi/` changes affect every wrapper (Python async + sync, Node, Java, Go, PHP, C#, Ruby) and both FFI modes. Validate across the matrix.
 7. **Routing lives in `redis::cluster_routing` (vendored), not `request_type.rs`.** `request_type.rs` is a command-name → enum mapping, nothing more. Routing decisions come from `RoutingInfo::for_routable()` and user-specified overrides.
+8. **Typo in upstream constant: `UNIX_SOCKER_DIR` (not `UNIX_SOCKET_DIR`).** In `glide-core/src/socket_listener.rs`. Grep for the misspelled name or you'll miss the socket-path source.
 
 ## Core Architecture
 

--- a/skills/glide-dev/skills/glide-dev/reference/build-and-test.md
+++ b/skills/glide-dev/skills/glide-dev/reference/build-and-test.md
@@ -6,72 +6,108 @@ Use when setting up a development environment, running tests, or debugging build
 
 - Rust toolchain (rustup)
 - Node.js 16+ (for Node.js wrapper)
-- Python 3.9+ (for Python wrapper)
+- Python 3.9+ (for Python wrappers)
 - Java 11+ (for Java wrapper)
 - Go 1.21+ (for Go wrapper)
 - Docker (for integration tests - cluster setup)
 - protoc (protobuf compiler)
 
-## Build
+## Preferred: top-level `Makefile`
 
-### Rust Core
+The repo root `Makefile` is the canonical way to build and test. It wires each language to its own toolchain.
+
+```bash
+make all          # java + python + node + go + all tests + lint
+make java         # release build
+make python       # python async + sync, release
+make node         # release build
+make go           # build
+
+make java-test    # integration tests
+make python-test
+make node-test
+make go-test
+
+make java-lint    # spotlessApply
+make python-lint
+make node-lint
+make go-lint
+```
+
+Tests that need a server use the `check-valkey-server` Make target which spins up a Valkey process.
+
+## Raw per-stack equivalents
+
+### Rust core
+
 ```bash
 cd glide-core
-cargo build
+cargo build --release
 cargo test
+cargo clippy
+cargo fmt
+cargo bench
 ```
 
 ### Node.js
+
 ```bash
 cd node
 npm install
-npm run build       # Builds Rust NAPI binding + TypeScript
-npm run build:release  # Release build
+npm run build:release
 npm test
 ```
 
-### Python
+### Python (async + sync)
+
+Python uses `python3 dev.py` as the canonical build/test/lint driver:
+
 ```bash
 cd python
-pip install -e .    # Editable install
-python -m pytest tests/
+python3 dev.py build --mode release
+python3 dev.py test
+python3 dev.py lint
 ```
 
+Raw pytest against the installed package also works once `dev.py build` has produced the wheels.
+
 ### Java
+
 ```bash
 cd java
-./gradlew build
-./gradlew test
+./gradlew :client:buildAllRelease
+./gradlew :integTest:test
+./gradlew :spotlessApply
 ```
 
 ### Go
+
 ```bash
 cd go
 make build
 make test
+make lint
 ```
 
-## Integration Tests
+## Integration tests - cluster setup
 
-Integration tests require a running Valkey cluster. Use the utility scripts:
+`utils/cluster_manager.py` manages the test topology:
 
 ```bash
-# Start a standalone Valkey instance
-python utils/cluster_manager.py start --cluster-mode false
+# Standalone Valkey
+python3 utils/cluster_manager.py start --cluster-mode false
 
-# Start a 3-primary + 3-replica cluster
-python utils/cluster_manager.py start --cluster-mode true
+# 3 primaries + 3 replicas
+python3 utils/cluster_manager.py start --cluster-mode true
 
-# Run Node.js integration tests
-cd node && npm run test:integration
-
-# Stop cluster
-python utils/cluster_manager.py stop
+# Stop
+python3 utils/cluster_manager.py stop
 ```
 
-## Common Issues
+## Common issues
 
-- **NAPI build fails**: ensure `node-gyp` dependencies are installed (Python, C++ compiler)
-- **PyO3 build fails**: ensure `maturin` is installed (`pip install maturin`)
-- **Protobuf mismatch**: regenerate with `protoc` if proto files changed
-- **Socket permission errors**: Unix sockets created in temp dir, check permissions
+- **NAPI build fails**: ensure `node-gyp` deps are installed (Python, C++ toolchain)
+- **PyO3 build fails**: `maturin` required - `pip install maturin` or let `dev.py` manage the `.env/` virtualenv
+- **Protobuf mismatch**: proto files are regenerated at build time; force rebuild if out of sync
+- **Socket permission errors**: UDS sockets created in temp dir - name includes `{pid}-{uuid}` to avoid collision. Check temp dir permissions and existing stale socket files if reuse is suspected.
+- **Cross-language change**: if you modify `glide-core/` or `ffi/`, rebuild AND test **every** language binding - the core is shared across all wrappers and both FFI modes (UDS and direct FFI).

--- a/skills/glide-dev/skills/glide-dev/reference/cluster-internals.md
+++ b/skills/glide-dev/skills/glide-dev/reference/cluster-internals.md
@@ -2,42 +2,59 @@
 
 Use when working on cluster slot mapping, failover handling, MOVED/ASK redirect logic, or topology refresh.
 
-## Slot Mapping
+## Cluster is its own client, not a pool
 
-GLIDE uses the `SlotMap` from the redis crate to track which node owns which slot range (0-16383). The slot map is refreshed:
-1. On initial connection
-2. On MOVED redirect (stale slot mapping)
-3. On ASK redirect (slot migration in progress)
-4. Periodically via topology refresh
+Cluster and standalone are two different implementations in `glide-core/src/client/`. `ClientWrapper::Cluster` holds a `redis::cluster_async::ClusterConnection` (from the vendored `glide-core/redis-rs/` tree); `ClientWrapper::Standalone` holds GLIDE's own `StandaloneClient`. They do not share a code path. Do not describe cluster as "a pool of standalone clients" - that's a common but wrong mental model.
 
-## MOVED/ASK Handling
+## Slot Map
 
-- **MOVED**: slot permanently moved to another node. Update slot map, retry on new node.
-- **ASK**: slot temporarily being migrated. Send ASKING + command to the indicated node, don't update slot map.
+`redis::cluster_slotmap::SlotMap` from the vendored redis-rs tracks which node owns which slot range (0-16383). It refreshes:
 
-## Topology Refresh
+1. On initial connection (slot map built from `CLUSTER SLOTS` / `CLUSTER SHARDS`)
+2. On `MOVED` redirect (stale slot mapping)
+3. On `ASK` redirect (slot migration in progress - single-use, does NOT update the map)
+4. Periodically via `periodic_topology_checks` (configured in `ConnectionRequest`; default interval `DEFAULT_PERIODIC_TOPOLOGY_CHECKS_INTERVAL = 60s` in `client/mod.rs`)
 
-Cluster topology is fetched via `CLUSTER SLOTS` or `CLUSTER SHARDS` (Valkey 7.0+). On refresh:
-1. Build new slot map
-2. Compare with current connections
-3. Create connections to new nodes
-4. Close connections to removed nodes
-5. Trigger PubSub resubscription for affected slots
+## MOVED vs ASK
 
-## Routing Decisions (`request_type.rs`)
+- **MOVED**: slot permanently moved. Update slot map, retry on new node.
+- **ASK**: slot mid-migration. Send `ASKING` + command to the indicated node. One-shot: the next command for the same slot still goes to the original owner until MOVED.
 
-Each command type has routing info:
-- **Single slot**: route to the node owning the slot for the command's key
-- **All nodes**: broadcast to all primaries (e.g., FLUSHALL, DBSIZE)
-- **Random node**: any node (e.g., PING, INFO)
-- **Primary preferred**: prefer primary, fall back to replica
+## Topology refresh
 
-Multi-key commands must target the same slot (hash tags help: `{same-slot}:key1`, `{same-slot}:key2`).
+`CLUSTER SLOTS` (older) or `CLUSTER SHARDS` (Valkey 7.0+). Flow:
 
-## Connection Pool
+1. Fetch topology.
+2. Build new `SlotMap`.
+3. Diff against current node set - open connections to new nodes, close connections to removed nodes.
+4. Trigger PubSub resynchronization for affected slots (see `pubsub-internals.md`).
 
-Per-node connection pool with:
-- Configurable min/max connections
-- Auto-reconnection with exponential backoff
-- Health checking via PING
-- Connection naming for debug (CLIENT SETNAME)
+Refresh path is in vendored `redis::cluster_async`; GLIDE adds the hook for PubSub resync via `PubSubSynchronizer::handle_topology_refresh(&SlotMap)` in `glide-core/src/pubsub/synchronizer.rs`.
+
+## Routing decisions
+
+Routing lives in vendored `redis::cluster_routing` (imported in `client/mod.rs` as `MultipleNodeRoutingInfo`, `ResponsePolicy`, `Routable`, `RoutingInfo`, `SingleNodeRoutingInfo`). It is NOT in `request_type.rs` - that file is only a command-name → `RequestType` enum with no routing logic.
+
+Categories:
+
+- **Single slot**: route to the node owning the slot of the command's key.
+- **All primaries**: broadcast (FLUSHALL, DBSIZE, CONFIG SET).
+- **All nodes**: broadcast to all primaries and replicas (PING via cluster, some diagnostics).
+- **Random node**: pick any primary.
+- **Response policy** determines how to aggregate multi-node responses: combine arrays, sum counts, take first value, all-succeeded-or-error.
+
+Multi-key commands on the same cluster must target one slot (hash tags: `{same-slot}:key1`, `{same-slot}:key2`). Cross-slot multi-key is split and dispatched by GLIDE when the command allows it (e.g., MGET/MSET in cluster mode).
+
+## Read-from-replica
+
+`redis::cluster_slotmap::ReadFromReplicaStrategy` (imported in `client/mod.rs`). Configured via `ConnectionRequest::read_from`. Strategies include primary-preferred and AZ-affinity; the actual enum variants live in the vendored redis-rs.
+
+## Connection lifecycle
+
+Per-node connections are held by `ClusterConnection` (vendored). Reconnection, heartbeat, and IAM-token refresh are driven by GLIDE code in `reconnecting_connection.rs`:
+
+- `HEARTBEAT_SLEEP_DURATION = 1s`
+- `CONNECTION_CHECKS_INTERVAL = 3s` (not user-exposed; per source comment, improper tuning affects PubSub resiliency)
+- `DEFAULT_RETRIES = 3`, `DEFAULT_RESPONSE_TIMEOUT = 250ms`, `DEFAULT_MAX_INFLIGHT_REQUESTS = 1000` (all in `client/mod.rs`)
+
+There is no min/max "pool size" - per-node links are the multiplexed connection managed by `ReconnectingConnection`.

--- a/skills/glide-dev/skills/glide-dev/reference/connection-internals.md
+++ b/skills/glide-dev/skills/glide-dev/reference/connection-internals.md
@@ -91,10 +91,14 @@ A single multiplexed connection cannot isolate state. Separate clients needed fo
 
 ## Batch Retry Strategies (Cluster Non-Atomic)
 
-- **retryServerError** - retry commands failing with retriable errors (e.g., TRYAGAIN). May cause out-of-order execution.
-- **retryConnectionError** - retry entire batch on connection failure. May cause duplicate executions.
+Core struct: `redis::cluster_async::PipelineRetryStrategy` (vendored, `glide-core/redis-rs/redis/src/cluster_async/mod.rs`).
 
-MOVED/ASK redirections always handled automatically regardless of retry config.
+- **`retry_server_error`** - retry commands failing with retriable errors (e.g., TRYAGAIN). May cause out-of-order execution.
+- **`retry_connection_error`** - retry the entire batch on connection failure. May cause duplicate executions.
+
+Wrapper APIs surface these under language-native names (`retryServerError` in Node/Java, `retry_server_error` in Python/Rust, `RetryServerError` in Go).
+
+MOVED/ASK redirections are always handled automatically regardless of retry config.
 
 ## Read-Only Mode (GLIDE 2.3)
 

--- a/skills/glide-dev/skills/glide-dev/reference/core-architecture.md
+++ b/skills/glide-dev/skills/glide-dev/reference/core-architecture.md
@@ -139,7 +139,7 @@ Wrapper (same process)  <--UDS-->  socket_listener  -->  glide-core
 
 **UDS here is in-process IPC, not a network connection.** The wrapper and the Rust core run in the same process - the Unix socket is just a message-passing channel between the language layer and the Rust Tokio runtime. The core is not a separate process.
 
-`socket_listener.rs` builds the socket path as `{UNIX_SOCKER_DIR}/{SOCKET_FILE_NAME}-{pid}-{uuid}.sock`. The PID is included so the name stays unique in Docker containers where PIDs can be reused. Requests are protobuf-encoded `CommandRequest` messages framed by varint length prefixes. `RotatingBuffer::new(65_536)` handles framing.
+`socket_listener.rs` builds the socket path as `{UNIX_SOCKER_DIR}/{SOCKET_FILE_NAME}-{pid}-{uuid}.sock` (yes, `UNIX_SOCKER_DIR` is the verbatim constant name in upstream source - typo preserved; its value is `"/tmp"`). The PID is included so the name stays unique in Docker containers where PIDs can be reused. Requests are protobuf-encoded `CommandRequest` messages framed by varint length prefixes. `RotatingBuffer::new(65_536)` handles framing.
 
 Key constants (verified in `socket_listener.rs`):
 - `SOCKET_FILE_NAME = "glide-socket"`

--- a/skills/glide-dev/skills/glide-dev/reference/core-architecture.md
+++ b/skills/glide-dev/skills/glide-dev/reference/core-architecture.md
@@ -2,18 +2,6 @@
 
 Use when understanding the Rust core design, three-layer architecture, FFI mechanisms per language, the module structure, command flow, runtime model, or debugging connection/protocol issues.
 
-## Contents
-
-- Three-Layer Design (line 17)
-- Request Pipeline (line 37)
-- Module Structure (line 73)
-- Key Structs and Types (line 92)
-- FFI Mechanisms by Language (line 139)
-- Runtime Model (line 183)
-- Command Flow (line 199)
-- Dependencies (line 213)
-- Version History (line 220)
-
 ## Three-Layer Design
 
 ```
@@ -54,13 +42,16 @@ Key types: `CommandRequest`, `Response`, `ClosingReason`, `RotatingBuffer`
 
 ### Client (`glide-core/src/client/mod.rs`)
 
-The client manages connections and command execution:
-- **Standalone**: single connection or primary+replicas
-- **Cluster**: connection pool per node, slot-based routing
+The client manages connections and command execution. Two distinct implementations, not a pool hierarchy:
+
+- **Standalone** (`StandaloneClient` in `client/standalone_client.rs`): GLIDE's own code. Single multiplexed connection, or primary + replicas.
+- **Cluster** (`ClusterConnection` from vendored `redis::cluster_async`): separate implementation with slot-based routing, maintained as a vendored fork in `glide-core/redis-rs/`.
+
+`ClientWrapper` is an enum - `Standalone(StandaloneClient)` and `Cluster { client: ClusterConnection }` are two different animals. Cluster is not a pool of standalones.
 
 Key components:
-- `ClientWrapper` - holds the underlying redis-rs client
-- `reconnecting_connection` - auto-reconnect with backoff
+- `ClientWrapper` - enum dispatching to standalone or cluster
+- `reconnecting_connection` - GLIDE-owned auto-reconnect state machine with backoff
 - `value_conversion` - converts redis-rs `Value` to protobuf `Response`
 
 ### Protobuf IPC (`glide-core/src/protobuf/`)
@@ -143,14 +134,16 @@ Two distinct communication paths:
 ### Socket IPC Path (Python async, Node.js)
 
 ```
-Wrapper  -->  Unix Domain Socket  -->  socket_listener  -->  glide-core
+Wrapper (same process)  <--UDS-->  socket_listener  -->  glide-core
 ```
 
-The `socket_listener.rs` creates a Unix socket at `/tmp/glide-socket-{uuid}`. Requests are Protobuf-encoded `CommandRequest` messages framed by varint length prefixes. The `RotatingBuffer` (initial size 65,536 bytes) handles efficient message framing.
+**UDS here is in-process IPC, not a network connection.** The wrapper and the Rust core run in the same process - the Unix socket is just a message-passing channel between the language layer and the Rust Tokio runtime. The core is not a separate process.
 
-Key constants:
-- `SOCKET_FILE_NAME`: `"glide-socket"`
-- `MAX_REQUEST_ARGS_LENGTH`: 4096 (2^12) - threshold for inline vs pointer arg pass
+`socket_listener.rs` builds the socket path as `{UNIX_SOCKER_DIR}/{SOCKET_FILE_NAME}-{pid}-{uuid}.sock`. The PID is included so the name stays unique in Docker containers where PIDs can be reused. Requests are protobuf-encoded `CommandRequest` messages framed by varint length prefixes. `RotatingBuffer::new(65_536)` handles framing.
+
+Key constants (verified in `socket_listener.rs`):
+- `SOCKET_FILE_NAME = "glide-socket"`
+- `MAX_REQUEST_ARGS_LENGTH = 2_i32.pow(12) = 4096` (source has TODO "find the right number")
 
 ### Direct FFI Path (Java, Go, Python sync, PHP, C#)
 
@@ -176,7 +169,7 @@ No socket involved - direct function calls through the language's FFI.
 
 **Node.js** - `node/rust-client/src/lib.rs` uses `#[napi]` macro, socket listener path. Exports constants: `DEFAULT_REQUEST_TIMEOUT_IN_MILLISECONDS`, `DEFAULT_CONNECTION_TIMEOUT_IN_MILLISECONDS`, `DEFAULT_INFLIGHT_REQUESTS_LIMIT`.
 
-**Java** - `java/src/lib.rs` uses JNI. Migrated from UDS+Protobuf to direct JNI in GLIDE 2.2 (Windows support). Includes own `process_command_for_compression` outside socket listener path.
+**Java** - `java/src/lib.rs` uses JNI. Migrated from UDS+Protobuf to direct JNI for Windows support. Entry points are `Java_glide_ffi_resolvers_*` + `Java_glide_internal_GlideNativeBridge_createClient`; protobuf is still used for command encoding across the JNI boundary (see `java/src/protobuf_bridge.rs`). Compression runs through the shared `process_command_for_compression` path in `glide-core/src/socket_listener.rs` - Java does NOT have its own copy.
 
 **Go and Python Sync** - `ffi/src/lib.rs` provides C-compatible API with `extern "C"` functions. Go uses CGO with cbindgen headers, Python sync uses CFFI. `#[repr(C)]` structs for cross-language compatibility.
 
@@ -212,18 +205,7 @@ pub struct GlideRt {
 
 ## Dependencies
 
-- `redis` crate (vendored/forked) - low-level RESP protocol, cluster routing
-- `tokio` - async runtime
-- `protobuf` - IPC serialization
-- `telemetrylib` - OpenTelemetry integration
-
-## Version History
-
-| Version | Date | Key Architectural Changes |
-|---------|------|---------------------------|
-| 1.2 | Dec 2024 | AZ-aware routing, Vector Search + JSON module support |
-| 1.3 | Feb 2025 | Go client preview |
-| 2.0 | Jun 2025 | Go GA, OpenTelemetry, Batch API (replacing Transaction), Lazy Connection |
-| 2.1 | Sep 2025 | Valkey 9 support, Python Sync API, Jedis compatibility layer |
-| 2.2 | Nov 2025 | Java JNI migration (Windows support), IAM auth, Seed-based topology refresh |
-| 2.3 | Mar 2026 | Dynamic PubSub, mTLS, Java 8 compat, uber JAR, read-only mode |
+- `redis` - vendored fork at `glide-core/redis-rs/`. Low-level RESP, cluster routing, slot map, `MultiplexedConnection`, `ClusterConnection`. Inheritance: not every function reachable from the tree is actually wired by GLIDE - trace callers from `glide-core/src/**` before claiming behavior.
+- `tokio` - single-threaded runtime on a dedicated OS thread (`"glide-runtime-thread"`).
+- `protobuf` - IPC serialization for the UDS path; also used inside JNI on Java.
+- `telemetrylib` - OpenTelemetry integration (exports `GlideOpenTelemetry` + builder types from `lib.rs`).

--- a/skills/glide-dev/skills/glide-dev/reference/pubsub-internals.md
+++ b/skills/glide-dev/skills/glide-dev/reference/pubsub-internals.md
@@ -55,11 +55,11 @@ When cluster topology changes (slot migration, node failure):
 
 ## Key Design Decisions
 
-- `Weak<TokioRwLock<ClientWrapper>>` for the client reference - avoids circular refs and memory leaks
-- `OnceCell` for late initialization - the client is set after construction
+- `OnceCell<Weak<TokioRwLock<ClientWrapper>>>` for the client reference - weak avoids circular refs, `OnceCell::set` enforces one-shot late init (see comment in `pubsub/mod.rs`).
 - `Notify` primitives for efficient wake-up - no polling overhead
-- `PubSubCommandApplier` trait - abstracts command execution for testability (see `mock.rs`)
-- Separate `desired` vs `current` state prevents subscription drift
+- `PubSubCommandApplier` trait - defined in `client/mod.rs`, implemented for `ClientWrapper`. Abstracts how subscription commands get dispatched; used by the synchronizer to send SUBSCRIBE/UNSUBSCRIBE without knowing cluster vs standalone specifics.
+- Test mock: `MockPubSubSynchronizer` in `pubsub/mock.rs` mocks the whole `PubSubSynchronizer` trait (not `PubSubCommandApplier`) for unit testing higher layers without a real client.
+- Separate `desired` vs `current` state prevents subscription drift.
 
 ## Files
 


### PR DESCRIPTION
## Summary

Two-pass validation of `glide-dev` against Valkey GLIDE `v2.3.1` (commit `9601a7695`). Fixes real fabrications in the core description, adds maintainer-flagged grep hazards, and consolidates accumulated skill-writing rules into `CLAUDE.md` so they persist across the repo.

- 6 reference files, 677 -> 725 lines (grew because grep hazards + cluster rewrite replaced invented content with verified content)
- Version bump 1.0.0 -> 1.1.0

## Pass-1 fixes (general source verification)

- Dropped pool-language creep in 4 places: `SKILL.md` tree comment, `cluster-internals.md` "Connection Pool" section, `core-architecture.md` "Cluster: connection pool per node". GLIDE is a multiplexer; cluster and standalone are distinct `ClientWrapper` enum variants, not a pool of standalones.
- Corrected socket path to `{UNIX_SOCKER_DIR}/glide-socket-{pid}-{uuid}.sock` (not `/tmp/glide-socket-{uuid}` - PID included for Docker PID reuse per the source comment).
- Clarified UDS is in-process IPC between language layer and Rust runtime, not a network connection to a separate process.
- Distinguished vendored `glide-core/redis-rs/` from real GLIDE code in `glide-core/src/`. This is the #1 source of "dead inherited code" mistakes when agents describe behavior.
- Replaced fabricated cluster "Connection Pool" section (min/max connections, health PING) with the real `redis::cluster_async::ClusterConnection` + `redis::cluster_slotmap::SlotMap` + `redis::cluster_routing::RoutingInfo` flow.
- Corrected routing source: `redis::cluster_routing::RoutingInfo`, NOT `request_type.rs` (which is just a command-name -> enum mapping).
- Dropped decay-prone version-history table and stale line-number TOC from `core-architecture.md`.
- Rewrote `build-and-test.md` around the canonical top-level `Makefile` (`make all`, `make python-test`, etc.) and `python3 dev.py` for Python, matching source `AGENTS.md`.

## Pass-2 fixes (targeted correctness audit - bugs pass 1 missed)

- **Java `process_command_for_compression` duplicate (fabrication)**: skill claimed Java had its own copy "outside socket listener path". That function exists ONLY in `glide-core/src/socket_listener.rs`. `java/src/lib.rs` has zero hits. Java's compression runs through the shared core path. Fixed to describe Java's actual JNI entry-point structure (`Java_glide_ffi_resolvers_*` + `GlideNativeBridge_createClient`) and `protobuf_bridge.rs`.
- **Batch retry field naming (camelCase drift)**: skill used `retryServerError` / `retryConnectionError` in a section describing the core Rust struct. Actual fields on `redis::cluster_async::PipelineRetryStrategy` are snake_case: `retry_server_error` / `retry_connection_error`. Fixed and added wrapper-API mapping note.
- **`PubSubCommandApplier` / `mock.rs` wording**: skill implied `mock.rs` mocks the applier trait. Actually `PubSubCommandApplier` is implemented for `ClientWrapper`; `mock.rs` mocks the higher `PubSubSynchronizer` trait. Clarified.

## SKILL.md grep-hazards block (maintainer-flagged)

Seven recurring agent mistakes now documented up-front so every future core change starts from the right mental model:

1. GLIDE is a multiplexer, not a connection pool (`DEFAULT_MAX_INFLIGHT_REQUESTS=1000` is inflight cap, not pool size)
2. Cluster client is NOT a pool of standalone clients; `ClientWrapper` is an enum, not a wrapper hierarchy
3. `glide-core/redis-rs/` is vendored redis-rs, NOT GLIDE - trace callers from `glide-core/src/**`
4. UDS is in-process IPC between language layer and Rust runtime
5. HA/reliability AND performance are both top priorities - neither is risked; HA arbitrates first only when a tradeoff forces a choice
6. Cross-language blast radius: `glide-core/` or `ffi/` changes affect every wrapper and both FFI modes
7. Routing lives in `redis::cluster_routing`, not `request_type.rs`

## CLAUDE.md - accumulated skill-writing rules

Added a "Skill-Writing Rules" section covering audience model, cut-without-regret list, no-line-numbers, grep-hazard priority, 2-pass validation discipline, per-skill baseline targeting, fabrication-response protocol, and the 7 GLIDE-specific correctness rules. These were learned across valkey, valkey-dev, valkey-ops, valkey-bloom-dev, valkey-search-dev, and glide-dev - now in one place so they apply to every future skill edit in this repo (including the 7 per-language glides and 7 migration skills still to validate).

## Verified against v2.3.1 source (commit 9601a7695)

Constants:
- `DEFAULT_MAX_INFLIGHT_REQUESTS = 1000`, `DEFAULT_RESPONSE_TIMEOUT = 250ms`, `DEFAULT_CONNECTION_TIMEOUT = 2000ms` + 500ms client-creation buffer
- `DEFAULT_RETRIES = 3`, `HEARTBEAT_SLEEP_DURATION = 1s`, `CONNECTION_CHECKS_INTERVAL = 3s`
- `DEFAULT_PERIODIC_TOPOLOGY_CHECKS_INTERVAL = 60s`, `DEFAULT_RECONCILIATION_INTERVAL = 3s`
- `BLOCKING_CMD_TIMEOUT_EXTENSION = 0.5` (seconds)
- `SOCKET_FILE_NAME = "glide-socket"`, `MAX_REQUEST_ARGS_LENGTH = 2^12 = 4096`
- `RotatingBuffer::new(65_536)`
- `DEFAULT_REQUEST_TIMEOUT_IN_MILLISECONDS`, `DEFAULT_CONNECTION_TIMEOUT_IN_MILLISECONDS`, `DEFAULT_INFLIGHT_REQUESTS_LIMIT`, `MAX_REQUEST_ARGS_LEN` in `node/rust-client/src/lib.rs`

Types and enums:
- `ClientWrapper` 3 variants: `Standalone(StandaloneClient)`, `Cluster { client: ClusterConnection }`, `Lazy(Box<LazyClient>)`
- `ConnectionState` 3 variants: `Connected(MultiplexedConnection)`, `Reconnecting`, `InitializedDisconnected`
- Permanent errors (never retried on initial connect): `AuthenticationFailed | InvalidClientConfig | RESP3NotSupported` plus strings matching `NOAUTH` / `WRONGPASS`
- `read_only` protobuf field 26 in `connection_request.proto`
- `standalone_heartbeat` feature flag in `Cargo.toml`
- Runtime: `Builder::new_current_thread()` single-threaded on OS thread `"glide-runtime-thread"`

Verified file paths:
- `python/glide-async/python/glide/async_commands/` with `CoreCommands(Protocol)` class
- `python/glide-sync/glide_sync/sync_commands/` (core, cluster_commands, ft.py for search)
- `go/internal/interfaces/` with 19 per-data-type interface files, implementations in `go/base_client.go`
- `node/rust-client/src/lib.rs` uses `#[napi]` macro
- `java/src/lib.rs` has `Java_glide_ffi_resolvers_*` + `Java_glide_internal_GlideNativeBridge_createClient` entry points
- `glide-core/src/iam/` uses `aws_config` + `aws_sigv4` (ElastiCache / MemoryDB claim accurate)

## Test plan

- [x] All 6 reference files read end-to-end after edits
- [x] Pass 1: general source verification against v2.3.1
- [x] Pass 2: targeted correctness audit - caught 2 real fabrications the first pass missed
- [x] Grep hazards match maintainer's explicit list of recurring agent mistakes
- [x] CLAUDE.md rules consolidated from all prior skill validation sessions
- [ ] Ecosystem reviewers (Copilot, Claude, Gemini, Codex)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only, but they alter contributor guidance around core routing/FFI/cluster behavior so factual correctness matters for downstream edits.
> 
> **Overview**
> Refreshes `glide-dev` docs and bumps the skill version to `1.1.0`, with a new upfront **"grep hazards"** section in `SKILL.md` to prevent recurring misconceptions (multiplexer vs pool, cluster vs standalone, vendored `glide-core/redis-rs/`, UDS IPC semantics, routing location).
> 
> Rewrites key reference docs to remove fabricated/decay-prone content and align descriptions with source-verified behavior: `cluster-internals.md` (slot map/topology refresh/routing), `core-architecture.md` (FFI paths, socket naming, Java JNI notes; removes TOC/version history), `connection-internals.md` (retry strategy field names + wrapper mappings), `build-and-test.md` (canonical `Makefile` + per-language commands), and `pubsub-internals.md` (trait/mock clarifications).
> 
> Adds repo-wide **Skill-Writing Rules** to `CLAUDE.md` (validation discipline, no line-number citations, baseline targeting, and GLIDE-specific correctness rules) to apply across future skill edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e03e4bd1729d2aa540ec7a40f67f1509c20ccc7d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->