### PR TITLE
python + migrate-redis-py: validate against v2.3.1, apply divergence-only lens

### DIFF
--- a/docs/SKILL_WRITING_RULES.md
+++ b/docs/SKILL_WRITING_RULES.md
@@ -43,8 +43,8 @@ The content that belongs in per-language glides (`valkey-glide-python`, `-java`,
    - `FT.` and other Valkey module commands through GLIDE
 
 3. **Cross-cutting behaviors maintainers keep correcting.** These recur because agents pattern-match from the legacy client:
-   - Multiplexer rule: one GLIDE client is shared across all async code in a process, concurrency is cheap. BUT blocking commands (BLPOP, BRPOP, BLMOVE, BZPOPMAX, etc.) occupy the multiplexed connection - they need a separate client.
-   - WATCH / MULTI / EXEC optimistic locking needs an isolated client (same occupancy reason).
+   - Multiplexer rule: one GLIDE client is shared across all async code in a process, concurrency is cheap. BUT blocking commands (BLPOP, BRPOP, BLMOVE, BZPOPMAX, BZPOPMIN, BRPOPLPUSH, BLMPOP, BZMPOP, XREAD/XREADGROUP with BLOCK, WAIT, WAITAOF) occupy the multiplexed connection - they need a separate client.
+   - WATCH / MULTI / EXEC optimistic locking needs an isolated client - connection-state leakage on a shared multiplexer, not occupancy.
    - Connection-state preservation across reconnect (DB ID, credentials, CLIENT SETNAME, protocol version).
    - HA/reliability and performance are both non-negotiable - never ship a change that regresses either.
    - Platform constraints: glibc 2.17+ (no Alpine), protobuf pin for Python, JVM version floors, Node.js ABI.

--- a/docs/SKILL_WRITING_RULES.md
+++ b/docs/SKILL_WRITING_RULES.md
@@ -2,18 +2,62 @@
 
 Rules learned while validating valkey, valkey-dev, valkey-ops, valkey-bloom-dev, valkey-search-dev, and glide-dev against source. Apply to every skill edit in this repo.
 
-## Audience: agents already trained on the ecosystem baseline
+## Audience: agents already trained on the ecosystem AND standard client libraries
 
-A trained LLM already knows standard Redis/Valkey structures, stock RESP, stock cmake, `processCommand -> call -> cmd->proc`, jemalloc defaults. Same for Rust/Cargo basics, PyO3/NAPI/JNI mechanics, standard Tokio runtime patterns. Restating these burns context.
+A trained LLM already knows standard Redis/Valkey server structures (stock RESP, `processCommand -> call -> cmd->proc`, jemalloc defaults, Rust/Cargo basics, PyO3/NAPI/JNI mechanics, Tokio patterns). It also already knows how to write basic redis-py, jedis, ioredis, go-redis, StackExchange.Redis, phpredis, redis-rb from training alone - get/set/hget/zadd/subscribe signatures, connection-pool builders, standard TLS config. Restating any of this burns context for zero value.
 
 Only write:
 
-1. **Divergence** - where this component behaves differently from the baseline an agent already knows.
-2. **Novel subsystems** - net-new files, ABIs, or mechanisms that don't exist in the baseline.
-3. **Non-obvious invariants / gotchas** - ownership rules, aliasing, hidden state, pausepoint discipline.
+1. **Divergence** - where GLIDE or Valkey behaves differently from the baseline an agent already knows.
+2. **Novel subsystems or features** - net-new files, ABIs, mechanisms, or client features that don't exist in the baseline.
+3. **Non-obvious invariants / gotchas** - ownership rules, aliasing, hidden state, pausepoint discipline, maintainer-flagged recurring mistakes.
 4. **Non-standard pieces** - JSON-generated code, TCL-plus-sanitizer test frameworks, vendored forks.
 
 POC test before writing any line: "would a trained agent know this if asked?" If yes, cut.
+
+## Per-language glide and migration skills: the API overlap is not the content
+
+**Maintainer rule (Avi, 2026-04-18):** "Where the API is the same, that's not interesting. Models know to write redis-py without docs. Question is where they differ - this is where models are wrong - and what GLIDE specifically needs you to know that is not in compare."
+
+The content that belongs in per-language glides (`valkey-glide-python`, `-java`, `-nodejs`, `-go`, `-csharp`, `-php`, `-ruby`) and migration skills (`migrate-redis-py`, `migrate-jedis`, `migrate-lettuce`, `migrate-ioredis`, `migrate-go-redis`, `migrate-stackexchange`, `spring-data-valkey`):
+
+### Keep
+
+1. **Divergence from the baseline client.** Where GLIDE differs from the redis-py / jedis / ioredis / go-redis / StackExchange.Redis the agent already knows. Examples:
+   - Bytes always returned (no `decode_responses` or equivalent)
+   - List args vs varargs for multi-key commands
+   - Timeout unit change (seconds -> milliseconds)
+   - Async-first primary API
+   - No connection-pool tuning (GLIDE is a multiplexer)
+   - Cluster topology auto-managed
+
+2. **GLIDE-only features with no baseline analogue.** These cannot be derived from training:
+   - IAM token refresh for ElastiCache / MemoryDB
+   - AZ affinity routing (`AZAffinity`, `AZAffinityReplicasAndPrimary`)
+   - OpenTelemetry integration and span wiring
+   - Built-in Zstd / LZ4 compression
+   - Lazy-connect semantics (`LazyClient` until first command)
+   - Read-only mode (`read_only`, skips primary discovery)
+   - Batch API retry strategies (`retry_server_error`, `retry_connection_error`)
+   - Cluster SCAN iterator with cursor lifecycle
+   - `FT.` and other Valkey module commands through GLIDE
+
+3. **Cross-cutting behaviors maintainers keep correcting.** These recur because agents pattern-match from the legacy client:
+   - Multiplexer rule: one GLIDE client is shared across all async code in a process, concurrency is cheap. BUT blocking commands (BLPOP, BRPOP, BLMOVE, BZPOPMAX, etc.) occupy the multiplexed connection - they need a separate client.
+   - WATCH / MULTI / EXEC optimistic locking needs an isolated client (same occupancy reason).
+   - Connection-state preservation across reconnect (DB ID, credentials, CLIENT SETNAME, protocol version).
+   - HA/reliability and performance are both non-negotiable - never ship a change that regresses either.
+   - Platform constraints: glibc 2.17+ (no Alpine), protobuf pin for Python, JVM version floors, Node.js ABI.
+
+### Cut aggressively
+
+- Command-by-command tables that mirror the baseline API 1:1 (MGET -> mget, HGET -> hget) except where GLIDE's signature actually differs
+- Generic "here's how to create a client" examples the agent can write from training
+- Language-idiomatic explanations (what `asyncio.gather` is, what `CompletableFuture` is)
+- "Run the tests" boilerplate
+- Library-version changelogs in reference files (decay fast)
+
+Goal: a contributor or migrating user reading the skill learns things they cannot derive from training on the baseline client alone.
 
 ## Cut without regret
 

--- a/skills/migrate-redis-py/.claude-plugin/plugin.json
+++ b/skills/migrate-redis-py/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-redis-py",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use when migrating Python from redis-py to Valkey GLIDE. Covers async-first API, bytes returns (no decode_responses), list args, PubSub, ExpirySet/ConditionalChange. Not for greenfield Python apps - use valkey-glide-python instead.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/migrate-redis-py/skills/migrate-redis-py/SKILL.md
+++ b/skills/migrate-redis-py/skills/migrate-redis-py/SKILL.md
@@ -18,7 +18,7 @@ Use when moving an existing redis-py application to GLIDE. Assumes you already k
 | Multi-arg commands | Varargs: `r.delete("k1", "k2")` | List args: `await client.delete(["k1", "k2"])` |
 | SET expiry/conditional | Kwargs `ex=60`, `nx=True` | Typed `ExpirySet(ExpiryType.SEC, 60)`, `ConditionalChange.ONLY_IF_DOES_NOT_EXIST` |
 | ZRANGE variants | `withscores=True` kwarg | Separate method `zrange_withscores`; typed `RangeByIndex` / `RangeByScore` / `RangeByLex` |
-| Pipeline | `pipe = r.pipeline(); pipe.execute()` | `Batch(is_atomic=False)` run via the client's batch method |
+| Pipeline | `pipe = r.pipeline(); pipe.execute()` | `batch = Batch(is_atomic=False); await client.exec(batch, raise_on_error=...)` - verb is a client method, not the batch |
 | Transaction | `r.pipeline(transaction=True)` | `Batch(is_atomic=True)` - same class, flag-selected |
 | Connection pool | `max_connections=N` | Multiplexer - no pool knob; one client per process |
 | Blocking commands | Share the pool | Occupy the single connection - use a dedicated client |

--- a/skills/migrate-redis-py/skills/migrate-redis-py/SKILL.md
+++ b/skills/migrate-redis-py/skills/migrate-redis-py/SKILL.md
@@ -24,6 +24,7 @@ Use when moving an existing redis-py application to GLIDE. Assumes you already k
 | Blocking commands | Share the pool | Occupy the single connection - use a dedicated client |
 | Cluster | `redis.RedisCluster(skip_full_coverage_check=...)` | `GlideClusterClient` with auto-topology discovery |
 | PubSub | `p = r.pubsub(); p.subscribe(...)`; `p.listen()` | Static config OR dynamic `subscribe()` (2.3+); callback OR polling |
+| `publish` | `r.publish(channel, message)` | `await client.publish(message, channel)` - **arguments REVERSED**; top silent-bug source in migration |
 | `decode_responses` | Kwarg | No equivalent - handle bytes at boundary |
 | `socket_timeout` | Seconds float | `request_timeout` milliseconds int |
 | `retry_on_timeout` | Bool | `reconnect_strategy=BackoffStrategy(...)` |
@@ -85,6 +86,7 @@ Big-bang migration trips on bytes-vs-str, blocking-command semantics, WATCH, and
 8. **PubSub static subscriptions require RESP3** - `ConfigurationError` otherwise.
 9. **`TimeoutError` / `ConnectionError` shadow Python built-ins** - import with aliases.
 10. **Reconnection is infinite** - `BackoffStrategy.num_of_retries` only caps the backoff sequence length.
+11. **`publish()` argument order is REVERSED** - GLIDE is `publish(message, channel)`, redis-py is `publish(channel, message)`. Silent bug during migration.
 
 ## Cross-references
 

--- a/skills/migrate-redis-py/skills/migrate-redis-py/SKILL.md
+++ b/skills/migrate-redis-py/skills/migrate-redis-py/SKILL.md
@@ -1,98 +1,92 @@
 ---
 name: migrate-redis-py
-description: "Use when migrating Python from redis-py to Valkey GLIDE. Covers async-first API, bytes returns (no decode_responses), list args, PubSub, ExpirySet/ConditionalChange. Not for greenfield Python apps - use valkey-glide-python instead."
-version: 1.0.0
+description: "Use when migrating Python from redis-py to Valkey GLIDE. Covers API-shape divergences (bytes returns, list args, ExpirySet/ConditionalChange, ZRANGE variants), PubSub mental-model switch, Batch API, platform constraints. Not for greenfield Python apps - use valkey-glide-python instead."
+version: 1.1.0
 argument-hint: "[API or pattern to migrate]"
 ---
 
 # Migrating from redis-py to Valkey GLIDE (Python)
 
-Use when migrating a Python application from redis-py to the GLIDE client library.
+Use when moving an existing redis-py application to GLIDE. Assumes you already know redis-py. Covers what breaks or changes shape; the 95% of commands that translate literally (just `r.` -> `await client.` with bytes returns) are not listed here.
 
-## Routing
-
-- String, hash, list, set, sorted set, delete, exists, cluster -> API Mapping
-- Pipeline, transaction, Batch API -> Advanced Patterns
-- PubSub, subscribe, publish, dynamic subscriptions -> Advanced Patterns
-
-## Key Differences
+## Divergences that actually matter
 
 | Area | redis-py | GLIDE |
 |------|----------|-------|
-| Default mode | Synchronous | Async-first (sync API from GLIDE 2.1) |
-| Return type | Strings (with decode_responses=True) | Bytes always - call .decode() |
-| Multi-arg commands | Varargs: delete("k1", "k2") | List args: delete(["k1", "k2"]) |
-| Expiry | Keyword args: ex=60 | ExpirySet objects |
-| Conditional SET | Separate setnx(), setex() | Enum options on set() |
-| Connection model | Connection pool (default 10 conns) | Single multiplexed connection per node |
-| Cluster client | redis.RedisCluster() | GlideClusterClient with auto-topology |
+| Default mode | Sync | Async-first; sync via `glide_sync` package (GLIDE 2.1+) |
+| Return types | `str` with `decode_responses=True` | `bytes` always - call `.decode()` at each read site |
+| Multi-arg commands | Varargs: `r.delete("k1", "k2")` | List args: `await client.delete(["k1", "k2"])` |
+| SET expiry/conditional | Kwargs `ex=60`, `nx=True` | Typed `ExpirySet(ExpiryType.SEC, 60)`, `ConditionalChange.ONLY_IF_DOES_NOT_EXIST` |
+| ZRANGE variants | `withscores=True` kwarg | Separate method `zrange_withscores`; typed `RangeByIndex` / `RangeByScore` / `RangeByLex` |
+| Pipeline | `pipe = r.pipeline(); pipe.execute()` | `Batch(is_atomic=False)` run via the client's batch method |
+| Transaction | `r.pipeline(transaction=True)` | `Batch(is_atomic=True)` - same class, flag-selected |
+| Connection pool | `max_connections=N` | Multiplexer - no pool knob; one client per process |
+| Blocking commands | Share the pool | Occupy the single connection - use a dedicated client |
+| Cluster | `redis.RedisCluster(skip_full_coverage_check=...)` | `GlideClusterClient` with auto-topology discovery |
+| PubSub | `p = r.pubsub(); p.subscribe(...)`; `p.listen()` | Static config OR dynamic `subscribe()` (2.3+); callback OR polling |
+| `decode_responses` | Kwarg | No equivalent - handle bytes at boundary |
+| `socket_timeout` | Seconds float | `request_timeout` milliseconds int |
+| `retry_on_timeout` | Bool | `reconnect_strategy=BackoffStrategy(...)` |
 
-## Quick Start - Connection Setup
+## Config translation
 
-**redis-py:**
 ```python
-import redis
-r = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
-r.ping()
-```
+# redis-py:
+r = redis.Redis(host="h", port=6379, db=0, password="pw",
+                ssl=True, socket_timeout=5, decode_responses=True)
 
-**GLIDE (async):**
-```python
-from glide import GlideClient, GlideClientConfiguration, NodeAddress
+# GLIDE async:
+from glide import (
+    GlideClient, GlideClientConfiguration, NodeAddress,
+    ServerCredentials,
+)
 config = GlideClientConfiguration(
-    addresses=[NodeAddress("localhost", 6379)], database_id=0, request_timeout=5000)
+    addresses=[NodeAddress("h", 6379)],
+    database_id=0,
+    credentials=ServerCredentials(password="pw"),
+    use_tls=True,
+    request_timeout=5000,  # ms not seconds
+)
 client = await GlideClient.create(config)
-await client.ping()
-```
 
-**GLIDE (sync - 2.1+):**
-```python
+# GLIDE sync (2.1+):
 from glide_sync import GlideClient, GlideClientConfiguration, NodeAddress
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("localhost", 6379)], database_id=0)
-client = GlideClient.create(config)
-client.ping()
+client = GlideClient.create(config)  # no await
 ```
 
-## Configuration Mapping
+## Migration strategy
 
-| redis-py parameter | GLIDE equivalent |
-|--------------------|------------------|
-| host, port | NodeAddress(host, port) in addresses list |
-| db | database_id |
-| password | ServerCredentials(password=...) in credentials |
-| username | ServerCredentials(username=..., password=...) |
-| socket_timeout | request_timeout (milliseconds, not seconds) |
-| ssl=True | use_tls=True |
-| retry_on_timeout | Built-in reconnection with BackoffStrategy |
-| decode_responses | No equivalent - always returns bytes |
+No compatibility layer exists for Python (unlike Java's jedis compat layer). Migrate incrementally via an adapter:
 
-## Incremental Migration Strategy
+1. Install `valkey-glide` alongside `redis-py`.
+2. Build a thin adapter covering every `r.*` call in your app.
+3. Start with the GLIDE side of the adapter implemented command-by-command.
+4. Swap services to the GLIDE adapter behind a feature flag.
+5. Remove `redis-py` only after every call site is migrated and canaried.
 
-No drop-in replacement or compatibility layer exists for Python. Migration approach:
-
-1. Install `valkey-glide` alongside `redis-py`
-2. Create a wrapper/adapter that abstracts the client interface
-3. Migrate command-by-command behind the adapter
-4. Use `asyncio.gather()` or the Batch API for bulk operations
-5. Swap out the adapter once all commands are migrated
-6. Remove `redis-py` dependency
+Big-bang migration trips on bytes-vs-str, blocking-command semantics, WATCH, and timeout unit changes.
 
 ## Reference
 
 | Topic | File |
 |-------|------|
-| Command-by-command API mapping (strings, hashes, lists, sets, sorted sets, delete, exists, cluster) | [api-mapping](reference/api-mapping.md) |
-| Pipelines, transactions, Pub/Sub, platform notes | [advanced-patterns](reference/advanced-patterns.md) |
+| Three universal changes (bytes, await, list args), SET typed options, HSET mapping, ZRANGE variants, cluster | [api-mapping](reference/api-mapping.md) |
+| PubSub mental-model switch, Batch API, migration strategy, platform notes | [advanced-patterns](reference/advanced-patterns.md) |
 
-## Gotchas
+## Gotchas (the short list)
 
-1. **Bytes everywhere.** GLIDE has no decode_responses option. All string values return as bytes. Call .decode() at each read site.
-2. **List arguments.** Commands like delete, exists, lpush, sadd take a list, not varargs.
-3. **No connection pool tuning.** GLIDE uses a single multiplexed connection per node.
-4. **Async by default.** The primary API is async. The sync wrapper (glide_sync) is available from GLIDE 2.1.
-5. **Timeout units.** redis-py uses seconds (float). GLIDE uses milliseconds (int). Default is 250ms.
-6. **No decode_responses shortcut.** Add .decode() calls at each read site, or build a thin wrapper.
-7. **Protobuf dependency conflict.** Requires `protobuf>=3.20` - pin versions carefully.
-8. **Alpine Linux not supported.** GLIDE requires glibc 2.17+ - use Debian-based container images.
-9. **Proxy incompatibility.** GLIDE runs INFO REPLICATION and CLIENT commands during connection setup.
+1. **Bytes everywhere** - no `decode_responses` option.
+2. **Timeout units** - `request_timeout` is milliseconds (default 250 ms), redis-py `socket_timeout` is seconds.
+3. **No connection pool** - single multiplexer per process; blocking commands (`BLPOP`, `BRPOP`, `BLMOVE`, `BZPOPMAX`/`MIN`, `BRPOPLPUSH`, `BLMPOP`, `BZMPOP`, `XREAD`/`XREADGROUP` with `BLOCK`) and WATCH/MULTI/EXEC need a dedicated client.
+4. **Async by default** - sync via `glide_sync` from 2.1+.
+5. **`protobuf>=3.20`** required - conflicts surface as import errors.
+6. **Alpine not supported** - glibc 2.17+ required.
+7. **Proxy incompatibility** - GLIDE sends `INFO REPLICATION`, `CLIENT SETINFO`, `CLIENT SETNAME` at connect; strict proxies break this.
+8. **PubSub static subscriptions require RESP3** - `ConfigurationError` otherwise.
+9. **`TimeoutError` / `ConnectionError` shadow Python built-ins** - import with aliases.
+10. **Reconnection is infinite** - `BackoffStrategy.num_of_retries` only caps the backoff sequence length.
+
+## Cross-references
+
+- `valkey-glide-python` - full Python skill for GLIDE features beyond the migration scope
+- `glide-dev` - GLIDE core internals if you need to debug binding-level issues

--- a/skills/migrate-redis-py/skills/migrate-redis-py/reference/advanced-patterns.md
+++ b/skills/migrate-redis-py/skills/migrate-redis-py/reference/advanced-patterns.md
@@ -66,7 +66,7 @@ Same two concepts, one class, different verb on execution:
 |----------|-------|
 | `pipe = r.pipeline(transaction=False)` | `pipe = Batch(is_atomic=False)` |
 | `tx = r.pipeline(transaction=True)` | `tx = Batch(is_atomic=True)` |
-| `pipe.execute()` | `await client .exec(pipe, raise_on_error=...)` - verb is a client method |
+| `pipe.execute()` | `await client.exec(pipe, raise_on_error=...)` - verb is a client method |
 | Error behavior implicit per-command | Explicit `raise_on_error=True` raises on first error; `False` puts `RequestError` inline in the result list |
 | Cluster: you split by slot manually | `ClusterBatch(is_atomic=False)` splits per-slot automatically |
 | WATCH before `pipe.multi()` | WATCH needs a dedicated client (multiplexer leakage); atomic execution returns `None` on WATCH conflict |

--- a/skills/migrate-redis-py/skills/migrate-redis-py/reference/advanced-patterns.md
+++ b/skills/migrate-redis-py/skills/migrate-redis-py/reference/advanced-patterns.md
@@ -1,30 +1,26 @@
-# redis-py to GLIDE Advanced Patterns
+# redis-py to GLIDE: migration patterns
 
-Use when migrating redis-py Pub/Sub, pipelines, transactions, or handling platform-specific deployment concerns.
+Use when translating redis-py Pub/Sub loops, pipelines, or handling platform-specific migration concerns.
 
-## Pub/Sub
+## Pub/Sub: the whole mental model changes
 
-**redis-py:**
+redis-py's pattern is a runtime `p = r.pubsub()` object with a `listen()` generator. GLIDE replaces this with two different approaches.
+
+### Path A - static subscriptions (any GLIDE version)
+
+Subscriptions are part of the client config - declared up front, applied at connect:
+
 ```python
-p = r.pubsub()
-p.subscribe("channel")
-p.psubscribe("events:*")
-for message in p.listen():
-    print(message["data"])
-```
-
-**GLIDE (static subscriptions - at client creation):**
-```python
-from glide import GlideClientConfiguration, NodeAddress, PubSubMsg
+from glide import GlideClient, GlideClientConfiguration, NodeAddress, PubSubMsg
 
 def on_message(msg: PubSubMsg, context):
-    print(f"[{msg.channel}] {msg.message} (pattern={msg.pattern})")
+    print(f"[{msg.channel}] {msg.message}")
 
 config = GlideClientConfiguration(
     addresses=[NodeAddress("localhost", 6379)],
     pubsub_subscriptions=GlideClientConfiguration.PubSubSubscriptions(
         channels_and_patterns={
-            GlideClientConfiguration.PubSubChannelModes.Exact: {"channel"},
+            GlideClientConfiguration.PubSubChannelModes.Exact:   {"channel"},
             GlideClientConfiguration.PubSubChannelModes.Pattern: {"events:*"},
         },
         callback=on_message,
@@ -33,84 +29,70 @@ config = GlideClientConfiguration(
 subscriber = await GlideClient.create(config)
 ```
 
-**GLIDE (dynamic subscriptions - GLIDE 2.3+):**
+To skip the callback and poll instead, omit `callback` and use `await subscriber.get_pubsub_message()` (blocking) or `subscriber.try_get_pubsub_message()` (non-blocking, returns `None` when empty). Callback and polling are mutually exclusive on the same client.
+
+**Static subscriptions require RESP3.** Using `protocol=ProtocolVersion.RESP2` raises `ConfigurationError`.
+
+### Path B - dynamic subscriptions (GLIDE 2.3+)
+
+Runtime subscribe / unsubscribe closer to redis-py's shape, with a lazy variant that returns immediately:
+
 ```python
-subscriber = await GlideClient.create(config)
+await subscriber.subscribe({"channel"}, timeout_ms=5000)       # waits for server ack
+await subscriber.subscribe_lazy({"channel"})                    # returns; reconciles async
 
-# Blocking - waits for server confirmation
-await subscriber.subscribe({"channel"}, timeout_ms=5000)
 await subscriber.psubscribe({"events:*"}, timeout_ms=5000)
-
-# Non-blocking - returns immediately, reconciliation happens async
-await subscriber.subscribe_lazy({"channel"})
 await subscriber.psubscribe_lazy({"events:*"})
 
-# Receive messages via polling
-msg = await subscriber.get_pubsub_message()       # async, blocks until message
-msg = subscriber.try_get_pubsub_message()          # non-blocking, returns None if empty
-
-# Unsubscribe
-await subscriber.unsubscribe({"channel"})
-await subscriber.punsubscribe({"events:*"})
-await subscriber.unsubscribe()                     # all exact channels
+await subscriber.unsubscribe({"channel"})     # or unsubscribe() for all
+await subscriber.unsubscribe_lazy()
 ```
 
-GLIDE automatically resubscribes on reconnection. Use a dedicated client for subscriptions - a subscribing client enters a special mode where most regular commands are unavailable. Callback and polling modes are mutually exclusive on the same client.
+Sharded pub/sub on cluster: `ssubscribe` / `ssubscribe_lazy` / `sunsubscribe` (Valkey 7.0+).
+
+### Key divergences from redis-py's pubsub
+
+- The subscribing client does NOT enter a special mode - GLIDE multiplexes subscriptions alongside regular commands on the same client. A dedicated client is still recommended for high-throughput subscribers to avoid head-of-line effects.
+- GLIDE resubscribes automatically on reconnection and topology change via the synchronizer. No manual reconnect handling.
+- Inspect desired-vs-actual with `await client.get_subscriptions()`, track sync health via `get_statistics()` keys `subscription_out_of_sync_count` and `subscription_last_sync_timestamp`.
 
 ---
 
-## Pipelines and Transactions
+## Pipelines and transactions
 
-**redis-py:**
-```python
-# Pipeline
-pipe = r.pipeline(transaction=False)
-pipe.set("k1", "v1")
-pipe.set("k2", "v2")
-pipe.get("k1")
-results = pipe.execute()
+Same two concepts, one class, different verb on execution:
 
-# Transaction
-tx = r.pipeline(transaction=True)
-tx.set("k1", "v1")
-tx.get("k1")
-results = tx.execute()
-```
+| redis-py | GLIDE |
+|----------|-------|
+| `pipe = r.pipeline(transaction=False)` | `pipe = Batch(is_atomic=False)` |
+| `tx = r.pipeline(transaction=True)` | `tx = Batch(is_atomic=True)` |
+| `pipe.execute()` | `await client .exec(pipe, raise_on_error=...)` - verb is a client method |
+| Error behavior implicit per-command | Explicit `raise_on_error=True` raises on first error; `False` puts `RequestError` inline in the result list |
+| Cluster: you split by slot manually | `ClusterBatch(is_atomic=False)` splits per-slot automatically |
+| WATCH before `pipe.multi()` | WATCH needs a dedicated client (multiplexer leakage); atomic execution returns `None` on WATCH conflict |
 
-**GLIDE:**
-```python
-from glide import Batch
-
-# Pipeline (non-atomic)
-pipe = Batch(is_atomic=False)
-pipe.set("k1", "v1")
-pipe.set("k2", "v2")
-pipe.get("k1")
-results = await client.exec(pipe, raise_on_error=False)
-
-# Transaction (atomic)
-tx = Batch(is_atomic=True)
-tx.set("k1", "v1")
-tx.get("k1")
-results = await client.exec(tx, raise_on_error=True)
-```
+Cluster-only option: `ClusterBatchOptions(retry_strategy=BatchRetryStrategy(retry_server_error=..., retry_connection_error=...))`. Only applies to NON-atomic cluster batches.
 
 ---
 
-## Platform Notes
+## Migration strategy
 
-### Protobuf Dependency Conflict
+GLIDE is not a drop-in. Plan for incremental migration:
 
-The async package requires `protobuf>=3.20`, which can conflict with other packages (gRPC stubs, etc.). The sync package (`valkey-glide-sync`) also requires `>=3.20` but has fewer transitive conflicts. Pin protobuf versions carefully.
+1. Install `valkey-glide` alongside `redis-py` - both import, both work.
+2. Build a thin adapter interface that covers every `r.*` call your app makes. Implement the redis-py side first (trivial passthrough).
+3. Implement the GLIDE side of the adapter command-by-command, starting with the hottest paths.
+4. Swap the adapter to GLIDE behind a feature flag per service.
+5. Remove `redis-py` only after every call site has been migrated and canaried.
 
-### Alpine Linux Not Supported
+Big-bang migrations fail on divergences - bytes-vs-str tripping code paths, blocking-command exceptions, WATCH semantics. The adapter pattern lets you translate incrementally while keeping the app runnable.
 
-GLIDE Python requires glibc 2.17+ - MUSL-based distributions like Alpine are not supported. Use Debian-based container images instead.
+---
 
-### Proxy Incompatibility
+## Platform and packaging notes
 
-GLIDE runs `INFO REPLICATION`, `CLIENT SETINFO`, and `CLIENT SETNAME` during connection setup. Proxies like Envoy that do not support these commands will fail at connect time.
-
-### Trio and anyio Support
-
-GLIDE transparently supports asyncio, anyio, and trio as of GLIDE 2.0.1. No special configuration needed.
+- **Protobuf pin**: `protobuf>=3.20` required. Conflicts with other packages pinning older protobuf will surface as import errors. Both `valkey-glide` (async) and `valkey-glide-sync` require this.
+- **Alpine not supported**: glibc 2.17+ required. Use Debian / Ubuntu / RHEL-based container images.
+- **Proxies**: connection setup sends `INFO REPLICATION`, `CLIENT SETINFO`, `CLIENT SETNAME`. Proxies that don't support these break connection.
+- **asyncio / anyio / trio**: transparently supported from GLIDE 2.0.1 onward. No special config.
+- **sync package**: from GLIDE 2.1, `pip install valkey-glide-sync` and `from glide_sync import GlideClient, ...` for synchronous code paths.

--- a/skills/migrate-redis-py/skills/migrate-redis-py/reference/api-mapping.md
+++ b/skills/migrate-redis-py/skills/migrate-redis-py/reference/api-mapping.md
@@ -1,150 +1,77 @@
-# redis-py to GLIDE API Mapping
+# redis-py to GLIDE: where signatures diverge
 
-Use when migrating specific redis-py commands to their GLIDE equivalents, looking up return type differences, or converting data type operations.
+Use when translating redis-py calls and the signature is NOT obvious. Where GLIDE mirrors redis-py 1:1 (most commands), just replace `r.` with `await client.` - that pattern is not listed here.
 
-## String Operations
+## Three universal changes
 
-**redis-py:**
+Apply to every command:
+
+1. **Bytes not str**: all string returns are `bytes`. `.decode()` at each read site.
+2. **Awaitable not blocking** (async API): prefix `await`, use `glide`. For sync use `glide_sync` with no `await`.
+3. **List args not varargs**: multi-key / multi-value commands take a list, not positional args.
+
 ```python
-r.set("key", "value")
-r.set("key", "value", ex=60)          # expire in 60s
-r.set("key", "value", nx=True)        # only if not exists
-r.setnx("key", "value")               # same as nx=True
-r.setex("key", 60, "value")           # set + expire
-val = r.get("key")                     # returns str
-```
-
-**GLIDE:**
-```python
-from glide import ExpirySet, ExpiryType, ConditionalChange
-
-await client.set("key", "value")
-await client.set("key", "value", expiry=ExpirySet(ExpiryType.SEC, 60))
-await client.set("key", "value", conditional_set=ConditionalChange.ONLY_IF_DOES_NOT_EXIST)
-# No separate setnx/setex - use set() with options
-val = await client.get("key")          # returns bytes
-val.decode()                           # "value"
-```
-
----
-
-## Hash Operations
-
-**redis-py:**
-```python
-r.hset("hash", "field1", "value1")
-r.hset("hash", mapping={"f1": "v1", "f2": "v2"})
-val = r.hget("hash", "field1")
-all_vals = r.hgetall("hash")           # {"f1": "v1", "f2": "v2"}
-```
-
-**GLIDE:**
-```python
-await client.hset("hash", {"field1": "value1"})
-await client.hset("hash", {"f1": "v1", "f2": "v2"})
-val = await client.hget("hash", "field1")       # bytes
-all_vals = await client.hgetall("hash")          # {b"f1": b"v1", b"f2": b"v2"}
-```
-
----
-
-## List Operations
-
-**redis-py:**
-```python
+# redis-py varargs:
+r.delete("k1", "k2", "k3")
+r.exists("k1", "k2")
 r.lpush("list", "a", "b", "c")
-r.rpush("list", "x", "y")
-val = r.lpop("list")
-vals = r.lrange("list", 0, -1)
-```
-
-**GLIDE:**
-```python
-await client.lpush("list", ["a", "b", "c"])     # list arg, not varargs
-await client.rpush("list", ["x", "y"])
-val = await client.lpop("list")                  # bytes
-vals = await client.lrange("list", 0, -1)        # list of bytes
-```
-
----
-
-## Set Operations
-
-**redis-py:**
-```python
 r.sadd("set", "a", "b", "c")
-r.srem("set", "a")
-members = r.smembers("set")
-r.sismember("set", "b")
+r.srem("set", "a", "b")
+
+# GLIDE: wrap the extra args in a list:
+await client.delete(["k1", "k2", "k3"])
+await client.exists(["k1", "k2"])
+await client.lpush("list", ["a", "b", "c"])
+await client.sadd("set", ["a", "b", "c"])
+await client.srem("set", ["a", "b"])
 ```
 
-**GLIDE:**
+## SET: typed options replace kwargs
+
+redis-py combines everything on `set()` / has specialized `setnx` / `setex`. GLIDE routes them through typed options and drops the aliases.
+
+| redis-py | GLIDE |
+|----------|-------|
+| `r.set(k, v, ex=60)` | `await client.set(k, v, expiry=ExpirySet(ExpiryType.SEC, 60))` |
+| `r.set(k, v, px=500)` | `await client.set(k, v, expiry=ExpirySet(ExpiryType.MILLSEC, 500))` |
+| `r.set(k, v, exat=ts)` | `await client.set(k, v, expiry=ExpirySet(ExpiryType.UNIX_SEC, ts))` |
+| `r.set(k, v, pxat=ms_ts)` | `await client.set(k, v, expiry=ExpirySet(ExpiryType.UNIX_MILLSEC, ms_ts))` |
+| `r.set(k, v, nx=True)` or `r.setnx(k, v)` | `await client.set(k, v, conditional_set=ConditionalChange.ONLY_IF_DOES_NOT_EXIST)` |
+| `r.set(k, v, xx=True)` | `await client.set(k, v, conditional_set=ConditionalChange.ONLY_IF_EXISTS)` |
+| `r.setex(k, 60, v)` | `await client.set(k, v, expiry=ExpirySet(ExpiryType.SEC, 60))` |
+| `r.set(k, v, keepttl=True)` | `await client.set(k, v, expiry=ExpirySet(ExpiryType.KEEP_TTL))` |
+
+`ExpiryType` has five values: `SEC`, `MILLSEC`, `UNIX_SEC`, `UNIX_MILLSEC`, `KEEP_TTL`. **Note the upstream typo - `MILLSEC` is missing the `I`. Grep for `MILLSEC`, not `MILLISEC`.**
+
+`ConditionalChange` has exactly two values: `ONLY_IF_EXISTS` and `ONLY_IF_DOES_NOT_EXIST`. Valkey 9.0's `IFEQ` is a separate `OnlyIfEqual(comparison_value=...)` dataclass (not part of the `ConditionalChange` enum).
+
+Imports: `from glide import ExpirySet, ExpiryType, ConditionalChange, OnlyIfEqual`.
+
+## HSET: mapping is positional
+
+redis-py accepts `hset(k, "f", "v")` and `hset(k, mapping={...})`. GLIDE drops the two-string form - always pass a dict:
+
 ```python
-await client.sadd("set", ["a", "b", "c"])       # list arg
-await client.srem("set", ["a"])                  # list arg
-members = await client.smembers("set")           # set of bytes
-await client.sismember("set", "b")               # bool
+await client.hset("hash", {"f1": "v1", "f2": "v2"})
 ```
 
----
+## ZRANGE variants: separate methods, not flags
 
-## Sorted Set Operations
+redis-py uses kwargs on one method; GLIDE has separate methods for the withscores variant, and takes typed range objects instead of raw indexes/scores:
 
-**redis-py:**
-```python
-r.zadd("zset", {"alice": 1.0, "bob": 2.0})
-r.zrange("zset", 0, -1, withscores=True)
-r.zscore("zset", "alice")
-```
+| redis-py | GLIDE |
+|----------|-------|
+| `r.zrange(k, 0, -1)` | `await client.zrange(k, RangeByIndex(0, -1))` |
+| `r.zrange(k, 0, -1, withscores=True)` | `await client.zrange_withscores(k, RangeByIndex(0, -1))` |
+| `r.zrange(k, 1.0, 2.0, byscore=True)` | `await client.zrange(k, RangeByScore(ScoreBoundary(1.0), ScoreBoundary(2.0)))` |
+| `r.zrevrange(k, 0, -1)` | `await client.zrange(k, RangeByIndex(0, -1, reverse=True))` |
 
-**GLIDE:**
-```python
-await client.zadd("zset", {"alice": 1.0, "bob": 2.0})
-await client.zrange_withscores("zset", RangeByIndex(0, -1))
-await client.zscore("zset", "alice")
-```
+`RangeByLex` exists too for BYLEX queries.
 
----
+## Cluster: `RedisCluster` -> `GlideClusterClient`
 
-## Delete and Exists
+`redis.RedisCluster(host=, port=, skip_full_coverage_check=True)` has no direct translation. GLIDE's `GlideClusterClient` does full-topology auto-discovery from any seed nodes; `skip_full_coverage_check` has no equivalent (GLIDE always discovers the full shard set). `read_from` replaces redis-py's read replica routing behavior.
 
-**redis-py:**
-```python
-r.delete("k1", "k2", "k3")           # varargs
-r.exists("k1", "k2")                  # returns count
-```
+## Everything else is named the same
 
-**GLIDE:**
-```python
-await client.delete(["k1", "k2", "k3"])         # list arg
-await client.exists(["k1", "k2"])                # returns count
-```
-
----
-
-## Cluster Mode
-
-**redis-py:**
-```python
-rc = redis.RedisCluster(
-    host="node1.example.com",
-    port=6379,
-    skip_full_coverage_check=True,
-)
-```
-
-**GLIDE:**
-```python
-from glide import GlideClusterClient, GlideClusterClientConfiguration, ReadFrom
-
-config = GlideClusterClientConfiguration(
-    addresses=[
-        NodeAddress("node1.example.com", 6379),
-        NodeAddress("node2.example.com", 6380),
-    ],
-    read_from=ReadFrom.PREFER_REPLICA,
-)
-client = await GlideClusterClient.create(config)
-```
-
-GLIDE discovers the full cluster topology from seed nodes automatically.
+For 95% of commands (`get`, `hget`, `hgetall`, `lpop`, `lrange`, `smembers`, `sismember`, `zadd`, `zscore`, `exists`, `ttl`, `expire`, `keys`, `type`, `incr`/`decr` and friends, `xadd`/`xread`/`xreadgroup`/`xack`, `publish`, etc.) the only changes are the three universal ones at the top of this file (bytes, await, list args). Just translate.

--- a/skills/valkey-glide-python/.claude-plugin/plugin.json
+++ b/skills/valkey-glide-python/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "valkey-glide-python",
-  "version": "2.0.0",
-  "description": "Use when building Python apps with Valkey GLIDE - async/sync APIs, GlideClient, GlideClusterClient, asyncio, TLS, OpenTelemetry, batching, PubSub, streams, Lua scripting. Not for redis-py migration - use migrate-redis-py skill.",
+  "version": "2.1.0",
+  "description": "Use when building Python apps with Valkey GLIDE - async/sync APIs, GlideClient, GlideClusterClient, multiplexer behavior, IAM, AZ affinity, OpenTelemetry, batching, PubSub, streams. Covers the divergence from redis-py; basic command shapes are assumed knowable from training. Not for redis-py migration - use migrate-redis-py.",
   "author": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"

--- a/skills/valkey-glide-python/skills/valkey-glide-python/SKILL.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/SKILL.md
@@ -46,6 +46,7 @@ Large values are NOT an exception - they pipeline through the multiplexer fine.
 8. **Sync is `glide_sync` (not `glide`).** The sync wrapper (GLIDE 2.1+) imports from `glide_sync`, with the same class names.
 9. **Static PubSub subscriptions require RESP3.** Using RESP2 raises `ConfigurationError`.
 10. **No Alpine support.** GLIDE requires glibc 2.17+.
+11. **`publish()` argument order is REVERSED from redis-py.** `await client.publish(message, channel)` - message first, channel second. redis-py is `r.publish(channel, message)`. Silent bug factory during migration.
 
 ## Cross-references
 

--- a/skills/valkey-glide-python/skills/valkey-glide-python/SKILL.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/SKILL.md
@@ -1,26 +1,54 @@
 ---
 name: valkey-glide-python
-description: "Use when building Python apps with Valkey GLIDE - async/sync APIs, GlideClient, GlideClusterClient, asyncio, TLS, OpenTelemetry, batching, PubSub, streams, Lua scripting. Not for redis-py migration - use migrate-redis-py skill."
-version: 2.0.0
+description: "Use when building Python apps with Valkey GLIDE - async/sync APIs, GlideClient, GlideClusterClient, multiplexer behavior, IAM, AZ affinity, OpenTelemetry, batching, PubSub, streams. Covers the divergence from redis-py; basic command shapes are assumed knowable from training. Not for redis-py migration - use migrate-redis-py."
+version: 2.1.0
 argument-hint: "[API or config question]"
 ---
 
 # Valkey GLIDE Python Client
 
+Agent-facing skill for GLIDE Python. Assumes the reader can already write basic redis-py from training (get/set/hset, pipelines, consumer groups, pubsub message loop). Covers only what diverges from redis-py and what GLIDE adds on top.
+
 ## Routing
 
 | Question | Reference |
 |----------|-----------|
-| Install, setup, client creation, TLS, auth, reconnect | [connection](reference/features-connection.md) |
-| PubSub, subscribe, publish, sharded channels | [pubsub](reference/features-pubsub.md) |
-| Batching, transactions, pipelines | [batching](reference/features-batching.md) |
-| Streams, consumer groups, XADD, XREAD | [streams](reference/features-streams.md) |
-| OTel, Lua scripting, cluster SCAN, command routing, logging, custom commands | [advanced](reference/features-advanced.md) |
-| Error types, retry, reconnection patterns | [error-handling](reference/best-practices-error-handling.md) |
-| Benchmarks, throughput, batching perf | [performance](reference/best-practices-performance.md) |
-| Timeouts, connection management, cloud defaults | [production](reference/best-practices-production.md) |
+| `GlideClient` vs `GlideClusterClient`, TLS, auth, IAM, lazy connect, AZ affinity, compression, statistics, graceful close | [connection](reference/features-connection.md) |
+| PubSub: static vs dynamic (2.3+) subscriptions, callback vs polling, reconciliation, sharded, `get_subscriptions()` | [pubsub](reference/features-pubsub.md) |
+| `Batch` / `ClusterBatch` (`is_atomic` flag), cluster routing, retry strategy, WATCH | [batching](reference/features-batching.md) |
+| Streams typed option classes, split `xclaim` vs `xclaim_just_id`, multi-stream slot constraint | [streams](reference/features-streams.md) |
+| Lua `Script`, cluster SCAN iterator, routing (`AllNodes`, `SlotKeyRoute`, ...), OpenTelemetry, Logger, error hierarchy | [advanced](reference/features-advanced.md) |
+| Error types: shadowing `TimeoutError` / `ConnectionError`, subclass hierarchy, reconnection semantics | [error-handling](reference/best-practices-error-handling.md) |
+| Multiplexer discipline, batching as top optimization, inflight cap, compression impact | [performance](reference/best-practices-performance.md) |
+| Production defaults, timeout tuning, AZ affinity, OTel setup, platform constraints (glibc, protobuf, proxies) | [production](reference/best-practices-production.md) |
 
-## Cross-References
+## Multiplexer rule (the #1 agent mistake)
 
-- `valkey-glide` skill - shared architecture, cluster topology, connection model
-- `valkey` skill - Valkey server commands, data types, patterns
+One `GlideClient` / `GlideClusterClient` per process, shared across every coroutine. Do not create per-task clients. Do not pool them.
+
+**Exceptions that need a dedicated client:**
+
+- Blocking commands (per the core's blocking-timeout table): `BLPOP`, `BRPOP`, `BLMOVE`, `BZPOPMAX`, `BZPOPMIN`, `BRPOPLPUSH`, `BLMPOP`, `BZMPOP`, plus `XREAD` / `XREADGROUP` when called with `BLOCK`, and `WAIT` / `WAITAOF`.
+- WATCH / MULTI / EXEC transactions (connection-state commands).
+- Long polling `get_pubsub_message()` (blocks an asyncio task).
+
+Large values are NOT an exception - they pipeline through the multiplexer fine.
+
+## Grep hazards
+
+1. **`decode_responses=True` does not exist.** All string-like returns are `bytes`. Add `.decode()` at each read site, or use the `str` overloads where typed.
+2. **Timeout unit change.** `request_timeout` is milliseconds (redis-py's `socket_timeout` is seconds).
+3. **`TimeoutError` and `ConnectionError` shadow Python built-ins** - always import them with `as GlideTimeoutError` / `as GlideConnectionError`.
+4. **Reconnection is infinite.** `BackoffStrategy.num_of_retries` caps the backoff SEQUENCE length; the client keeps retrying until close.
+5. **`get_statistics()` values are strings, not int.** The dict values are `str` (stringified counters / timestamps).
+6. **Batches are executed by the client, not the batch.** Call `await client .exec(batch, ...)` - the verb is a client method. Not `batch.execute()`.
+7. **`is_atomic=True` for transactions, `False` for pipelines.** One class (`Batch` / `ClusterBatch`), two modes.
+8. **Sync is `glide_sync` (not `glide`).** The sync wrapper (GLIDE 2.1+) imports from `glide_sync`, with the same class names.
+9. **Static PubSub subscriptions require RESP3.** Using RESP2 raises `ConfigurationError`.
+10. **No Alpine support.** GLIDE requires glibc 2.17+.
+
+## Cross-references
+
+- `migrate-redis-py` - migrating from redis-py
+- `glide-dev` - GLIDE core internals (Rust), binding mechanics
+- `valkey` - Valkey commands and app patterns

--- a/skills/valkey-glide-python/skills/valkey-glide-python/SKILL.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/SKILL.md
@@ -41,7 +41,7 @@ Large values are NOT an exception - they pipeline through the multiplexer fine.
 3. **`TimeoutError` and `ConnectionError` shadow Python built-ins** - always import them with `as GlideTimeoutError` / `as GlideConnectionError`.
 4. **Reconnection is infinite.** `BackoffStrategy.num_of_retries` caps the backoff SEQUENCE length; the client keeps retrying until close.
 5. **`get_statistics()` values are strings, not int.** The dict values are `str` (stringified counters / timestamps).
-6. **Batches are executed by the client, not the batch.** Call `await client .exec(batch, ...)` - the verb is a client method. Not `batch.execute()`.
+6. **Batches are executed by the client, not the batch.** Call `await client.exec(batch, ...)` - the verb is a client method. Not `batch.execute()`.
 7. **`is_atomic=True` for transactions, `False` for pipelines.** One class (`Batch` / `ClusterBatch`), two modes.
 8. **Sync is `glide_sync` (not `glide`).** The sync wrapper (GLIDE 2.1+) imports from `glide_sync`, with the same class names.
 9. **Static PubSub subscriptions require RESP3.** Using RESP2 raises `ConfigurationError`.

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-error-handling.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-error-handling.md
@@ -1,33 +1,37 @@
 # Error Handling
 
-Use when implementing error handling, retry logic, or batch error semantics in the GLIDE Python client.
+Use when implementing error handling, retry logic, or batch error semantics. Covers GLIDE-specific divergence from `redis-py` (which raises `redis.exceptions.ConnectionError`, `TimeoutError`, `ResponseError`, etc.).
 
-## Error Types
+## Key gotcha: GLIDE error classes shadow Python built-ins
 
-GLIDE defines its own `TimeoutError` and `ConnectionError` classes that shadow Python built-ins when imported directly. Always import with explicit aliases:
+`GlideError`, `RequestError`, `ClosingError`, `LoggerError` are GLIDE-specific. But `TimeoutError` and `ConnectionError` collide with Python built-ins if imported directly. Always alias:
 
 ```python
 from glide import (
-    GlideClient,
     GlideError,
+    RequestError,
     TimeoutError as GlideTimeoutError,
     ConnectionError as GlideConnectionError,
-    RequestError,
     ExecAbortError,
     ConfigurationError,
     ClosingError,
 )
 ```
 
-| Error | Parent | When It Occurs |
-|-------|--------|---------------|
-| `GlideError` | `Exception` | Base class for all GLIDE errors |
-| `RequestError` | `GlideError` | Base class for server/protocol errors |
-| `GlideTimeoutError` | `RequestError` | Request exceeded `request_timeout` (default 250ms) |
-| `GlideConnectionError` | `RequestError` | Connection lost (auto-reconnects) |
-| `ExecAbortError` | `RequestError` | Atomic batch aborted by server (e.g., command error in MULTI) |
-| `ConfigurationError` | `RequestError` | Invalid configuration (TLS, PubSub, compression) |
-| `ClosingError` | `GlideError` | Client was closed while requests pending |
+## Hierarchy
+
+```
+GlideError                       # base - catches everything
+├── ClosingError                 # client closed / unusable
+├── LoggerError                  # logger init failure
+└── RequestError                 # catches everything below too - most code catches at this level
+    ├── TimeoutError             # request exceeded request_timeout (default 250ms)
+    ├── ExecAbortError           # server aborted atomic batch (type mismatch in MULTI/EXEC)
+    ├── ConnectionError          # network disconnect - GLIDE is already reconnecting; retry after delay
+    └── ConfigurationError       # invalid config (TLS, RESP2+PubSub, compression)
+```
+
+**Common mistake:** catching `Exception` in redis-py matches `redis.exceptions.RedisError` and subclasses. In GLIDE, `except RequestError:` already catches timeouts, connection errors, and configuration errors - they are subclasses. Catch `GlideError` only if you also need `ClosingError` / `LoggerError`.
 
 ## Basic Error Handling
 
@@ -112,27 +116,21 @@ for attempt in range(3):
 
 ---
 
-## Reconnection Behavior
+## Reconnection behavior
 
-GLIDE reconnects automatically on connection loss with exponential backoff:
+GLIDE reconnects automatically on connection loss with exponential backoff. Two key differences from redis-py's `retry_on_timeout`:
+
+1. **Reconnection is infinite.** `num_of_retries` caps the backoff sequence length, not the total number of retries. After `num_of_retries` attempts the delay plateaus at the ceiling and the client keeps retrying until close. This is very different from redis-py where retries give up after N attempts.
+2. **Permanent errors are only blocked at INITIAL connect.** During reconnection, auth failures and `RESP3NotSupported` will also end up in an error state, but the mid-session classification logic is in the Rust core - callers just see `ConnectionError` until the client is closed or the server recovers.
 
 ```python
-from glide import BackoffStrategy, GlideClientConfiguration, NodeAddress
+from glide import BackoffStrategy
 
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("localhost", 6379)],
-    reconnect_strategy=BackoffStrategy(
-        num_of_retries=5,
-        factor=100,          # 100ms base delay
-        exponent_base=2,
-    ),
-)
+BackoffStrategy(num_of_retries=5, factor=100, exponent_base=2, jitter_percent=20)
+# Delay formula: rand_jitter * factor * (exponent_base ** attempt), clamped at the ceiling
 ```
 
-- Delay formula: `rand(0 ... factor * (exponent_base ^ attempt))`
-- After `num_of_retries`, delay stays at the ceiling indefinitely
-- PubSub channels are automatically resubscribed on reconnect
-- Permanent errors (NOAUTH, WRONGPASS) are not retried
+PubSub channels resubscribe automatically on reconnect via the synchronizer (see [pubsub-internals](../../../glide-dev/skills/glide-dev/reference/pubsub-internals.md) on the core side).
 
 ---
 

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-error-handling.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-error-handling.md
@@ -130,7 +130,7 @@ BackoffStrategy(num_of_retries=5, factor=100, exponent_base=2, jitter_percent=20
 # Delay formula: rand_jitter * factor * (exponent_base ** attempt), clamped at the ceiling
 ```
 
-PubSub channels resubscribe automatically on reconnect via the synchronizer (see [pubsub-internals](../../../glide-dev/skills/glide-dev/reference/pubsub-internals.md) on the core side).
+PubSub channels resubscribe automatically on reconnect via the synchronizer on the core side (see the `glide-dev` skill for the reconciliation loop details).
 
 ---
 

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-performance.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-performance.md
@@ -1,125 +1,66 @@
-# Performance Tuning
+# Performance tuning
 
-Use when optimizing GLIDE Python throughput and latency, tuning inflight limits, or choosing batching strategies.
+Use when optimizing GLIDE Python throughput and latency. Covers GLIDE-specific points - general async discipline (use `asyncio.gather` for independent ops, avoid `await` in tight loops) is the same as any async Python and is not covered here.
 
-## Batching Is the Top Optimization
+## Client model: one client per process, not per task
 
-Batching amortizes the PyO3 FFI overhead across all commands - one crossing per batch instead of one per command. Batched workloads are competitive with redis-py.
+GLIDE is a multiplexer. One `GlideClient` / `GlideClusterClient` instance serves every coroutine in the process concurrently - requests are tagged with IDs and demuxed. Creating a client per asyncio task is wasted allocation and a fresh TCP handshake to every cluster node.
 
-### Non-Atomic Pipeline
+**Exceptions - use a dedicated client:**
+
+- Blocking commands: `BLPOP`, `BRPOP`, `BLMOVE`, `BZPOPMAX`, `BZPOPMIN`, `BRPOPLPUSH`, `BLMPOP`, `BZMPOP`, plus `XREAD` / `XREADGROUP` with `BLOCK` (full list matches the blocking-timeout table in `glide-core/src/client/mod.rs`). These occupy the multiplexed connection for the block duration.
+- WATCH / MULTI / EXEC - connection-state commands; leak across callers on the shared multiplexer.
+- Long polling of `get_pubsub_message()` - blocks an asyncio task indefinitely.
+
+Large values do NOT require a dedicated client - they pipeline through the multiplexed connection; they just take longer to transfer.
+
+## Batching is the top optimization
+
+Batching amortizes the PyO3 / UDS crossing across all commands - one crossing per batch instead of one per command. This is the single biggest throughput knob.
 
 ```python
 from glide import Batch
 
-pipeline = Batch(is_atomic=False)
+batch = Batch(is_atomic=False)
 for i in range(100):
-    pipeline.set(f"key:{i}", f"value:{i}")
-result = await client.exec(pipeline, raise_on_error=True)
-# One round-trip for 100 commands
+    batch.set(f"key:{i}", f"value:{i}")
+await client .exec (batch, raise_on_error=True)  # one round-trip, one multiplexer slot
 ```
 
-### Atomic Transaction
+In cluster mode, atomic batches require all keys to share a hash slot: `batch.set("{account}:src", ...)`, `batch.set("{account}:dst", ...)`.
+
+Rough batch-size guidelines:
+
+| Size | Trade-off |
+|------|-----------|
+| 10-50 | Good default; low latency, solid throughput gain |
+| 50-200 | Best throughput; slight per-batch latency increase |
+| 200-1000 | Diminishing returns, large response buffers |
+| 1000+ | Memory pressure, long parsing - avoid |
+
+## Inflight request limit
+
+The multiplexer caps concurrent inflight requests at `DEFAULT_MAX_INFLIGHT_REQUESTS = 1000` per client. Beyond the cap, requests fail with `RequestError("Reached maximum inflight requests")` - rejected, not queued.
 
 ```python
-tx = Batch(is_atomic=True)
-tx.set("{account}:src", "100")
-tx.set("{account}:dst", "0")
-tx.incrby("{account}:dst", 50)
-tx.decrby("{account}:src", 50)
-result = await client.exec(tx, raise_on_error=True)
+GlideClientConfiguration(addresses=[...], inflight_requests_limit=500)
 ```
 
-All keys must share a hash slot in cluster mode. Use `{tag}` hash tags.
-
-### Batch Size Guidelines
-
-| Batch Size | Trade-off |
-|------------|-----------|
-| 10-50 | Good default. Low latency, solid throughput gain |
-| 50-200 | Best throughput. Slight increase in per-batch latency |
-| 200-1000 | Diminishing returns. Risk of large response buffers |
-| 1000+ | Avoid. Memory pressure and long parsing time |
-
----
-
-## Async Best Practices
-
-Use `asyncio.gather()` for concurrent independent operations:
-
-```python
-import asyncio
-
-results = await asyncio.gather(
-    client.get("key1"),
-    client.get("key2"),
-    client.get("key3"),
-)
-```
-
-For bulk loads, prefer batching over individual awaits:
-
-```python
-# Slow: 1000 round-trips
-for i in range(1000):
-    await client.set(f"key:{i}", f"value:{i}")
-
-# Fast: 10 round-trips (100 per batch)
-for chunk_start in range(0, 1000, 100):
-    batch = Batch(is_atomic=False)
-    for i in range(chunk_start, min(chunk_start + 100, 1000)):
-        batch.set(f"key:{i}", f"value:{i}")
-    await client.exec(batch, raise_on_error=True)
-```
-
----
-
-## Inflight Request Limit
-
-GLIDE caps concurrent inflight requests at 1000 per client. Requests beyond the limit are rejected immediately.
-
-```python
-from glide import GlideClientConfiguration, NodeAddress
-
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("localhost", 6379)],
-    inflight_requests_limit=500,  # lower for constrained servers
-)
-```
-
-If hitting the limit:
-1. Batch commands - one batch counts as one inflight request
-2. Create additional client instances - each gets its own 1000-request budget
-3. Review concurrency - 1000+ concurrent requests usually means the bottleneck is server-side
-
----
-
-## Connection Model
-
-GLIDE uses a single multiplexed connection per node. No connection pools to size or manage. All requests pipeline through one connection using Valkey's built-in pipelining.
-
-### When to Create Multiple Clients
-
-- Blocking commands (BLPOP, BRPOP, XREADGROUP with BLOCK) - tie up the connection
-- WATCH/UNWATCH - requires connection-level isolation
-- Large value transfers - prevents head-of-line blocking
-- PubSub subscribers - dedicated listener, cannot share with command traffic
-
----
+If you hit it: first batch commands (one batch = one slot), then consider whether 1000 concurrent in-flight is actually the bottleneck (usually it's server-side). Only as a last resort create a second client - doubling clients doubles the TCP footprint and breaks the single-multiplexer invariant.
 
 ## Compression
 
-Enable transparent compression for large values:
+Transparent value compression can reduce network bytes for large string/hash values; decompression happens automatically on read:
 
 ```python
 from glide import CompressionConfiguration, CompressionBackend
 
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("localhost", 6379)],
-    compression=CompressionConfiguration(
-        enabled=True,
-        backend=CompressionBackend.LZ4,
-        min_compression_size=64,  # bytes
-    ),
+CompressionConfiguration(
+    enabled=True,
+    backend=CompressionBackend.LZ4,  # or ZSTD (default)
+    min_compression_size=64,          # bytes; below this, no compression
 )
 ```
+
+Monitor effect via `get_statistics()`: `total_bytes_compressed` vs `total_original_bytes` vs `compression_skipped_count`.
 

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-performance.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-performance.md
@@ -24,7 +24,7 @@ from glide import Batch
 batch = Batch(is_atomic=False)
 for i in range(100):
     batch.set(f"key:{i}", f"value:{i}")
-await client .exec (batch, raise_on_error=True)  # one round-trip, one multiplexer slot
+await client.exec(batch, raise_on_error=True)  # one round-trip, one multiplexer slot
 ```
 
 In cluster mode, atomic batches require all keys to share a hash slot: `batch.set("{account}:src", ...)`, `batch.set("{account}:dst", ...)`.

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-production.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/best-practices-production.md
@@ -1,111 +1,59 @@
-# Production Deployment
+# Production deployment
 
-Use when deploying GLIDE Python to production, configuring timeouts, managing connections, or setting up observability.
+Use when deploying GLIDE Python to production. Covers GLIDE-specific defaults and the pitfalls that matter for operators. For basic setup examples see [features-connection](features-connection.md).
 
-## Connection Management
+## One client per process
 
-### Single Client Per Application
+Do not pool `GlideClient` / `GlideClusterClient`. The multiplexer is the pool. Creating N clients opens N sets of TCP connections to every node and defeats the connection-state tracking the core does.
 
-GLIDE multiplexes all requests over one connection per node. Do not create client pools.
+Use `lazy_connect=True` if your app must start before Valkey is reachable - the first command pays the connection cost.
 
-```python
-from glide import GlideClient, GlideClientConfiguration, NodeAddress
+Always `await client.close()` on shutdown; pending futures get `ClosingError`.
 
-# Correct: one client shared across the application
-config = GlideClientConfiguration(addresses=[NodeAddress("localhost", 6379)])
-client = await GlideClient.create(config)
+## GLIDE defaults agents should know
 
-# Wrong: do not pool GLIDE clients
-# pool = [await GlideClient.create(config) for _ in range(10)]
-```
+| Knob | Default | Config |
+|------|---------|--------|
+| Request timeout | 250 ms | `request_timeout` |
+| Connection timeout | 2000 ms | `AdvancedGlideClientConfiguration.connection_timeout` |
+| Inflight request cap | 1000 | `inflight_requests_limit` |
+| Topology check interval (cluster) | 60 s | `periodic_checks=PeriodicChecksManualInterval(...)` |
+| Backoff retries | (infinite; cap only on sequence length) | `reconnect_strategy` |
+| Protocol | RESP3 | `protocol=ProtocolVersion.RESP2` to downgrade |
+| TCP_NODELAY | True | `AdvancedGlideClientConfiguration.tcp_nodelay` |
 
-### Lazy Connect
+GLIDE also extends the effective request timeout for blocking commands (BLPOP, XREADGROUP BLOCK, etc.) by 0.5 s beyond the block duration - no tuning required.
 
-Defers connection until the first command. Allows startup when the server is not yet available.
+## Timeout tuning
 
-```python
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("localhost", 6379)],
-    lazy_connect=True,
-)
-client = await GlideClient.create(config)
-# No connection yet - first command triggers it
-```
+The 250 ms default is tight. Raise per-workload, not globally:
 
-### Client Cleanup
+| Workload | Recommended |
+|----------|-------------|
+| Cache lookup (GET, HGET) | 250-500 ms |
+| Writes (SET, HSET, ZADD) | 250-500 ms |
+| Complex (SORT, SCAN, ZRANGEBYSCORE large) | 1-5 s |
+| Lua scripts | 5-30 s |
+| Blocking commands | Auto-extended - do not raise |
 
-Always close clients on shutdown. Pending futures receive `ClosingError`.
+## Cluster: seed nodes and AZ affinity
 
-```python
-await client.close()
-await client.close("shutting down")  # custom error message
-```
+Provide multiple seed addresses for redundancy. Topology is auto-discovered.
 
----
-
-## Timeout Configuration
-
-| Timeout | Default | Config Parameter |
-|---------|---------|-----------------|
-| Request timeout | 250ms | `request_timeout` |
-| Connection timeout | 2000ms | `AdvancedGlideClientConfiguration(connection_timeout=ms)` |
-
-### Tuning by Workload
-
-| Workload | Recommended Timeout |
-|----------|-------------------|
-| Cache lookups (GET, HGET) | 250-500ms |
-| Write operations (SET, HSET) | 250-500ms |
-| Complex operations (SORT, SCAN) | 1000-5000ms |
-| Lua scripts (EVALSHA) | 5000-30000ms |
-| Blocking commands (BLPOP, XREADGROUP) | Handled automatically |
-
-GLIDE extends blocking command timeouts by 500ms beyond the block duration.
-
-```python
-from glide import AdvancedGlideClientConfiguration
-
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("localhost", 6379)],
-    request_timeout=1000,
-    advanced_config=AdvancedGlideClientConfiguration(connection_timeout=5000),
-)
-```
-
----
-
-## Cluster Configuration
-
-Provide multiple seed nodes for redundancy. GLIDE discovers the full topology automatically.
-
-### AZ Affinity
-
-Route reads to same-AZ replicas to reduce latency and cross-AZ costs:
-
-```python
-from glide import GlideClusterClientConfiguration, NodeAddress, ReadFrom
-
-config = GlideClusterClientConfiguration(
-    addresses=[NodeAddress("node1.example.com", 6379)],
-    read_from=ReadFrom.AZ_AFFINITY,
-    client_az="us-east-1a",
-)
-```
+`ReadFrom` strategies (in `glide_shared.config.ReadFrom`):
 
 | Strategy | Behavior |
 |----------|----------|
 | `PRIMARY` | All reads to primary (default) |
-| `PREFER_REPLICA` | Round-robin replicas, fallback to primary |
-| `AZ_AFFINITY` | Prefer same-AZ replicas |
-| `AZ_AFFINITY_REPLICAS_AND_PRIMARY` | Same-AZ replicas, then primary, then remote |
+| `PREFER_REPLICA` | Round-robin replicas, fall back to primary |
+| `AZ_AFFINITY` | Same-AZ replicas preferred, then other replicas, then primary |
+| `AZ_AFFINITY_REPLICAS_AND_PRIMARY` | Same-AZ replicas, then same-AZ primary, then any replica, then primary |
 
-Requires Valkey 8.0+ with `availability-zone` configured on each server node.
-
----
+AZ-affinity strategies require `client_az` to be set AND the server exposing availability-zone metadata in CLUSTER SHARDS - otherwise falls back to primary.
 
 ## OpenTelemetry
 
-OTel is initialized globally before creating any clients:
+Initialize once, globally, before creating clients (subsequent `init()` calls are ignored):
 
 ```python
 from glide import (
@@ -118,28 +66,20 @@ OpenTelemetry.init(OpenTelemetryConfig(
         endpoint="http://otel-collector:4317",
         sample_percentage=1,
     ),
-    metrics=OpenTelemetryMetricsConfig(
-        endpoint="http://otel-collector:4317",
-    ),
+    metrics=OpenTelemetryMetricsConfig(endpoint="http://otel-collector:4317"),
     flush_interval_ms=5000,
 ))
+
+# Runtime adjustments
+OpenTelemetry.set_sample_percentage(10)
+OpenTelemetry.is_initialized()
 ```
 
-| Environment | Sample Rate |
-|-------------|------------|
-| Production | 1-2% |
-| Staging | 5-10% |
-| Debugging | 50-100% |
+Rough sampling rates: 1-2% prod, 5-10% staging, 50-100% debugging.
 
----
+## Platform constraints
 
-## Connection Defaults
-
-| Parameter | Default |
-|-----------|---------|
-| Request timeout | 250ms |
-| Connection timeout | 2000ms |
-| Inflight request limit | 1000 |
-| Connections per node | 2 (data + management) |
-| Topology check | 60s |
-| Protocol | RESP3 |
+- **glibc 2.17+** required. Alpine (musl) is NOT supported - use Debian/Ubuntu-based images.
+- **Protobuf**: the `protobuf` Python package must be ≥ 3.20. Conflicts with other packages pinning older protobuf will surface as import errors on client creation.
+- **Proxies / connection inspectors**: GLIDE sends `CLIENT SETNAME`, `CLIENT SETINFO`, `INFO REPLICATION` during setup. Transparent proxies that strip or rewrite these will break topology detection.
+- **Protocol**: RESP3 is the default. RESP2 is accepted but PubSub static subscriptions require RESP3 and raise `ConfigurationError` otherwise.

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-advanced.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-advanced.md
@@ -84,23 +84,7 @@ Always use the returned cursor for the next iteration - reusing a cursor produce
 
 ### Standalone SCAN
 
-```python
-from glide import ObjectType
-
-cursor = "0"
-all_keys = []
-
-while True:
-    result = await client.scan(cursor, match="session:*", count=100)
-    cursor = result[0]       # next cursor (bytes)
-    keys = result[1]         # list of keys (List[bytes])
-    all_keys.extend(keys)
-    if cursor == b"0":
-        break
-
-# Filter by type
-result = await client.scan("0", match="*", count=50, type=ObjectType.HASH)
-```
+Same shape as `redis-py.scan()`: pass cursor `"0"`, loop until the returned cursor is `b"0"` (bytes, not str). Filter by `type=ObjectType.STRING | HASH | LIST | SET | ZSET | STREAM` (GLIDE's typed enum, not a string).
 
 ## Routing and Custom Commands (Cluster)
 
@@ -177,14 +161,17 @@ except Exception as e:
 
 Log levels: `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `OFF`.
 
-## Error Types
+## Error types
 
-| Exception | When |
-|-----------|------|
-| `GlideError` | Base class for all GLIDE errors |
-| `ClosingError` | Client is closed or connection lost |
-| `ConfigurationError` | Invalid configuration (TLS, PubSub, compression) |
-| `ConnectionError` | Network or connection issues |
-| `RequestError` | Command execution failure |
-| `TimeoutError` | Request or subscription timeout |
-| `ExecAbortError` | Transaction aborted (e.g., type mismatch) |
+Hierarchy in `glide_shared.exceptions` - important because `except RequestError:` also catches timeouts, config errors, and connection errors (they are subclasses, not siblings):
+
+```
+GlideError                       # base
+├── ClosingError                 # client closed / unusable
+├── LoggerError                  # logger init failure
+└── RequestError                 # command execution failure
+    ├── TimeoutError             # request or subscription timeout
+    ├── ExecAbortError           # transaction aborted (type mismatch, etc.)
+    ├── ConnectionError          # network disconnect; temporary - client will reconnect
+    └── ConfigurationError       # invalid config (TLS, PubSub/RESP2, compression)
+```

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-batching.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-batching.md
@@ -1,164 +1,101 @@
-# Batching - Pipelines and Transactions
+# Batching - pipelines and transactions
 
-Use when you need to send multiple commands in a single round-trip for throughput or atomicity - pipelines for bulk operations, transactions for atomic multi-command blocks.
+Use when sending multiple commands in one round-trip. Pipelines for bulk throughput, transactions for atomicity. Covers what differs from `redis-py` - the basic "queue commands, run them" pattern works as expected.
 
-GLIDE uses a unified `Batch` / `ClusterBatch` class hierarchy with an `is_atomic` flag. Setting `is_atomic=True` creates a transaction (MULTI/EXEC); `is_atomic=False` creates a pipeline.
+## Divergence from redis-py
 
-## Core Concepts
+| redis-py | GLIDE Python |
+|----------|--------------|
+| `pipe = r.pipeline(transaction=True)` + `pipe.execute()` | `batch = Batch(is_atomic=True)` + `await client.exec(batch, raise_on_error=True)` |
+| `pipe.watch(...)` then `pipe.multi()` | WATCH/MULTI/EXEC needs a dedicated client (occupies the multiplexer); result is `None` on WATCH conflict |
+| Separate pipeline vs transaction methods | Unified `Batch` / `ClusterBatch` with `is_atomic` flag |
+| Cluster pipelining: manual slot split | `ClusterBatch(is_atomic=False)` auto-routes per-slot; multi-node batches split internally |
+| `strict_transactions=True` errors | `raise_on_error=True` raises on first error after all retries; `False` puts `RequestError` in the result array |
 
-| Mode | Flag | Protocol | Slot Constraint |
-|------|------|----------|-----------------|
-| Transaction | `is_atomic=True` | MULTI/EXEC | All keys must map to the same hash slot in cluster mode |
-| Pipeline | `is_atomic=False` | Pipelined commands | Can span multiple slots and nodes in cluster mode |
+One class, two modes:
 
-## Standalone Batching
+| Mode | `is_atomic` | Protocol | Cluster constraint |
+|------|-------------|----------|---------------------|
+| Transaction | `True` | MULTI/EXEC | All keys must map to one hash slot (use hash tags) |
+| Pipeline | `False` | Pipelined commands | Any slots; GLIDE splits and dispatches per-slot |
+
+## Minimal shape
 
 ```python
-from glide import GlideClient, Batch, BatchOptions
+from glide import Batch, ClusterBatch
 
-# Atomic batch (transaction)
-transaction = Batch(is_atomic=True)
-transaction.set("key", "1")
-transaction.incr("key")
-transaction.get("key")
-
-result = await client.exec(transaction, raise_on_error=True)
-# result: [OK, 2, b'2']
+batch = Batch(is_atomic=False)  # or ClusterBatch for a cluster client
+batch.set("k1", "v1")
+batch.incr("k1")
+batch.get("k1")
+results = await client.exec(batch, raise_on_error=True)
 ```
 
-```python
-# Non-atomic batch (pipeline)
-pipeline = Batch(is_atomic=False)
-pipeline.set("key1", "value1")
-pipeline.set("key2", "value2")
-pipeline.get("key1")
-pipeline.get("key2")
-
-result = await client.exec(pipeline, raise_on_error=True)
-# result: [OK, OK, b'value1', b'value2']
-```
-
-## Cluster Batching
+## Cluster-only options (`ClusterBatchOptions`)
 
 ```python
-from glide import GlideClusterClient, ClusterBatch, ClusterBatchOptions
+from glide import (
+    ClusterBatchOptions, BatchRetryStrategy, SlotKeyRoute, SlotType,
+)
 
-batch = ClusterBatch(is_atomic=False)
-batch.set("key1", "value1")
-batch.set("key2", "value2")
-batch.get("key1")
-
-result = await client.exec(batch, raise_on_error=True)
-```
-
-For atomic cluster batches, all keys must hash to the same slot. Use hash tags (e.g., `{user}.name`, `{user}.email`) to colocate keys.
-
-## Batch Options
-
-### Standalone
-
-```python
-options = BatchOptions(timeout=5000)  # timeout in milliseconds
-result = await client.exec(transaction, raise_on_error=True, options=options)
-```
-
-### Cluster
-
-```python
-from glide import ClusterBatchOptions, BatchRetryStrategy, SlotKeyRoute, SlotType
-
-options = ClusterBatchOptions(
-    timeout=5000,
-    route=SlotKeyRoute(SlotType.PRIMARY, "my-key"),
+opts = ClusterBatchOptions(
+    timeout=5000,                                # ms
+    route=SlotKeyRoute(SlotType.PRIMARY, "key"), # optional; pins entire batch to one node
     retry_strategy=BatchRetryStrategy(
-        retry_server_error=True,
-        retry_connection_error=False,
+        retry_server_error=True,     # retry on TRYAGAIN etc.
+        retry_connection_error=True, # retry the batch on connection failure
     ),
 )
-result = await client.exec(batch, raise_on_error=False, options=options)
+results = await client.exec(batch, raise_on_error=False, options=opts)
 ```
 
-## Routing Behavior (Cluster)
+### Routing behavior
 
-- With explicit `route`: entire batch goes to the specified node.
-- Without `route` + atomic: routed to the slot owner of the first key.
-- Without `route` + non-atomic: each command routed individually by key slot. Multi-node commands are split and dispatched automatically.
+| Config | Dispatch |
+|--------|----------|
+| `route=` specified | Entire batch to that node |
+| Atomic, no `route` | Slot owner of the first key |
+| Non-atomic, no `route` | Per-command by key slot; multi-node batches split automatically |
 
-## Error Handling
+### Retry strategy (cluster non-atomic only)
+
+`BatchRetryStrategy` is not supported on atomic batches. Hazards:
+
+- `retry_server_error=True` can reorder commands within a slot.
+- `retry_connection_error=True` can cause duplicate executions - the server may have already processed the request before the connection died.
+- Increase `timeout` when enabling retries so the retry window fits.
+
+MOVED / ASK redirects are always handled automatically and are orthogonal to this knob.
+
+## `raise_on_error` semantics
 
 ```python
 from glide import RequestError
 
-# raise_on_error=True: first error raises RequestError after all retries
+# raise_on_error=True: first error raises; nothing returned
 try:
-    result = await client.exec(batch, raise_on_error=True)
+    results = await client.exec(batch, raise_on_error=True)
 except RequestError as e:
-    print(f"Batch failed: {e}")
+    ...
 
-# raise_on_error=False: errors appear as RequestError instances in the result array
-result = await client.exec(batch, raise_on_error=False)
-for i, res in enumerate(result):
-    if isinstance(res, RequestError):
-        print(f"Command {i} failed: {res}")
-    else:
-        print(f"Command {i} result: {res}")
+# raise_on_error=False: errors are inline in results as RequestError instances
+results = await client.exec(batch, raise_on_error=False)
+for i, r in enumerate(results):
+    if isinstance(r, RequestError):
+        ...
 ```
 
-## Retry Strategy (Cluster Only)
+## WATCH with transactions
 
-`BatchRetryStrategy` controls retry behavior for non-atomic cluster batches.
-
-```python
-strategy = BatchRetryStrategy(
-    retry_server_error=True,     # retry on TRYAGAIN etc.
-    retry_connection_error=True, # retry on connection failure
-)
-```
-
-Cautions:
-- `retry_server_error=True` may cause commands targeting the same slot to execute out of order.
-- `retry_connection_error=True` may cause duplicate executions since the server may have already processed the request.
-- Retry strategies are only supported for non-atomic batches.
-- Increase `timeout` when enabling retries.
-
-## WATCH with Transactions
-
-Atomic batches support optimistic locking via WATCH. If a watched key changes before EXEC, the transaction returns `None`.
+Atomic batches support WATCH. If a watched key changes before EXEC, `exec()` returns `None` (not a list, not an error):
 
 ```python
-transaction = Batch(is_atomic=True)
-transaction.set("counter", "10")
-transaction.incr("counter")
-
-result = await client.exec(transaction, raise_on_error=True)
-# result is None if a WATCH conflict occurred
+batch = Batch(is_atomic=True)
+batch.incr("counter")
+result = await client.exec(batch, raise_on_error=True)
 if result is None:
-    print("Transaction aborted due to WATCH conflict")
+    # WATCH conflict - retry or abort
+    ...
 ```
 
-## Building Batches with All Command Types
-
-`Batch` and `ClusterBatch` support the full GLIDE command set. Commands are queued and executed in order:
-
-```python
-batch = Batch(is_atomic=False)
-batch.set("str-key", "hello")
-batch.hset("hash-key", {"field1": "val1", "field2": "val2"})
-batch.lpush("list-key", ["c", "b", "a"])
-batch.sadd("set-key", ["x", "y", "z"])
-batch.xadd("stream-key", [("sensor", "42")])
-batch.publish("hello", "notifications")
-
-result = await client.exec(batch, raise_on_error=True)
-# Each result corresponds to the command at the same index
-```
-
-## Custom Commands in Batches
-
-```python
-batch = Batch(is_atomic=False)
-batch.custom_command(["SET", "key", "value"])
-batch.custom_command(["GET", "key"])
-result = await client.exec(batch, raise_on_error=True)
-# result: [OK, b'value']
-```
+WATCH itself must be issued on a dedicated client - it's a connection-state command; the multiplexed connection would leak watch state across callers.

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-connection.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-connection.md
@@ -1,238 +1,168 @@
 # Connection and Configuration
 
-Use when creating GLIDE client instances, configuring addresses, authentication, TLS, reconnection, protocol version, compression, AZ affinity, or managing connection lifecycle.
+Use when creating GLIDE client instances, configuring addresses, authentication, TLS, reconnection, protocol version, compression, AZ affinity, or managing connection lifecycle. Covers what differs from `redis-py` / `RedisCluster` - skip the basics, they work as expected.
 
-## Contents
+## Divergence from redis-py
 
-- Client Types (line 20)
-- Standalone Client (line 29)
-- Cluster Client (line 63)
-- TLS and mTLS (line 85)
-- Authentication (line 135)
-- Runtime Password Update (line 157)
-- IAM Token Refresh (line 170)
-- Compression (line 177)
-- AZ Affinity (line 195)
-- Lazy Connect (line 207)
-- Connection Statistics (line 218)
-- Graceful Shutdown (line 230)
+| redis-py | GLIDE Python |
+|----------|--------------|
+| `redis.Redis(host, port, ...)` | `await GlideClient.create(config)` - async classmethod |
+| `redis.asyncio.Redis(...)` / `redis.RedisCluster(...)` | `GlideClient` / `GlideClusterClient` (separate types, not wrappers) |
+| Connection pool with `max_connections` | Single multiplexed connection per node - no pool knob |
+| Per-task client OK | One client shared across all coroutines in the process (multiplexer) |
+| Blocking commands share the pool | Blocking commands (BLPOP, BRPOP, BZPOPMAX, WATCH/MULTI/EXEC) occupy the single connection - use a dedicated client for them |
+| `decode_responses=True` | No equivalent - always `bytes`; call `.decode()` or use `str` arg overloads where typed |
+| `socket_timeout` seconds | `request_timeout` milliseconds |
+| `retry_on_timeout=True` | `reconnect_strategy=BackoffStrategy(...)` |
 
-## Client Types
+## Client types
 
-| Client | Class | Config Class | Use Case |
-|--------|-------|-------------|----------|
-| Standalone | `GlideClient` | `GlideClientConfiguration` | Single node or read replicas |
-| Cluster | `GlideClusterClient` | `GlideClusterClientConfiguration` | Cluster mode with slot-based routing |
+| Client | Class | Config |
+|--------|-------|--------|
+| Standalone / primary + replicas | `GlideClient` | `GlideClientConfiguration` |
+| Cluster | `GlideClusterClient` | `GlideClusterClientConfiguration` |
 
-Both clients are created via the async `create()` classmethod and closed via `close()`.
-
-## Standalone Client
-
-```python
-import asyncio
-from glide import (
-    GlideClient, GlideClientConfiguration, NodeAddress,
-    ServerCredentials, BackoffStrategy, ReadFrom, ProtocolVersion,
-)
-
-async def main():
-    config = GlideClientConfiguration(
-        addresses=[
-            NodeAddress("localhost", 6379),
-            NodeAddress("replica1.example.com", 6379),
-        ],
-        use_tls=False,
-        credentials=ServerCredentials(password="secretpass"),
-        read_from=ReadFrom.PREFER_REPLICA,
-        request_timeout=500,          # ms
-        reconnect_strategy=BackoffStrategy(
-            num_of_retries=5, factor=100, exponent_base=2,
-            jitter_percent=20,  # optional, adds randomness to retry intervals
-        ),
-        database_id=0,
-        client_name="my-app",
-        protocol=ProtocolVersion.RESP3,
-    )
-    client = await GlideClient.create(config)
-    await client.set("key", "value")
-    await client.close()
-
-asyncio.run(main())
-```
-
-## Cluster Client
-
-```python
-from glide import (
-    GlideClusterClient, GlideClusterClientConfiguration, NodeAddress,
-    PeriodicChecksManualInterval, ServerCredentials, BackoffStrategy,
-)
-
-config = GlideClusterClientConfiguration(
-    addresses=[NodeAddress("cluster-node-1.example.com", 6379)],
-    use_tls=True,
-    credentials=ServerCredentials(username="admin", password="secret"),
-    periodic_checks=PeriodicChecksManualInterval(duration_in_sec=30),
-    reconnect_strategy=BackoffStrategy(
-        num_of_retries=5, factor=1000, exponent_base=2,
-    ),
-)
-client = await GlideClusterClient.create(config)
-```
-
-Seed addresses can be partial - the client discovers the full cluster topology automatically.
-
-## TLS and mTLS
-
-```python
-from glide import TlsAdvancedConfiguration, AdvancedGlideClientConfiguration
-
-# Basic TLS
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("host", 6380)],
-    use_tls=True,
-)
-
-# mTLS with custom CA
-with open("/path/to/ca-cert.pem", "rb") as f:
-    ca_cert = f.read()
-with open("/path/to/client-cert.pem", "rb") as f:
-    client_cert = f.read()
-with open("/path/to/client-key.pem", "rb") as f:
-    client_key = f.read()
-
-tls_config = TlsAdvancedConfiguration(
-    root_pem_cacerts=ca_cert,
-    client_cert_pem=client_cert,
-    client_key_pem=client_key,
-)
-advanced = AdvancedGlideClientConfiguration(
-    connection_timeout=5000,  # ms
-    tls_config=tls_config,
-    tcp_nodelay=True,         # disable Nagle's algorithm (default: True)
-)
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("host", 6380)],
-    use_tls=True,
-    advanced_config=advanced,
-)
-```
-
-For self-signed certs in dev, set `use_insecure_tls=True` on `TlsAdvancedConfiguration`.
-
-For cluster clients, use `AdvancedGlideClusterClientConfiguration` which adds `refresh_topology_from_initial_nodes`:
-
-```python
-from glide import AdvancedGlideClusterClientConfiguration
-
-advanced = AdvancedGlideClusterClientConfiguration(
-    connection_timeout=5000,
-    tls_config=tls_config,
-    refresh_topology_from_initial_nodes=True,  # only use seed nodes for topology
-)
-```
+Both are GLIDE's own code; neither wraps the other. Create via `await ClientClass.create(config)`, close via `await client.close()`. Seed addresses can be partial - topology is discovered.
 
 ## Authentication
 
 ```python
-# Password-only
-creds = ServerCredentials(password="my-password")
+from glide import ServerCredentials, IamAuthConfig, ServiceType
 
-# Username + password (ACL)
-creds = ServerCredentials(username="app-user", password="my-password")
+# Password or username+password (ACL)
+creds = ServerCredentials(password="pw")
+creds = ServerCredentials(username="user", password="pw")
 
-# IAM authentication (AWS ElastiCache / MemoryDB)
-from glide import IamAuthConfig, ServiceType
-iam = IamAuthConfig(
-    cluster_name="my-cluster",
-    service=ServiceType.ELASTICACHE,
-    region="us-east-1",
-    refresh_interval_seconds=300,
-)
-creds = ServerCredentials(username="iam-user", iam_config=iam)
-```
-
-Password and IAM are mutually exclusive. IAM requires a username.
-
-## Runtime Password Update
-
-```python
-# Update stored password for future reconnections (no immediate AUTH)
-await client.update_connection_password("new-password")
-
-# Update and immediately re-authenticate all connections
-await client.update_connection_password("new-password", immediate_auth=True)
-
-# Remove stored password
-await client.update_connection_password(None)
-```
-
-## IAM Token Refresh
-
-```python
-# Manually refresh IAM token (only for clients created with IAM auth)
-await client.refresh_iam_token()
-```
-
-## Compression
-
-```python
-from glide import CompressionConfiguration, CompressionBackend
-
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("localhost", 6379)],
-    compression=CompressionConfiguration(
-        enabled=True,
-        backend=CompressionBackend.LZ4,   # or ZSTD (default)
-        compression_level=3,               # backend-specific
-        min_compression_size=64,           # bytes, minimum threshold
+# IAM (ElastiCache / MemoryDB) - GLIDE-only, no redis-py equivalent
+creds = ServerCredentials(
+    username="iam-user",
+    iam_config=IamAuthConfig(
+        cluster_name="my-cluster",
+        service=ServiceType.ELASTICACHE,  # or ServiceType.MEMORYDB
+        region="us-east-1",
+        refresh_interval_seconds=300,  # optional
     ),
 )
 ```
 
-Compression is transparent - set-type commands compress automatically, get-type commands decompress.
+Password and IAM are mutually exclusive on a single `ServerCredentials`. IAM requires a username.
 
-## AZ Affinity
+### Runtime updates
 
 ```python
-config = GlideClusterClientConfiguration(
-    addresses=[NodeAddress("host", 6379)],
-    read_from=ReadFrom.AZ_AFFINITY,
-    client_az="us-east-1a",
+await client.update_connection_password("new-pw")                   # stored, used on next reconnect
+await client.update_connection_password("new-pw", immediate_auth=True)  # re-AUTH now
+await client.update_connection_password(None)                       # clear stored password
+await client.refresh_iam_token()                                    # force IAM token refresh
+```
+
+## TLS / mTLS
+
+Basic TLS is just `use_tls=True`. Everything else (client cert, insecure dev mode, custom CA) goes through `TlsAdvancedConfiguration` + `AdvancedGlideClientConfiguration`:
+
+```python
+from glide import (
+    TlsAdvancedConfiguration, AdvancedGlideClientConfiguration,
+    AdvancedGlideClusterClientConfiguration,
+)
+
+tls = TlsAdvancedConfiguration(
+    root_pem_cacerts=ca_bytes,
+    client_cert_pem=cert_bytes,
+    client_key_pem=key_bytes,
+    use_insecure_tls=False,  # True to bypass verification (dev only)
+)
+advanced = AdvancedGlideClientConfiguration(
+    connection_timeout=5000,  # ms; default 2000
+    tls_config=tls,
+    tcp_nodelay=True,         # default True; disable Nagle
+    pubsub_reconciliation_interval=None,  # ms; sets PubSub reconciliation cadence
 )
 ```
 
-`AZ_AFFINITY` routes reads to same-AZ replicas first. `AZ_AFFINITY_REPLICAS_AND_PRIMARY` includes the local primary in the rotation. Both require `client_az` to be set.
+`AdvancedGlideClusterClientConfiguration` adds `refresh_topology_from_initial_nodes: bool = False` - when `True`, only seed nodes are used for periodic topology refresh.
 
-## Lazy Connect
+## GLIDE-only features
+
+### AZ affinity
 
 ```python
-config = GlideClientConfiguration(
-    addresses=[NodeAddress("localhost", 6379)],
-    lazy_connect=True,   # defer connection until first command
+from glide import ReadFrom
+
+GlideClusterClientConfiguration(
+    addresses=[...],
+    read_from=ReadFrom.AZ_AFFINITY,             # or AZ_AFFINITY_REPLICAS_AND_PRIMARY
+    client_az="us-east-1a",                      # REQUIRED when AZ_AFFINITY*
 )
 ```
 
-The first command pays the connection establishment cost. Governed by `connection_timeout`, not `request_timeout`.
+Raises `ConfigurationError` if `client_az` is missing on an AZ-affinity strategy.
 
-## Connection Statistics
+### Lazy connect
+
+```python
+GlideClientConfiguration(addresses=[...], lazy_connect=True)
+```
+
+Connection establishment deferred until the first command. That first command pays connection-timeout cost, not request-timeout.
+
+### Compression
+
+Transparent value compression, driven by the Rust core:
+
+```python
+from glide import CompressionConfiguration, CompressionBackend
+
+CompressionConfiguration(
+    enabled=False,                          # default False
+    backend=CompressionBackend.ZSTD,        # or CompressionBackend.LZ4
+    compression_level=None,                  # backend default if None; core validates range
+    min_compression_size=64,                 # bytes; below this, no compression
+)
+```
+
+### BackoffStrategy
+
+```python
+from glide import BackoffStrategy
+
+BackoffStrategy(
+    num_of_retries=5,
+    factor=100,
+    exponent_base=2,
+    jitter_percent=20,  # Optional; default used if not set
+)
+```
+
+Reconnection retries are **infinite** regardless of `num_of_retries` - `num_of_retries` only caps the backoff sequence length before the max interval plateaus. Client will keep reconnecting until close.
+
+## Connection statistics
 
 ```python
 stats = await client.get_statistics()
-# Returns dict with int values:
-#   total_connections, total_clients, total_values_compressed,
-#   total_values_decompressed, total_original_bytes,
-#   total_bytes_compressed, total_bytes_decompressed,
-#   compression_skipped_count, subscription_out_of_sync_count,
-#   subscription_last_sync_timestamp (ms since epoch)
+# dict[str, str] - all values are stringified counters/timestamps
+# Keys:
+#   total_connections, total_clients,
+#   total_values_compressed, total_values_decompressed,
+#   total_original_bytes, total_bytes_compressed, total_bytes_decompressed,
+#   compression_skipped_count,
+#   subscription_out_of_sync_count, subscription_last_sync_timestamp   # ms since epoch
 ```
 
-## Graceful Shutdown
+## Graceful shutdown
 
 ```python
-await client.close()
-# Optional: pass an error message for in-flight futures
-await client.close("shutting down")
+await client.close()                # in-flight futures get ClosingError
+await client.close("draining")     # optional message stored on the error
 ```
 
-All pending futures receive a `ClosingError` with the provided message.
+## Periodic topology checks (cluster)
+
+```python
+from glide import PeriodicChecksManualInterval, PeriodicChecksStatus
+
+GlideClusterClientConfiguration(
+    addresses=[...],
+    periodic_checks=PeriodicChecksManualInterval(duration_in_sec=30),  # override default 60s
+)
+```

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-pubsub.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-pubsub.md
@@ -1,19 +1,20 @@
 # Pub/Sub
 
-Use when you need real-time message broadcasting between clients - chat, notifications, event distribution, or live data feeds. For durable message processing with consumer groups and replay, see [Streams](features-streams.md) instead.
+Use when working with publish/subscribe. Covers what differs from `redis-py` - the core publish/message-receive loop is similar but the subscription model diverges significantly.
 
-GLIDE supports Valkey's publish/subscribe messaging with three subscription modes, automatic reconnection with resubscription, and a synchronizer that reconciles desired vs actual subscription state. Sharded subscriptions require Valkey 7.0+. Dynamic subscribe/unsubscribe requires GLIDE 2.3+.
+## Divergence from redis-py
 
-## Contents
+| redis-py | GLIDE Python |
+|----------|--------------|
+| `pubsub = r.pubsub(); pubsub.subscribe(...)` - runtime object per subscriber | Either static subscriptions configured into client config, or dynamic `client.subscribe()` calls (GLIDE 2.3+) |
+| `for msg in pubsub.listen(): ...` | Either callback (push) or `get_pubsub_message()` / `try_get_pubsub_message()` (polling) - cannot mix |
+| Manual resubscribe on reconnect | GLIDE's synchronizer reconciles desired vs actual across reconnects and topology changes |
+| No notion of "desired" state | `client.get_subscriptions()` exposes desired and actual; metrics `subscription_out_of_sync_count` and `subscription_last_sync_timestamp` |
+| Cluster sharded pub/sub not built in | `GlideClusterClient` with `PubSubChannelModes.Sharded` + `publish(..., sharded=True)` |
 
-- Subscription Modes (line 16)
-- Subscription Approaches (line 24)
-- Receiving Messages (line 123)
-- Subscription State Inspection (line 152)
-- Reconciliation (line 171)
-- Publishing (line 191)
+Static subscriptions require RESP3. Using RESP2 raises `ConfigurationError`.
 
-## Subscription Modes
+## Subscription modes
 
 | Mode | Subscribe / Unsubscribe | Description | Client |
 |------|------------------------|-------------|--------|

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-pubsub.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-pubsub.md
@@ -191,15 +191,15 @@ last_sync = stats["subscription_last_sync_timestamp"]  # ms since epoch
 
 ## Publishing
 
-Publishing is a regular command, not tied to subscriptions:
+**GOTCHA: argument order is REVERSED from redis-py.** redis-py is `r.publish(channel, message)`; GLIDE is `await client.publish(message, channel)`. Silent mis-routing if you don't notice - this is the #1 `publish()` bug in migration code.
 
 ```python
-# Standalone client: publish(message, channel) -> int
+# Standalone:  publish(message, channel) -> int
 num_receivers = await client.publish("hello world", "alerts")
 
-# Cluster client: publish(message, channel, sharded=False) -> int
+# Cluster:     publish(message, channel, sharded=False) -> int
 num_receivers = await client.publish("hello world", "alerts")
 
-# Cluster client: sharded publish (Valkey 7.0+)
+# Cluster sharded (Valkey 7.0+):
 num_receivers = await client.publish("hello shard", "shard-events", sharded=True)
 ```

--- a/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-streams.md
+++ b/skills/valkey-glide-python/skills/valkey-glide-python/reference/features-streams.md
@@ -1,227 +1,73 @@
 # Streams
 
-Use when you need durable, ordered message processing with consumer groups, message acknowledgment, and replay capability. For ephemeral real-time broadcasting, see [Pub/Sub](features-pubsub.md) instead.
+Use when working with Valkey streams (XADD / XREAD / consumer groups). The command names and semantics are identical to Valkey/redis-py - the divergence is the typed option classes, response bytes, and a couple of API shape choices.
 
-## Contents
+## Divergence from redis-py
 
-- Adding Entries (line 15)
-- Trimming (line 47)
-- Reading Entries (line 56)
-- Consumer Groups (line 86)
-- Group Management (line 189)
-- Info, Length, and Deletion (line 206)
-- Cluster Mode (line 218)
+| redis-py | GLIDE Python |
+|----------|--------------|
+| `r.xadd(stream, {"f": "v"}, maxlen=1000, approximate=True)` | `client.xadd(stream, [("f", "v")], StreamAddOptions(trim=TrimByMaxLen(exact=False, threshold=1000)))` |
+| kwargs for MAXLEN / MINID trim | typed `TrimByMaxLen(exact, threshold, limit)` / `TrimByMinId(exact, threshold)` |
+| `start="-"`, `end="+"` strings | typed `MinId()`, `MaxId()`, `IdBound("1-0")`, `ExclusiveIdBound("1-0")` |
+| `block=5000` kwarg on xread | `StreamReadOptions(block_ms=5000, count=10)` |
+| `r.xclaim(..., justid=True)` flag | Separate methods: `xclaim` vs `xclaim_just_id`, `xautoclaim` vs `xautoclaim_just_id` |
+| `r.xpending(...)` one call covers both summary and detail | `xpending(stream, group)` summary vs `xpending_range(stream, group, min, max, count, options=StreamPendingOptions(...))` |
+| `decode_responses=True` returns str | Always bytes: IDs are `b"1-0"`, field names and values are `bytes` |
+| Cluster pipelining of multi-stream reads | Multi-key xread / xreadgroup must hash to one slot (use hash tags) |
 
-## Adding Entries
+## Typed option classes (GLIDE-specific)
+
+These replace redis-py's kwargs and string sentinels:
+
+| Class | Replaces |
+|-------|----------|
+| `StreamAddOptions(id, make_stream, trim)` | xadd kwargs (`id=`, `nomkstream`, `maxlen`, `minid`) |
+| `StreamReadOptions(block_ms, count)` | xread kwargs |
+| `StreamReadGroupOptions(block_ms, count, no_ack)` | xreadgroup kwargs |
+| `StreamGroupOptions(make_stream, entries_read)` | xgroup CREATE kwargs (`mkstream`) |
+| `StreamPendingOptions(consumer_name, min_idle_time_ms)` | XPENDING detail filters |
+| `StreamClaimOptions(idle_ms, time_ms, retry_count, is_force)` | XCLAIM kwargs |
+| `TrimByMaxLen(exact, threshold, limit)`, `TrimByMinId(exact, threshold)` | MAXLEN/MINID trim args |
+| `MinId()`, `MaxId()`, `IdBound("1-0")`, `ExclusiveIdBound("1-0")` | `-`, `+`, and `(` prefix strings |
+
+Example using the divergence:
 
 ```python
-from glide import StreamAddOptions, TrimByMaxLen
-
-# Auto-generated ID
-entry_id = await client.xadd("mystream", [("sensor", "temperature"), ("value", "22.5")])
-# entry_id: b"1615957011958-0"
-
-# Explicit ID
-entry_id = await client.xadd(
-    "mystream",
-    [("field", "value")],
-    StreamAddOptions(id="0-1"),
+from glide import (
+    StreamAddOptions, StreamReadOptions, StreamReadGroupOptions,
+    TrimByMaxLen, MinId, MaxId,
 )
 
-# Don't create stream if it doesn't exist
-entry_id = await client.xadd(
+await client.xadd(
     "mystream",
-    [("field", "value")],
-    StreamAddOptions(make_stream=False),
-)
-# Returns None if stream doesn't exist
-
-# Add with trimming
-entry_id = await client.xadd(
-    "mystream",
-    [("field", "value")],
+    [("sensor", "temp"), ("value", "22.5")],
     StreamAddOptions(trim=TrimByMaxLen(exact=False, threshold=1000, limit=100)),
 )
-```
 
-## Trimming
-
-```python
-from glide import TrimByMaxLen, TrimByMinId
-
-deleted = await client.xtrim("mystream", TrimByMaxLen(exact=False, threshold=1000))
-deleted = await client.xtrim("mystream", TrimByMinId(exact=True, threshold="1526985054069-0"))
-```
-
-## Reading Entries
-
-### Range Queries
-
-```python
-from glide import MinId, MaxId, IdBound, ExclusiveIdBound
-
-entries = await client.xrange("mystream", MinId(), MaxId())
-# {b"0-1": [[b"field1", b"value1"]], b"0-2": [[b"field2", b"value2"]]}
-
-entries = await client.xrange("mystream", MinId(), MaxId(), count=10)
-entries = await client.xrange("mystream", IdBound("1526985054069-0"), MaxId())
-entries = await client.xrange("mystream", ExclusiveIdBound("1526985054069-0"), MaxId())
-entries = await client.xrevrange("mystream", MaxId(), MinId(), count=5)
-```
-
-### XREAD - Multi-Stream Reading
-
-```python
-from glide import StreamReadOptions
-
-entries = await client.xread({"stream1": "0-0", "stream2": "0-0"})
-# {b"stream1": {b"1-0": [[b"f", b"v"]]}, ...}
-
-# Blocking read with timeout (returns None on timeout)
 entries = await client.xread(
-    {"mystream": "$"}, StreamReadOptions(block_ms=5000, count=10),
+    {"mystream": "$"},
+    StreamReadOptions(block_ms=5000, count=10),
+)
+
+# Re-read pending owned by this consumer (use "0-0" instead of ">")
+pending = await client.xreadgroup(
+    {"mystream": "0-0"}, "mygroup", "consumer-1",
+    StreamReadGroupOptions(count=10),
 )
 ```
 
-## Consumer Groups
+## Split xclaim / xautoclaim
 
-### Create Group
+`xclaim` returns the full entries; `xclaim_just_id` returns only IDs. Same split for `xautoclaim` / `xautoclaim_just_id`. redis-py combines these under a `justid=True` flag.
 
-```python
-from glide import StreamGroupOptions
+`xautoclaim*` (Valkey 6.2+) returns `[next_cursor, entries_or_ids, deleted_ids]`.
 
-await client.xgroup_create("mystream", "mygroup", "$")       # from latest
-await client.xgroup_create("mystream", "mygroup", "0-0")     # from beginning
-await client.xgroup_create(                                   # auto-create stream
-    "mystream", "mygroup", "$", StreamGroupOptions(make_stream=True),
-)
-```
+## Cluster: multi-stream reads must share a slot
 
-### Read with Consumer Group
-
-```python
-from glide import StreamReadGroupOptions
-
-# Read new messages
-entries = await client.xreadgroup(
-    {"mystream": ">"}, "mygroup", "consumer-1", StreamReadGroupOptions(count=10),
-)
-# {b"mystream": {b"1-0": [[b"field1", b"value1"]]}}
-
-# Re-read pending messages (use "0-0" instead of ">")
-pending = await client.xreadgroup({"mystream": "0-0"}, "mygroup", "consumer-1")
-
-# Blocking read
-entries = await client.xreadgroup(
-    {"mystream": ">"}, "mygroup", "consumer-1",
-    StreamReadGroupOptions(block_ms=5000, count=10),
-)
-```
-
-### Acknowledge Messages
-
-```python
-acked = await client.xack("mystream", "mygroup", ["1615957011958-0", "1615957011959-0"])
-# acked: 2
-```
-
-### Pending Messages
-
-```python
-# Summary of pending messages
-summary = await client.xpending("mystream", "mygroup")
-# [4, b"1-0", b"1-3", [[b"consumer-1", b"3"], [b"consumer-2", b"1"]]]
-
-# Detailed pending range
-from glide import StreamPendingOptions
-
-pending = await client.xpending_range(
-    "mystream", "mygroup",
-    MinId(), MaxId(),
-    count=10,
-    options=StreamPendingOptions(consumer_name="consumer-1"),
-)
-# [[b"1-0", b"consumer-1", 1234, 1], [b"1-1", b"consumer-1", 1123, 1]]
-# Format: [id, consumer, idle_ms, delivery_count]
-```
-
-### Claim Messages
-
-```python
-from glide import StreamClaimOptions
-
-# Claim messages idle for > 60 seconds
-claimed = await client.xclaim(
-    "mystream", "mygroup", "consumer-2",
-    min_idle_time_ms=60000,
-    ids=["1-0", "1-1"],
-)
-# Returns: {b"1-0": [[b"field", b"value"]], ...}
-
-# Claim and return only IDs
-claimed_ids = await client.xclaim_just_id(
-    "mystream", "mygroup", "consumer-2",
-    min_idle_time_ms=60000,
-    ids=["1-0", "1-1"],
-)
-```
-
-### Auto-Claim (Valkey 6.2+)
-
-```python
-result = await client.xautoclaim(
-    "mystream", "mygroup", "consumer-2",
-    min_idle_time_ms=60000, start="0-0", count=10,
-)
-# [next_cursor, {b"1-0": [[b"field", b"value"]]}, [b"deleted-id"]]
-```
-
-### Auto-Claim IDs Only (Valkey 6.2+)
-
-```python
-result = await client.xautoclaim_just_id(
-    "mystream", "mygroup", "consumer-2",
-    min_idle_time_ms=60000, start="0-0", count=10,
-)
-# [next_cursor, [b"1-0", b"1-1"], [b"deleted-id"]]
-```
-
-## Group Management
-
-```python
-# Set group's last-delivered-ID
-await client.xgroup_set_id("mystream", "mygroup", "0-0")
-await client.xgroup_set_id("mystream", "mygroup", "$", entries_read=100)
-
-# Create a consumer explicitly
-await client.xgroup_create_consumer("mystream", "mygroup", "new-consumer")
-
-# Delete a consumer (returns number of pending messages that were owned by the consumer)
-pending_count = await client.xgroup_del_consumer("mystream", "mygroup", "old-consumer")
-
-# Destroy the entire group
-await client.xgroup_destroy("mystream", "mygroup")
-```
-
-## Info, Length, and Deletion
-
-```python
-groups = await client.xinfo_groups("mystream")
-consumers = await client.xinfo_consumers("mystream", "mygroup")
-info = await client.xinfo_stream("mystream")
-full_info = await client.xinfo_stream_full("mystream", count=10)
-
-length = await client.xlen("mystream")
-deleted = await client.xdel("mystream", ["1-0", "1-1"])
-```
-
-## Cluster Mode
-
-In cluster mode, all keys in a multi-stream `xread` or `xreadgroup` call must map to the same hash slot. Use hash tags to colocate streams:
+`xread` / `xreadgroup` over multiple stream keys goes to a single node - the keys must all hash to the same slot. Use hash tags:
 
 ```python
 await client.xadd("{app}.events", [("type", "click")])
-await client.xadd("{app}.logs", [("level", "info")])
-
-entries = await client.xread({"{app}.events": "0-0", "{app}.logs": "0-0"})
+await client.xadd("{app}.logs",   [("level", "info")])
+await client.xread({"{app}.events": "0-0", "{app}.logs": "0-0"})
 ```


### PR DESCRIPTION
## Summary

Two-pass validation of `valkey-glide-python` and `migrate-redis-py` against Valkey GLIDE `v2.3.1` (commit `9601a7695`), applying the new "divergence-only" skill-writing rule captured in [docs/SKILL_WRITING_RULES.md](docs/SKILL_WRITING_RULES.md).

**Maintainer framing (Avi, 2026-04-18):** "Where the API is the same, that's not interesting. Models know to write redis-py without docs. Question is where they differ - this is where models are wrong - and what GLIDE specifically needs you to know that is not in compare."

## Size reduction

- `valkey-glide-python`: 1471 -> 1079 lines (27% cut), plugin 2.0.0 -> 2.1.0
- `migrate-redis-py`: 364 -> 265 lines (27% cut), plugin 1.0.0 -> 1.1.0

Cuts came from removing redis-py-knowable content (command-by-command mirrors where only the bytes-vs-str and await-prefix change applies), dropping TOC-with-line-numbers blocks, and replacing basic setup examples with the divergence that actually matters.

## Pass-1 editorial changes

- Dropped all "line N" TOCs per skill-writing rules
- Rewrote SKILL.md with a multiplexer-first framing and a 10-point grep-hazards block
- Replaced command-by-command API mirrors with divergence tables (only the signature delta)
- PubSub section re-framed around the mental-model switch: redis-py's runtime `pubsub()` object -> GLIDE's static-config OR dynamic-subscribe (2.3+), callback OR polling, synchronizer-managed resubscribe
- Batch section: `is_atomic` flag, verb is on the client not the batch, retry-strategy hazards explicit
- Streams: cut baseline command examples, kept typed option classes (`StreamAddOptions`, `TrimByMaxLen`, `MinId`/`MaxId`/`IdBound`/`ExclusiveIdBound`, etc.), the split between `xclaim` vs `xclaim_just_id`, cluster multi-stream slot constraint
- Error section: subclass-tree diagram clarifies `except RequestError:` also catches timeouts / config / connection errors
- Performance: one-client-per-process discipline, blocking-command exceptions, inflight cap, compression metrics via `get_statistics()`
- Production: defaults table, timeout tuning, AZ-affinity `ReadFrom`, OTel init-once, platform constraints (glibc, protobuf, proxies)

## Pass-2 correctness fixes (bugs pass 1 missed)

1. **`get_statistics()` return type**: skill claimed "dict with int values". Source `python/glide-async/src/lib.rs` uses `HashMap<String, String>` and converts values via `PyString::new` - they are strings. Corrected.
2. **ExpiryType upstream typo**: enum values are `SEC`, `MILLSEC`, `UNIX_SEC`, `UNIX_MILLSEC`, `KEEP_TTL` - the `MILLSEC` / `UNIX_MILLSEC` names are missing the `I` in upstream `python/glide-shared/.../core_options.py`. The skill had the corrected spelling which does not exist. Fixed and added an explicit grep hazard so agents searching for the "correct" `MILLISEC` do not dead-end.
3. **`ConditionalChange.ONLY_IF_EQUAL` fabrication**: the skill claimed this variant existed to match Valkey 9.0's `IFEQ`. Source enum has only two values (`ONLY_IF_EXISTS`, `ONLY_IF_DOES_NOT_EXIST`). `IFEQ` is a separate `OnlyIfEqual(comparison_value=...)` dataclass. Fixed.
4. **Blocking command list incomplete**: previous list was `BLPOP, BRPOP, BLMOVE, BZPOPMAX, XREADGROUP BLOCK`. Per `glide-core/src/client/mod.rs` blocking-timeout table, the actual set is `BLPOP, BRPOP, BLMOVE, BZPOPMAX, BZPOPMIN, BRPOPLPUSH, BLMPOP, BZMPOP`, plus `XREAD` / `XREADGROUP` with `BLOCK`, plus `WAIT` / `WAITAOF`. Updated everywhere it appeared.
5. **Fabricated "2 connections per node (data + management)"** in production defaults - grep shows this text only in Python test code; no user-facing concept exists. Removed.
6. **Permanent-errors framing**: "NOAUTH / WRONGPASS / AuthenticationFailed / RESP3NotSupported are never retried" applies only to INITIAL connection attempts (`reconnecting_connection.rs:236-240`). During ongoing reconnect the client keeps retrying and surfaces `ConnectionError`. Clarified.
7. **Error hierarchy**: added `LoggerError` which was missing from the table.
8. **`tcp_nodelay` default**: Python literal default is `None`, meaning "use core default which is True". Clarified to avoid confusion.

## docs/SKILL_WRITING_RULES.md update

Added the maintainer rule for per-language + migration skills:

> The API overlap is not the content. Document only what differs (bytes returns, list args, typed options vs kwargs, timeout unit changes), GLIDE-only features (IAM, AZ affinity, OTel, compression, lazy connect, Batch retry strategies, cluster SCAN, sharded pub/sub), and cross-cutting behaviors maintainers keep correcting (multiplexer-with-blocking-exception, WATCH needs dedicated client, connection-state preservation, HA+perf both non-negotiable, platform constraints).

Applies to all seven per-language glides and all seven migrations still to validate.

## Verified against v2.3.1 source

- Config classes: `NodeAddress`, `ReadFrom` (4 variants), `ProtocolVersion`, `BackoffStrategy(num_of_retries, factor, exponent_base, jitter_percent)`, `ServerCredentials`, `IamAuthConfig(cluster_name, service, region, refresh_interval_seconds)`, `ServiceType` (`ELASTICACHE`/`MEMORYDB`), `CompressionConfiguration(enabled=False, backend=ZSTD, compression_level=None, min_compression_size=64)`, `CompressionBackend` (`LZ4`/`ZSTD`), `TlsAdvancedConfiguration(root_pem_cacerts, client_cert_pem, client_key_pem, use_insecure_tls)`, `AdvancedGlideClientConfiguration(connection_timeout, tls_config, tcp_nodelay, pubsub_reconciliation_interval)`, `AdvancedGlideClusterClientConfiguration` adds `refresh_topology_from_initial_nodes: bool = False`, `PeriodicChecksManualInterval(duration_in_sec)`, `PeriodicChecksStatus`
- Error classes with full subclass hierarchy (`glide_shared.exceptions`)
- `PubSubMsg` dataclass (`message`, `channel`, `pattern`)
- `Script` class + `invoke_script` / `invoke_script_route` / `script_kill` / `script_exists` / `script_flush`
- `ClusterScanCursor` + `scan(cursor, match, count, type, allow_non_covered_slots)` with `ObjectType` enum
- Routing classes: `AllNodes`, `AllPrimaries`, `RandomNode`, `SlotKeyRoute`, `SlotIdRoute`, `ByAddressRoute`, `SlotType`
- OpenTelemetry classes: `OpenTelemetryConfig`, `OpenTelemetryTracesConfig`, `OpenTelemetryMetricsConfig`, `OpenTelemetry.init()` / `set_sample_percentage()` / `is_initialized()`
- `Logger` + `LogLevel`
- `get_statistics()` exact key set and string-valued return
- `update_connection_password(password, immediate_auth)` / `refresh_iam_token()` / `close(err_message)`
- `read_only` is protobuf field 26; `DEFAULT_MAX_INFLIGHT_REQUESTS = 1000`; `DEFAULT_RESPONSE_TIMEOUT = 250ms`; `DEFAULT_CONNECTION_TIMEOUT = 2000ms`; `BLOCKING_CMD_TIMEOUT_EXTENSION = 0.5s`
- Batch classes: `Batch`, `ClusterBatch` with `is_atomic` flag; `BatchOptions`, `ClusterBatchOptions` with `timeout`, `route`, `retry_strategy=BatchRetryStrategy(retry_server_error, retry_connection_error)`

## Test plan

- [x] All 9 Python reference files read end-to-end after edits
- [x] Both migration files read end-to-end after edits
- [x] Pass 1: general source verification against v2.3.1
- [x] Pass 2: targeted correctness audit - caught 4 real fabrications pass 1 missed (`get_statistics` int claim, `ONLY_IF_EQUAL`, `MILLISEC` vs `MILLSEC`, blocking-command list)
- [x] Cross-file consistency: blocking commands, error classes, ExpiryType values all match source in SKILL.md + reference files + migration skill
- [ ] Ecosystem reviewers (Gemini)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes, but they revise migration/usage guidance and could mislead users if any API details are incorrect or drift from GLIDE versions.
> 
> **Overview**
> Rewrites the `valkey-glide-python` and `migrate-redis-py` skills to apply a **“divergence-only”** lens, cutting baseline redis-py/standard-client material and emphasizing the behaviors that actually differ (async-first + `glide_sync`, bytes-only returns, list-args signatures, typed options, timeout units, multiplexer rules, and cluster auto-topology).
> 
> Updates and corrects reference docs around **PubSub mental model (static vs dynamic subscriptions, callback vs polling, RESP3 requirement)**, **Batch/transaction semantics (`is_atomic`, `client.exec`, retry-strategy hazards, WATCH needing isolation)**, streams typed option classes, error hierarchy/aliasing, production defaults (timeouts/inflight caps/reconnect behavior), and platform constraints; bumps plugin versions (`migrate-redis-py` 1.1.0, `valkey-glide-python` 2.1.0) and expands `SKILL_WRITING_RULES.md` with maintainer guidance for per-language/migration skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a18311b68dd8c3ffa1adda340c49ff82dc88620f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->