### PR TITLE
nodejs + migrate-ioredis: validate against v2.3.1, apply divergence-only lens

### DIFF
--- a/skills/migrate-ioredis/.claude-plugin/plugin.json
+++ b/skills/migrate-ioredis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-ioredis",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use when migrating Node.js from ioredis to Valkey GLIDE. Covers API mapping, creation-time PubSub, reversed publish args, Batch API, TypeScript types. Not for greenfield Node.js apps - use valkey-glide-nodejs instead.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/migrate-ioredis/skills/migrate-ioredis/SKILL.md
+++ b/skills/migrate-ioredis/skills/migrate-ioredis/SKILL.md
@@ -16,7 +16,7 @@ Use when moving an existing ioredis app to GLIDE. Assumes you already know iored
 | Construction | `new Redis({ host, port })` - sync | `await GlideClient.createClient(config)` - async factory |
 | Hash args | `hset(key, "f1", "v1", "f2", "v2")` (spread pairs) | `hset(key, { f1: "v1", f2: "v2" })` (object) |
 | Sorted set args | `zadd(key, 1, "a", 2, "b")` (interleaved) | `zadd(key, [{ element: "a", score: 1 }, { element: "b", score: 2 }])` |
-| SET expiry / conditional | `setex`, `psetex`, `setnx` / kwargs `EX`, `PX`, `NX`, `XX` | `client.set(k, v, { expiry: { type: "sec", count: 60 }, conditionalSet: "onlyIfDoesNotExist" })` |
+| SET expiry / conditional | `setex`, `psetex`, `setnx` / kwargs `EX`, `PX`, `NX`, `XX` | `await client.set(k, v, { expiry: { type: TimeUnit.Seconds, count: 60 }, conditionalSet: "onlyIfDoesNotExist" })` |
 | Multi-arg commands | Varargs: `del("k1", "k2")` | Array: `del(["k1", "k2"])` - same rule for `exists`, `lpush`, `sadd`, `srem` etc. |
 | Connection pool | `new Redis({ ... })` per connection, or cluster with N connections | Multiplexer - one client per process; blocking commands need a dedicated client |
 | Cluster | `new Redis.Cluster([{host, port}], { ... })` | `await GlideClusterClient.createClient({ addresses })` |

--- a/skills/migrate-ioredis/skills/migrate-ioredis/SKILL.md
+++ b/skills/migrate-ioredis/skills/migrate-ioredis/SKILL.md
@@ -1,93 +1,99 @@
 ---
 name: migrate-ioredis
-description: "Use when migrating Node.js from ioredis to Valkey GLIDE. Covers API mapping, creation-time PubSub, reversed publish args, Batch API, TypeScript types. Not for greenfield Node.js apps - use valkey-glide-nodejs instead."
-version: 1.0.0
+description: "Use when migrating Node.js from ioredis to Valkey GLIDE. Covers API-shape divergences (hash object vs spread, zadd element-score objects, typed SET options, array args), PubSub mental-model switch, Batch API, EventEmitter removal, reversed publish args. Not for greenfield Node.js - use valkey-glide-nodejs."
+version: 1.1.0
 argument-hint: "[API or pattern to migrate]"
 ---
 
 # Migrating from ioredis to Valkey GLIDE (Node.js)
 
-Use when migrating a Node.js application from ioredis to the GLIDE client library.
+Use when moving an existing ioredis app to GLIDE. Assumes you already know ioredis. Covers what breaks or changes shape; commands that translate literally (just `client.` -> `await glideClient.`, array args for multi-key) are not listed here.
 
-## Routing
-
-- String, hash, list, set, sorted set, delete, exists, cluster -> API Mapping
-- Pipeline, transaction, Batch API, multi -> Advanced Patterns
-- PubSub, subscribe, publish, reversed args -> Advanced Patterns
-- Lua scripting, defineCommand, evalsha -> Advanced Patterns
-- Event handling, TypeScript -> Advanced Patterns
-
-## Key Differences
+## Divergences that actually matter
 
 | Area | ioredis | GLIDE |
 |------|---------|-------|
-| Hash args | Spread pairs: hset("h", "k1", "v1", "k2", "v2") | Object: hset("h", {k1: "v1", k2: "v2"}) |
-| Sorted set args | Interleaved: zadd("z", 1, "a", 2, "b") | Array of objects: zadd("z", [{element: "a", score: 1}]) |
-| Expiry | Separate commands: setex, psetex | Options on set(): {expiry: {type, count}} |
-| Multi-arg commands | Varargs or rest params | Array arguments |
-| Connection model | Connection pool or single | Single multiplexed connection per node |
-| Cluster | new Redis.Cluster([...]) | GlideClusterClient.createClient({...}) |
-| Script caching | Manual defineCommand | Automatic via Script class |
-| Events | EventEmitter (on("error")) | No event emitter - errors surface per-command |
+| Construction | `new Redis({ host, port })` - sync | `await GlideClient.createClient(config)` - async factory |
+| Hash args | `hset(key, "f1", "v1", "f2", "v2")` (spread pairs) | `hset(key, { f1: "v1", f2: "v2" })` (object) |
+| Sorted set args | `zadd(key, 1, "a", 2, "b")` (interleaved) | `zadd(key, [{ element: "a", score: 1 }, { element: "b", score: 2 }])` |
+| SET expiry / conditional | `setex`, `psetex`, `setnx` / kwargs `EX`, `PX`, `NX`, `XX` | `client.set(k, v, { expiry: { type: "sec", count: 60 }, conditionalSet: "onlyIfDoesNotExist" })` |
+| Multi-arg commands | Varargs: `del("k1", "k2")` | Array: `del(["k1", "k2"])` - same rule for `exists`, `lpush`, `sadd`, `srem` etc. |
+| Connection pool | `new Redis({ ... })` per connection, or cluster with N connections | Multiplexer - one client per process; blocking commands need a dedicated client |
+| Cluster | `new Redis.Cluster([{host, port}], { ... })` | `await GlideClusterClient.createClient({ addresses })` |
+| Pipeline | `client.pipeline().set().get().exec()` - chainable on client | `new Batch(false).set().get()` run through the client's batch method - standalone object |
+| Transaction | `client.multi().set().get().exec()` | `new Batch(true)` - same class, `isAtomic` flag |
+| Pipeline result | `[[err, result], ...]` tuples | Flat results array; with `raiseOnError: false`, errors are `RequestError` instances inline |
+| Script caching | `client.defineCommand(name, { lua, numberOfKeys })` | `new Script(lua)` + `client.invokeScript(script, { keys, args })`; remember `script.release()` |
+| PubSub | `sub = client.duplicate(); sub.subscribe(ch); sub.on("message", ...)` | Static config OR runtime `await client.subscribe(new Set([ch]))` (GLIDE 2.3+); callback in config OR `await client.getPubSubMessage()` polling |
+| `publish` | `client.publish(channel, message)` | `await client.publish(message, channel)` - **arguments REVERSED**; top silent-bug source during migration |
+| Events | `client.on("error", ...)`, `on("ready", ...)`, `on("end", ...)` EventEmitter | No EventEmitter; errors surface per-Promise via `await`, state via `getStatistics()` counters |
+| `retryStrategy: (times) => ...` | Function | Object: `connectionBackoff: { numberOfRetries, factor, exponentBase, jitterPercent }` |
+| `maxRetriesPerRequest` | Caps retries | Reconnection is INFINITE in GLIDE; no equivalent. Commands fail with `ConnectionError` while reconnecting. |
+| `lazyConnect: true` | Delays implicit connect | GLIDE equivalent is also `lazyConnect: true` (NOT default) - delays the TCP connect until first command |
+| `connectTimeout` | ms for initial socket | GLIDE: `advancedConfiguration.connectionTimeout` (default 2000 ms); `requestTimeout` is separate (default 250 ms) |
+| `tls: {}` | TLS config object | `useTLS: true` top-level + `advancedConfiguration.tlsAdvancedConfiguration` for custom CA / insecure mode |
+| `client.disconnect()` / `.quit()` | Methods | `client.close()` - synchronous (`void`, not a Promise) |
+| `client.status` property | Enum-like string | Not exposed; observe via commands or `getStatistics()` |
 
-## Quick Start - Connection Setup
+## Config translation
 
-**ioredis:**
 ```javascript
-const Redis = require("ioredis");
-const redis = new Redis({ host: "localhost", port: 6379 });
-```
+// ioredis:
+const redis = new Redis({
+    host: "h", port: 6379, db: 0, password: "pw",
+    tls: {}, connectTimeout: 5000, retryStrategy: (times) => Math.min(times * 50, 2000),
+});
 
-**GLIDE:**
-```javascript
+// GLIDE:
 import { GlideClient } from "@valkey/valkey-glide";
 const client = await GlideClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    requestTimeout: 5000,
+    addresses: [{ host: "h", port: 6379 }],
+    databaseId: 0,
+    credentials: { password: "pw" },
+    useTLS: true,
+    requestTimeout: 5000,  // ms, default 250
+    connectionBackoff: { numberOfRetries: 5, factor: 50, exponentBase: 2, jitterPercent: 20 },
 });
 ```
 
-## Configuration Mapping
+## Migration strategy
 
-| ioredis parameter | GLIDE equivalent |
-|-------------------|------------------|
-| host, port | addresses: [{host, port}] |
-| db | databaseId |
-| password | credentials: {password} |
-| username | credentials: {username, password} |
-| connectTimeout | requestTimeout (covers full lifecycle) |
-| tls: {} | useTls: true |
-| retryStrategy | Built-in reconnection with connectionBackoff |
-| maxRetriesPerRequest | Not applicable - GLIDE handles retries internally |
-| lazyConnect: true | Default behavior in GLIDE |
+No compatibility layer exists for Node. Migrate incrementally via a wrapper module:
 
-## Incremental Migration Strategy
+1. Install `@valkey/valkey-glide` alongside `ioredis`.
+2. Build a thin adapter interface that covers every `client.*` call your app makes.
+3. Implement the GLIDE side of the adapter command-by-command, starting with hot paths.
+4. Swap services or route handlers behind a feature flag.
+5. Remove `ioredis` only after every call site is migrated and canaried.
 
-No drop-in compatibility layer exists for Node.js. Migration approach:
-
-1. Install `@valkey/valkey-glide` alongside `ioredis`
-2. Create a wrapper module that abstracts the client interface
-3. Migrate route handlers or services one at a time behind the wrapper
-4. Use GLIDE's Batch API for bulk operations previously handled by ioredis pipelines
-5. Swap the wrapper implementation once all call sites are migrated
-6. Remove `ioredis` dependency
+Big-bang migration trips on divergences - hash object vs spread, sorted-set element-score format, REVERSED publish args, pipeline result shape, EventEmitter removal, lazyConnect semantics change.
 
 ## Reference
 
 | Topic | File |
 |-------|------|
-| Command-by-command API mapping (strings, hashes, lists, sets, sorted sets, delete, exists, cluster) | [api-mapping](reference/api-mapping.md) |
-| Pipelines, transactions, Pub/Sub, Lua scripting, events, TypeScript | [advanced-patterns](reference/advanced-patterns.md) |
+| SET typed options, HSET object form, ZADD element/score objects, array args, cluster | [api-mapping](reference/api-mapping.md) |
+| PubSub mental-model switch, Batch API, Lua Script.release(), no-EventEmitter, TypeScript | [advanced-patterns](reference/advanced-patterns.md) |
 
-## Gotchas
+## Gotchas (the short list)
 
-1. **Hash argument format.** ioredis accepts spread key-value pairs. GLIDE requires an object or HashDataType array.
-2. **Sorted set format.** ioredis uses interleaved score, member pairs. GLIDE uses {element, score} objects.
-3. **No setex/psetex/setnx.** Use set() with the expiry and conditionalSet options.
-4. **Array args for multi-key commands.** del, exists, lpush, sadd all take arrays, not rest parameters.
-5. **Pipeline result format.** ioredis returns [[error, result], ...]. GLIDE returns a flat result array.
-6. **No event emitter.** Handle errors per-command or set up external health checks.
-7. **Node.js PubSub is creation-time only.** Unlike Java/Python/Go, the Node.js client requires all subscriptions at connection time.
-8. **Publish arg order reversed.** ioredis: publish(channel, message). GLIDE: publish(message, channel).
-9. **protobufjs bundle size.** Adds ~19KB gzipped - relevant for serverless cold starts.
-10. **npm version on Linux.** Requires npm 11+ for proper optional dependency handling.
+1. **`publish(message, channel)` - arguments REVERSED** from ioredis's `publish(channel, message)`. Silent bug source.
+2. **HSET takes an object, not spread pairs.** `hset(key, { f1: "v1" })` not `hset(key, "f1", "v1")`.
+3. **ZADD takes `{element, score}` array** - `zadd(key, [{ element: "a", score: 1 }])`.
+4. **Multi-key commands take arrays** not varargs: `del(["k1", "k2"])`.
+5. **No EventEmitter.** Handle errors per-Promise. For health monitoring use `getStatistics()`.
+6. **Pipeline result is a flat array**, not `[[err, result], ...]` tuples. Use `raiseOnError: false` to get errors inline.
+7. **No connection pool.** Multiplexer - one client per process; blocking commands (`BLPOP`, `BRPOP`, `BLMOVE`, `BZPOPMAX`/`MIN`, `BRPOPLPUSH`, `BLMPOP`, `BZMPOP`, `XREAD`/`XREADGROUP` with `BLOCK`) and WATCH/MULTI/EXEC need a dedicated client.
+8. **Node.js HAS dynamic pub/sub at v2.3+** - `subscribe`, `subscribeLazy`, `psubscribe`, `ssubscribe`, `unsubscribe`, `getSubscriptions`. Older docs claiming Node is config-only are outdated.
+9. **Static pub/sub subscriptions require RESP3.** Using RESP2 raises `ConfigurationError`.
+10. **Reconnection is infinite** - no `maxRetriesPerRequest` equivalent; commands fail with `ConnectionError` while reconnecting.
+11. **`Script` needs manual `release()`** - not garbage collected, leaks native memory otherwise.
+12. **Scripts not supported in Batch** - use `batch.customCommand(["EVAL", ...])` instead.
+13. **`close()` is synchronous** - returns `void`, not a Promise. Don't `await` it.
+14. **Alpine not supported** out of the box - glibc 2.17+ required. Use Debian-based images.
+15. **`ServiceType.Elasticache` / `ServiceType.MemoryDB`** - PascalCase enum values for IAM config.
+
+## Cross-references
+
+- `valkey-glide-nodejs` - full Node skill for GLIDE features beyond the migration scope
+- `glide-dev` - GLIDE core internals if you need to debug binding-level issues

--- a/skills/migrate-ioredis/skills/migrate-ioredis/reference/advanced-patterns.md
+++ b/skills/migrate-ioredis/skills/migrate-ioredis/reference/advanced-patterns.md
@@ -1,33 +1,26 @@
-# ioredis to GLIDE Advanced Patterns
+# ioredis to GLIDE: migration patterns
 
-Use when migrating ioredis Lua scripting, pipelines, transactions, Pub/Sub, or handling event and TypeScript differences.
+Use when translating ioredis Lua scripts, pipelines, Pub/Sub, or handling event / TypeScript differences.
 
-## Lua Scripting
+## Lua Scripting: Script class, required `.release()`
 
-**ioredis:**
 ```javascript
-// Manual defineCommand
-redis.defineCommand("mycommand", {
-    numberOfKeys: 1,
-    lua: "return redis.call('GET', KEYS[1])",
-});
-const result = await redis.mycommand("key1");
+// ioredis - manual defineCommand or evalsha
+redis.defineCommand("mycmd", { numberOfKeys: 1, lua: "return redis.call('GET', KEYS[1])" });
+await redis.mycmd("key1");
 
-// Or evalsha manually
-const sha = await redis.script("LOAD", luaScript);
-const result2 = await redis.evalsha(sha, 1, "key1");
-```
-
-**GLIDE:**
-```javascript
+// GLIDE
 import { Script } from "@valkey/valkey-glide";
 
-// Automatic caching - SCRIPT LOAD on first call, EVALSHA on subsequent
 const script = new Script("return redis.call('GET', KEYS[1])");
-const result = await client.invokeScript(script, { keys: ["key1"] });
+try {
+    const result = await client.invokeScript(script, { keys: ["key1"] });
+} finally {
+    script.release();  // REQUIRED - not garbage collected, leaks native memory otherwise
+}
 ```
 
-GLIDE caches the script automatically and uses EVALSHA on repeat calls. No manual SHA management.
+Automatic EVALSHA-with-EVAL-fallback. No manual SHA management. For cluster keyless scripts: `clusterClient.invokeScriptWithRoute(script, { args, route })`. Scripts are NOT allowed inside a `Batch` - use `batch.customCommand(["EVAL", ...])` there.
 
 ---
 
@@ -84,7 +77,8 @@ sub.on("pmessage", (pattern, channel, message) => {
 });
 ```
 
-**GLIDE (static subscriptions - at client creation):**
+### Path A - static subscriptions (any GLIDE version)
+
 ```javascript
 import { GlideClusterClient, GlideClusterClientConfiguration } from "@valkey/valkey-glide";
 
@@ -92,44 +86,51 @@ const subscriber = await GlideClusterClient.createClient({
     addresses: [{ host: "localhost", port: 6379 }],
     pubsubSubscriptions: {
         channelsAndPatterns: {
-            [GlideClusterClientConfiguration.PubSubChannelModes.Exact]: new Set(["channel"]),
+            [GlideClusterClientConfiguration.PubSubChannelModes.Exact]:   new Set(["channel"]),
             [GlideClusterClientConfiguration.PubSubChannelModes.Pattern]: new Set(["events:*"]),
         },
         callback: (msg) => {
-            console.log(`[${msg.channel}] ${msg.message} (pattern: ${msg.pattern ?? "none"})`);
+            console.log(`[${msg.channel}] ${msg.message}`);
         },
     },
 });
 ```
 
-**GLIDE (polling - no callback):**
-```javascript
-const subscriber = await GlideClusterClient.createClient({
-    addresses,
-    pubsubSubscriptions: {
-        channelsAndPatterns: {
-            [GlideClusterClientConfiguration.PubSubChannelModes.Exact]: new Set(["channel"]),
-        },
-        // No callback - use polling
-    },
-});
+Omit `callback` and poll with `await subscriber.getPubSubMessage()` (blocking) or `subscriber.tryGetPubSubMessage()` (non-blocking). Callback and polling are mutually exclusive.
 
-const msg = await subscriber.getPubSubMessage();    // awaits until message arrives
-const next = subscriber.tryGetPubSubMessage();       // returns null if no message
+### Path B - dynamic subscriptions (GLIDE 2.3+; yes, Node has these)
+
+Node at v2.3.1 includes the full dynamic pubsub API - older docs claiming Node lacks runtime subscribe are outdated:
+
+```javascript
+await subscriber.subscribe(new Set(["channel"]), /* timeoutMs? */ 5000);
+await subscriber.subscribeLazy(new Set(["channel"]));  // non-blocking
+await subscriber.psubscribe(new Set(["events:*"]), 5000);
+await subscriber.ssubscribe(new Set(["shard-topic"]), 5000);  // cluster only
+
+await subscriber.unsubscribe(new Set(["channel"]));
+await subscriber.unsubscribeLazy();
+
+const state = await subscriber.getSubscriptions();  // desired vs actual
 ```
 
-**Publishing - argument order is reversed:**
+### Publishing
+
+**GOTCHA: argument order is REVERSED from ioredis.** ioredis is `r.publish(channel, message)`; GLIDE is `await client.publish(message, channel)`. The `publish` table row in SKILL.md's divergence list calls this out too.
+
 ```javascript
-// ioredis: channel first, message second
-await cluster.publish("events:order", JSON.stringify({ id: 1, status: "created" }));
+// ioredis:                     publish(channel, message)
+await cluster.publish("events:order", JSON.stringify({ id: 1 }));
 
 // GLIDE: message first, channel second
-await publisher.publish(JSON.stringify({ id: 1, status: "created" }), "events:order");
+await publisher.publish(JSON.stringify({ id: 1 }), "events:order");
 ```
 
-The publisher must be a separate client from the subscriber. Any `GlideClusterClient` without `pubsubSubscriptions` can publish.
+### Other pubsub differences
 
-Node.js GLIDE has no runtime `subscribe()` / `psubscribe()` methods. All subscriptions are declared at client creation time. To change subscriptions, close and recreate the client. Callback and polling are mutually exclusive. RESP3 required for PubSub.
+- GLIDE multiplexes pubsub onto the same connection - the subscribing client can still run regular commands. Dedicated client still recommended for high-throughput subscribers to avoid head-of-line effects.
+- Automatic resubscription on reconnect and cluster topology change via the synchronizer.
+- RESP3 required for static subscriptions; RESP2 raises `ConfigurationError`.
 
 ---
 

--- a/skills/migrate-ioredis/skills/migrate-ioredis/reference/api-mapping.md
+++ b/skills/migrate-ioredis/skills/migrate-ioredis/reference/api-mapping.md
@@ -1,153 +1,97 @@
-# ioredis to GLIDE API Mapping
+# ioredis to GLIDE: where signatures diverge
 
-Use when migrating specific ioredis commands to their GLIDE equivalents, looking up argument format changes, or converting data type operations.
+Use when translating ioredis calls and the signature is NOT obvious. Where GLIDE mirrors ioredis (most commands), just replace `redis.` with `await client.` - that pattern is not listed here.
 
-## String Operations
+## Three universal changes
 
-**ioredis:**
+Apply to every command:
+
+1. **Await needed**: GLIDE returns Promises; ioredis returns ioredis-Promise-like objects that sometimes work sync-ish in pipelines. Add `await`.
+2. **Array args, not varargs**: multi-key / multi-value commands take a list, not positional args.
+3. **Default decoder returns `string`**: use `defaultDecoder: Decoder.Bytes` or per-command `{ decoder: Decoder.Bytes }` to get `Buffer` returns.
+
 ```javascript
-await redis.set("key", "value");
-await redis.set("key", "value", "EX", 60);
-await redis.set("key", "value", "NX");
-await redis.setex("key", 60, "value");
-const val = await redis.get("key");
-```
+// ioredis varargs:
+redis.del("k1", "k2", "k3");
+redis.exists("k1", "k2");
+redis.lpush("list", "a", "b", "c");
+redis.sadd("set", "a", "b", "c");
+redis.srem("set", "a", "b");
 
-**GLIDE:**
-```javascript
-import { TimeUnit } from "@valkey/valkey-glide";
-
-await client.set("key", "value");
-await client.set("key", "value", { expiry: { type: TimeUnit.Seconds, count: 60 } });
-await client.set("key", "value", { conditionalSet: "onlyIfDoesNotExist" });
-// No separate setex - use set() with expiry option
-const val = await client.get("key");
-```
-
----
-
-## Hash Operations
-
-**ioredis:**
-```javascript
-await redis.hset("hash", "f1", "v1", "f2", "v2");    // spread pairs
-await redis.hset("hash", { f1: "v1", f2: "v2" });     // also works
-const val = await redis.hget("hash", "f1");
-const all = await redis.hgetall("hash");                // {f1: "v1", f2: "v2"}
-```
-
-**GLIDE:**
-```javascript
-// Object form or HashDataType array form
-await client.hset("hash", { f1: "v1", f2: "v2" });
-await client.hset("hash", [{ field: "f1", value: "v1" }, { field: "f2", value: "v2" }]);
-const val = await client.hget("hash", "f1");
-const all = await client.hgetall("hash");               // Record<string, string>
-```
-
----
-
-## List Operations
-
-**ioredis:**
-```javascript
-await redis.lpush("list", "a", "b", "c");
-await redis.rpush("list", "x", "y");
-const val = await redis.lpop("list");
-const range = await redis.lrange("list", 0, -1);
-```
-
-**GLIDE:**
-```javascript
-await client.lpush("list", ["a", "b", "c"]);            // array arg
-await client.rpush("list", ["x", "y"]);
-const val = await client.lpop("list");
-const range = await client.lrange("list", 0, -1);
-```
-
----
-
-## Set Operations
-
-**ioredis:**
-```javascript
-await redis.sadd("set", "a", "b", "c");
-await redis.srem("set", "a", "b");
-const members = await redis.smembers("set");
-```
-
-**GLIDE:**
-```javascript
-await client.sadd("set", ["a", "b", "c"]);              // array arg
+// GLIDE: wrap the multi args in a list:
+await client.del(["k1", "k2", "k3"]);
+await client.exists(["k1", "k2"]);
+await client.lpush("list", ["a", "b", "c"]);
+await client.sadd("set", ["a", "b", "c"]);
 await client.srem("set", ["a", "b"]);
-const members = await client.smembers("set");
 ```
 
----
+## SET: typed options replace kwargs and specialized methods
 
-## Sorted Set Operations
+ioredis accepts positional kwargs (`"EX", 60`), plus specialized `setex` / `psetex` / `setnx`. GLIDE routes all of them through typed options on `set()` and drops the aliases.
 
-**ioredis:**
+| ioredis | GLIDE |
+|---------|-------|
+| `redis.set(k, v, "EX", 60)` | `await client.set(k, v, { expiry: { type: TimeUnit.Seconds, count: 60 } })` |
+| `redis.set(k, v, "PX", 500)` | `await client.set(k, v, { expiry: { type: TimeUnit.Milliseconds, count: 500 } })` |
+| `redis.set(k, v, "EXAT", ts)` | `await client.set(k, v, { expiry: { type: TimeUnit.UnixSeconds, count: ts } })` |
+| `redis.set(k, v, "PXAT", ms)` | `await client.set(k, v, { expiry: { type: TimeUnit.UnixMilliseconds, count: ms } })` |
+| `redis.set(k, v, "NX")` or `redis.setnx(k, v)` | `await client.set(k, v, { conditionalSet: "onlyIfDoesNotExist" })` |
+| `redis.set(k, v, "XX")` | `await client.set(k, v, { conditionalSet: "onlyIfExists" })` |
+| `redis.setex(k, 60, v)` | `await client.set(k, v, { expiry: { type: TimeUnit.Seconds, count: 60 } })` |
+| `redis.set(k, v, "KEEPTTL")` | `await client.set(k, v, { expiry: "keepExisting" })` |
+
+`TimeUnit` has four values: `Seconds`, `Milliseconds`, `UnixSeconds`, `UnixMilliseconds` (note the spelling - no typo, unlike Python's `UNIX_MILLSEC`). All PascalCase.
+
+`conditionalSet` for `set()` uses STRING LITERALS: `"onlyIfExists" | "onlyIfDoesNotExist" | "onlyIfEqual"`. Valkey 9.0's IFEQ needs `conditionalSet: "onlyIfEqual"` plus `comparisonValue: "..."`. Other commands (ZADD) use a separate `ConditionalChange` enum - they are NOT the same type.
+
+## HSET: takes an object, not spread pairs
+
 ```javascript
-await redis.zadd("zset", 1, "alice", 2, "bob");         // score, member pairs
-await redis.zadd("zset", "NX", 1, "alice");              // NX flag
-const score = await redis.zscore("zset", "alice");
-const range = await redis.zrange("zset", 0, -1, "WITHSCORES");
+// ioredis (either works):
+redis.hset("h", "f1", "v1", "f2", "v2");
+redis.hset("h", { f1: "v1", f2: "v2" });
+
+// GLIDE - object OR [{field, value}] array:
+await client.hset("h", { f1: "v1", f2: "v2" });
+await client.hset("h", [{ field: "f1", value: "v1" }, { field: "f2", value: "v2" }]);
 ```
 
-**GLIDE:**
+## ZADD: `{element, score}` objects, separate `zrangeWithScores`
+
 ```javascript
+// ioredis:
+redis.zadd("z", 1, "alice", 2, "bob");
+redis.zadd("z", "NX", 1, "alice");
+redis.zrange("z", 0, -1, "WITHSCORES");
+
+// GLIDE:
 import { ConditionalChange } from "@valkey/valkey-glide";
 
-// Array of {element, score} objects or Record<string, number>
-await client.zadd("zset", [
-    { element: "alice", score: 1 },
-    { element: "bob", score: 2 },
-]);
-await client.zadd("zset", { alice: 1 }, { conditionalChange: ConditionalChange.ONLY_IF_DOES_NOT_EXIST });
-const score = await client.zscore("zset", "alice");
-const range = await client.zrangeWithScores("zset", { start: 0, end: -1 });
+await client.zadd("z", [{ element: "alice", score: 1 }, { element: "bob", score: 2 }]);
+await client.zadd("z", { alice: 1 }, { conditionalChange: ConditionalChange.ONLY_IF_DOES_NOT_EXIST });
+await client.zrangeWithScores("z", { start: 0, stop: -1 });  // NOTE: `stop`, not `end`
 ```
 
----
+`ConditionalChange` is ALL_CAPS enum (GLIDE_NODE convention for this specific enum) with two values: `ONLY_IF_EXISTS`, `ONLY_IF_DOES_NOT_EXIST`. For ZADD only.
 
-## Delete and Exists
+## Cluster: `Redis.Cluster` -> `GlideClusterClient`
 
-**ioredis:**
 ```javascript
-await redis.del("k1", "k2", "k3");
-const count = await redis.exists("k1", "k2");
-```
-
-**GLIDE:**
-```javascript
-await client.del(["k1", "k2", "k3"]);                   // array arg
-const count = await client.exists(["k1", "k2"]);
-```
-
----
-
-## Cluster Mode
-
-**ioredis:**
-```javascript
+// ioredis:
 const cluster = new Redis.Cluster([
-    { host: "node1.example.com", port: 6379 },
-    { host: "node2.example.com", port: 6380 },
+    { host: "n1", port: 6379 }, { host: "n2", port: 6379 },
 ], { scaleReads: "slave" });
-```
 
-**GLIDE:**
-```javascript
-import { GlideClusterClient } from "@valkey/valkey-glide";
-
+// GLIDE:
 const client = await GlideClusterClient.createClient({
-    addresses: [
-        { host: "node1.example.com", port: 6379 },
-        { host: "node2.example.com", port: 6380 },
-    ],
+    addresses: [{ host: "n1", port: 6379 }, { host: "n2", port: 6379 }],
     readFrom: "preferReplica",
 });
 ```
 
-GLIDE auto-discovers the full topology from seed nodes. No natMap or manual slot configuration.
+Full topology auto-discovered from seed nodes. `scaleReads: "slave"` maps to `readFrom: "preferReplica"`. `natMap` / manual slot map / `skipFullCoverageCheck` have no equivalent; GLIDE handles discovery internally.
+
+## Everything else is named the same
+
+For 90% of commands (`get`, `hget`, `hgetall`, `lpop`, `lrange`, `smembers`, `sismember`, `zscore`, `exists`, `ttl`, `expire`, `keys`, `type`, `incr`/`decr`, `xadd`/`xread`/`xreadgroup`/`xack`, `publish` BUT WITH REVERSED ARGS, etc.) the only changes are the three universal ones at the top of this file. Just translate.

--- a/skills/valkey-glide-nodejs/.claude-plugin/plugin.json
+++ b/skills/valkey-glide-nodejs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "valkey-glide-nodejs",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Use when building Node.js/TypeScript apps with Valkey GLIDE - Promise API, GlideClient, TypeScript types, ESM/CJS, TLS, OpenTelemetry, Batch, PubSub, streams. Not for ioredis migration - use migrate-ioredis skill.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/SKILL.md
+++ b/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/SKILL.md
@@ -1,26 +1,58 @@
 ---
 name: valkey-glide-nodejs
-description: "Use when building Node.js/TypeScript apps with Valkey GLIDE - Promise API, GlideClient, TypeScript types, ESM/CJS, TLS, OpenTelemetry, Batch, PubSub, streams. Not for ioredis migration - use migrate-ioredis skill."
-version: 2.0.0
+description: "Use when building Node.js / TypeScript apps with Valkey GLIDE - Promise API, GlideClient, GlideClusterClient, multiplexer behavior, IAM, AZ affinity, OpenTelemetry, Batch, PubSub, streams. Covers the divergence from ioredis; basic command shapes are assumed knowable from training. Not for ioredis migration - use migrate-ioredis."
+version: 2.1.0
 argument-hint: "[API or config question]"
 ---
 
 # Valkey GLIDE Node.js Client
 
+Agent-facing skill for GLIDE Node. Assumes the reader can already write basic ioredis or node-redis from training (get/set/hset, pipelines, pub/sub EventEmitter loop). Covers only what diverges from those clients and what GLIDE adds on top.
+
 ## Routing
 
 | Question | Reference |
 |----------|-----------|
-| Install, setup, client creation, TLS, auth, reconnect | [connection](reference/features-connection.md) |
-| PubSub, subscribe, publish, sharded channels | [pubsub](reference/features-pubsub.md) |
-| Batching, transactions, pipelines | [batching](reference/features-batching.md) |
-| Streams, consumer groups, XADD, XREAD | [streams](reference/features-streams.md) |
-| TLS details, auth (password/IAM), Lua scripting, Valkey functions, error types, decoder, protocol version | [advanced](reference/features-advanced.md) |
-| Error types, retry, reconnection patterns | [error-handling](reference/best-practices-error-handling.md) |
-| Benchmarks, throughput, batching perf | [performance](reference/best-practices-performance.md) |
-| Timeouts, connection management, AZ affinity, OTel, cloud defaults | [production](reference/best-practices-production.md) |
+| `GlideClient` vs `GlideClusterClient`, TLS, auth, IAM, lazy connect, AZ affinity, decoder, close | [connection](reference/features-connection.md) |
+| PubSub: static config vs dynamic `subscribe` (2.3+), callback vs polling, `getSubscriptions()`, sharded | [pubsub](reference/features-pubsub.md) |
+| `Batch` / `ClusterBatch` (constructor `isAtomic`), `raiseOnError`, cluster retry strategy, WATCH | [batching](reference/features-batching.md) |
+| Streams typed option objects, split `xclaim` / `xclaimJustId`, split `xpending` / `xpendingWithOptions`, multi-stream slot constraint | [streams](reference/features-streams.md) |
+| TLS advanced config, IAM, Lua `Script` (requires `.release()`), Valkey Functions 7.0+, error hierarchy, Decoder | [advanced](reference/features-advanced.md) |
+| Error types: `ValkeyError` base (not `GlideError`), subclass hierarchy, reconnection semantics, no EventEmitter | [error-handling](reference/best-practices-error-handling.md) |
+| Multiplexer discipline, batching as top optimization, inflight cap, TCP_NODELAY, compression | [performance](reference/best-practices-performance.md) |
+| Production defaults, timeout tuning, AZ affinity, OTel setup, platform constraints (glibc, native binding, proxies) | [production](reference/best-practices-production.md) |
 
-## Cross-References
+## Multiplexer rule (the #1 agent mistake)
 
-- `valkey-glide` skill - shared architecture, cluster topology, connection model
-- `valkey` skill - Valkey server commands, data types, patterns
+One `GlideClient` / `GlideClusterClient` per process, shared across every pending Promise. Do not create per-request clients. Do not pool them.
+
+**Exceptions that need a dedicated client:**
+
+- Blocking commands (per the core's blocking-timeout table): `BLPOP`, `BRPOP`, `BLMOVE`, `BZPOPMAX`, `BZPOPMIN`, `BRPOPLPUSH`, `BLMPOP`, `BZMPOP`, plus `XREAD` / `XREADGROUP` when called with `BLOCK`, and `WAIT` / `WAITAOF`.
+- WATCH / MULTI / EXEC transactions (connection-state commands).
+- Long polling `getPubSubMessage()` (holds the Promise indefinitely).
+
+Large values are NOT an exception - they pipeline through the multiplexer fine.
+
+## Grep hazards
+
+1. **`decode_responses` has no direct equivalent, but `Decoder` does.** Default is `Decoder.String`; switch to `Decoder.Bytes` client-wide via `defaultDecoder` or per-command via `{ decoder: Decoder.Bytes }` to get `Buffer` returns.
+2. **`publish()` argument order is REVERSED from ioredis.** `await client.publish(message, channel)` - message first, channel second. ioredis is `client.publish(channel, message)`. Silent bug factory during migration.
+3. **`close()` is synchronous.** Returns `void`, not a `Promise`. Unlike Python where `close()` is async.
+4. **`getStatistics()` is synchronous.** Local accessor returning an object with string values. Unlike Python where it is `await client.get_statistics()`.
+5. **Error base is `ValkeyError`, NOT `GlideError`.** Python uses `GlideError`; Node uses `ValkeyError` as the abstract base. `RequestError` / `ClosingError` are direct subclasses.
+6. **`instanceof RequestError` catches timeouts, conn errors, config errors, exec aborts.** They are subclasses. Check specifics first.
+7. **Reconnection is infinite.** `connectionBackoff.numberOfRetries` caps the backoff SEQUENCE length; the client keeps retrying until close.
+8. **`periodicChecks.duration_in_sec` is snake_case** - unusual for a JS API; don't correct it to camelCase.
+9. **`ServiceType` is PascalCase enum values: `ServiceType.Elasticache` / `ServiceType.MemoryDB`.** All-caps variants don't exist.
+10. **`isAtomic` is a constructor arg, not an option object.** `new Batch(true)` for transaction, `new Batch(false)` for pipeline. `Transaction` / `ClusterTransaction` are deprecated aliases.
+11. **Scripts are NOT usable inside a Batch.** Use `batch.customCommand(["EVAL", ...])` instead. Also: `Script` objects are not garbage collected - always call `script.release()`.
+12. **No Alpine support** out of the box - requires glibc 2.17+. Use Debian-based images.
+13. **Static PubSub subscriptions require RESP3.** RESP2 raises `ConfigurationError`.
+14. **Node.js HAS dynamic pub/sub at v2.3+** (`subscribe`, `subscribeLazy`, `psubscribe`, `ssubscribe`, `unsubscribe`, `getSubscriptions`). Don't repeat the older docs claim that Node lacks it.
+
+## Cross-references
+
+- `migrate-ioredis` - migrating from ioredis
+- `glide-dev` - GLIDE core internals (Rust), binding mechanics
+- `valkey` - Valkey commands and app patterns

--- a/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/best-practices-error-handling.md
+++ b/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/best-practices-error-handling.md
@@ -1,132 +1,51 @@
-# Error Handling
+# Error Handling (Node.js)
 
-Use when implementing error handling, retry logic, or batch error semantics in the GLIDE Node.js client.
+Use for retry logic and batch error semantics. Covers GLIDE-specific divergence from ioredis (which throws `redis.ReplyError`, `MaxRetriesPerRequestError`, etc. or emits via EventEmitter).
 
-## Error Types
+## Hierarchy
 
-GLIDE exports typed error classes from `@valkey/valkey-glide`:
+Subclass tree from `@valkey/valkey-glide`:
 
-```typescript
-import {
-    RequestError,
-    TimeoutError,
-    ConnectionError,
-    ClosingError,
-} from "@valkey/valkey-glide";
+```
+ValkeyError (abstract)           # Node's base is ValkeyError (NOT GlideError like Python)
+├── ClosingError                 # client closed; create a new client
+└── RequestError                 # catches everything below too
+    ├── TimeoutError             # request exceeded requestTimeout (default 250ms)
+    ├── ExecAbortError           # atomic batch aborted (WATCH conflict, MULTI errors)
+    ├── ConnectionError          # temporary; GLIDE is auto-reconnecting
+    └── ConfigurationError       # invalid config (TLS mismatch, RESP2+PubSub)
 ```
 
-| Error | When It Occurs | Recovery |
-|-------|---------------|----------|
-| `RequestError` | Base class for server/protocol errors | Check message for details |
-| `TimeoutError` | Request exceeded `requestTimeout` (default 250ms) | Increase timeout or check server load |
-| `ConnectionError` | Connection lost | GLIDE auto-reconnects; retry the operation |
-| `ClosingError` | Client was closed while requests were pending | Create a new client |
+**Gotcha**: `instanceof RequestError` matches `TimeoutError`, `ConnectionError`, `ConfigurationError`, `ExecAbortError`. Order your `instanceof` checks specifics-first. Use `ValkeyError` only when you also want `ClosingError`.
 
-## Basic Error Handling
+## Divergence from ioredis
+
+| ioredis | GLIDE Node |
+|---------|-----------|
+| `client.on('error', err => ...)` EventEmitter | No event emitter - errors surface per-promise, `await` catches them |
+| `redis.ReplyError` for server errors | `RequestError` and subclasses |
+| Connection errors swallowed + auto-recovered silently | `ConnectionError` surfaces on the command; GLIDE is reconnecting in the background |
+| `MaxRetriesPerRequestError` after N retries | Reconnection is **infinite** - `BackoffStrategy.numberOfRetries` only caps the backoff curve length; client keeps retrying until close |
+| `client.status` property exposes connection state | No public status property - observe via command success/failure or `getStatistics()` counters |
+
+## Reconnection behavior
 
 ```typescript
-import { GlideClient, TimeoutError, ConnectionError, RequestError } from "@valkey/valkey-glide";
-
-try {
-    const value = await client.get("key");
-} catch (error) {
-    if (error instanceof TimeoutError) {
-        // Request exceeded requestTimeout - check server load or increase timeout
-    } else if (error instanceof ConnectionError) {
-        // Connection lost - GLIDE is already reconnecting
-        // Retry the operation after a brief delay
-    } else if (error instanceof RequestError) {
-        // General request failure (WRONGTYPE, auth errors, etc.)
-        console.error(`Request failed: ${error.message}`);
-    }
+connectionBackoff: {
+    numberOfRetries: 5,       // caps the BACKOFF sequence length, not total retries
+    factor: 100,              // ms base
+    exponentBase: 2,
+    jitterPercent: 20,        // optional
 }
 ```
 
-`RequestError` is the base class - catch it last as a catch-all.
+- Delay formula: `rand_jitter * factor * (exponentBase ** attempt)`, clamped at a ceiling.
+- After `numberOfRetries` the delay plateaus and reconnection continues infinitely until close.
+- Initial-connect permanent errors (`AuthenticationFailed`, `InvalidClientConfig`, `RESP3NotSupported`, plus string matches on `NOAUTH` / `WRONGPASS`) are not retried. After initial connect, the core keeps trying to reconnect regardless and surfaces `ConnectionError` per command until the server recovers or the client is closed.
+- PubSub channels resubscribe automatically via the synchronizer.
 
----
+## Failover and timeout
 
-## Batch Error Handling
+During cluster failover expect `ConnectionError` bursts for 1-5 seconds while the slot map refreshes. Retry is the right response.
 
-The `raiseOnError` parameter on `client.exec()` controls how batch errors surface:
-
-### raiseOnError = true
-
-Throws `RequestError` on the first error. Use when all commands must succeed.
-
-```typescript
-import { Batch, RequestError } from "@valkey/valkey-glide";
-
-const batch = new Batch(true).set("key", "val").get("key");
-try {
-    const results = await client.exec(batch, true);
-} catch (error) {
-    if (error instanceof RequestError) {
-        console.error(`Batch failed: ${error.message}`);
-    }
-}
-```
-
-### raiseOnError = false
-
-Errors appear inline in the results array. Use for partial-success workloads.
-
-```typescript
-import { Batch, RequestError } from "@valkey/valkey-glide";
-
-const batch = new Batch(false)
-    .set("key", "value")
-    .lpush("key", ["oops"])  // WRONGTYPE error
-    .get("key");
-
-const results = await client.exec(batch, false);
-for (const item of results!) {
-    if (item instanceof RequestError) {
-        console.log(`Failed: ${item.message}`);
-    } else {
-        console.log(`OK: ${item}`);
-    }
-}
-```
-
-Atomic batches with WATCH return `null` from `exec()` if a watched key was modified.
-
----
-
-## Reconnection Behavior
-
-GLIDE reconnects automatically on connection loss with exponential backoff:
-
-```typescript
-const client = await GlideClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    connectionBackoff: {
-        numberOfRetries: 5,
-        factor: 100,
-        exponentBase: 2,
-        jitterPercent: 20,
-    },
-});
-```
-
-- Delay formula: `rand(0 ... factor * (exponentBase ^ attempt))`
-- After `numberOfRetries`, delay stays at the ceiling indefinitely
-- PubSub channels are automatically resubscribed on reconnect
-- Permanent errors (NOAUTH, WRONGPASS) are not retried
-
----
-
-## Failover and Timeout
-
-During cluster failover, expect `ConnectionError` bursts for 1-5 seconds. GLIDE refreshes the slot map and re-routes automatically. Retry failed operations.
-
-Frequent `TimeoutError` indicates server load - verify before increasing timeout:
-
-```typescript
-const client = await GlideClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    requestTimeout: 1000, // ms, default 250
-});
-```
-
-GLIDE auto-extends timeouts for blocking commands (BLPOP, XREADGROUP BLOCK) by 500ms beyond the block duration.
+Frequent `TimeoutError` usually indicates server load, not a too-tight timeout. GLIDE auto-extends the effective timeout for blocking commands (BLPOP/BRPOP/BLMOVE/BZPOPMAX/BZPOPMIN/BRPOPLPUSH/BLMPOP/BZMPOP and XREAD/XREADGROUP with BLOCK) by 0.5 s beyond the block duration - no tuning required.

--- a/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/best-practices-performance.md
+++ b/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/best-practices-performance.md
@@ -1,87 +1,53 @@
-# Performance Tuning
+# Performance tuning (Node.js)
 
-Use when optimizing GLIDE Node.js throughput and latency, tuning inflight limits, or choosing batching strategies.
+Use when optimizing GLIDE Node throughput and latency. Covers GLIDE-specific discipline - general Node async patterns (`Promise.all`, don't `await` in tight loops) are the same as any Node app and not covered here.
 
-## Batching Is the Top Optimization
+## Client model: one client per process, not per request
 
-Batching amortizes the napi-rs FFI overhead across all commands - one crossing per batch instead of one per command. Batched workloads are competitive with native Node.js clients (ioredis, node-redis).
+GLIDE is a multiplexer. One `GlideClient` / `GlideClusterClient` instance serves every pending Promise in the process concurrently - requests are tagged with IDs and demuxed. Creating a client per request or per worker thread is wasted allocation and a fresh TCP handshake to every cluster node.
 
-### Non-Atomic Pipeline
+**Exceptions - use a dedicated client:**
+
+- Blocking commands: `BLPOP`, `BRPOP`, `BLMOVE`, `BZPOPMAX`, `BZPOPMIN`, `BRPOPLPUSH`, `BLMPOP`, `BZMPOP`, plus `XREAD` / `XREADGROUP` with `BLOCK`. They occupy the multiplexed connection for the block duration.
+- WATCH / MULTI / EXEC - connection-state commands; leak across callers on the shared multiplexer.
+- Long polling `getPubSubMessage()` - holds the Promise indefinitely.
+
+Large values are NOT an exception - they pipeline through the multiplexer fine.
+
+## Batching is the top optimization
+
+Batching amortizes the napi-rs FFI + UDS crossing across all commands - one crossing per batch instead of one per command. This is the single biggest throughput knob.
 
 ```typescript
 import { Batch } from "@valkey/valkey-glide";
 
 const batch = new Batch(false);
-for (let i = 0; i < 100; i++) {
-    batch.set(`key:${i}`, `value:${i}`);
-}
-const results = await client.exec(batch, true);
-// One round-trip for 100 commands
+for (let i = 0; i < 100; i++) batch.set(`k:${i}`, `v:${i}`);
+await client.exec(batch, true);  // one round-trip, one multiplexer slot
 ```
 
-### Atomic Transaction
+In cluster mode, atomic batches require all keys to share a hash slot: `batch.set("{account}:src", ...)`, `batch.set("{account}:dst", ...)`.
 
-```typescript
-const tx = new Batch(true)
-    .set("{account}:src", "100")
-    .set("{account}:dst", "0")
-    .incrBy("{account}:dst", 50)
-    .decrBy("{account}:src", 50);
-const results = await client.exec(tx, true);
-```
+Rough batch-size guidelines:
 
-All keys must share a hash slot in cluster mode. Use `{tag}` hash tags.
+| Size | Trade-off |
+|------|-----------|
+| 10-50 | Good default; low latency, solid throughput gain |
+| 50-200 | Best throughput; slight per-batch latency increase |
+| 200-1000 | Diminishing returns, large response buffers |
+| 1000+ | Memory pressure, long parsing - avoid |
 
-### Batch Size Guidelines
+## Inflight request limit
 
-| Batch Size | Trade-off |
-|------------|-----------|
-| 10-50 | Good default. Low latency, solid throughput gain |
-| 50-200 | Best throughput. Slight increase in per-batch latency |
-| 200-1000 | Diminishing returns. Risk of large response buffers |
-| 1000+ | Avoid. Memory pressure and long parsing time |
+The multiplexer caps concurrent inflight requests at `inflightRequestsLimit: 1000` per client by default. Beyond the cap, requests fail with `RequestError("Reached maximum inflight requests")` - rejected, not queued.
 
----
+If you hit it: first batch commands (one batch = one slot), then consider whether 1000 concurrent in-flight is actually the bottleneck (usually it's server-side). Only as a last resort create a second client - doubling clients doubles the TCP footprint and breaks the single-multiplexer invariant.
 
-## Inflight Request Limit
+## TCP_NODELAY
 
-GLIDE caps concurrent inflight requests at 1000 per client. Requests beyond the limit are rejected immediately.
+Default `true` - commands sent immediately rather than Nagle-buffered. Almost always the right choice for request/response traffic. Disable (`advancedConfiguration: { tcpNoDelay: false }`) only if benchmarks show TCP-level batching helps your workload.
 
-```typescript
-const client = await GlideClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    inflightRequestsLimit: 500, // lower for constrained servers
-});
-```
+## Compression
 
-If hitting the limit:
-1. Batch commands - one batch counts as one inflight request
-2. Create additional client instances - each gets its own 1000-request budget
-3. Review concurrency - 1000+ concurrent requests usually means the bottleneck is server-side
-
----
-
-## Connection Model
-
-GLIDE uses a single multiplexed connection per node. No connection pools to size or manage. All requests pipeline through one connection using Valkey's built-in pipelining.
-
-### When to Create Multiple Clients
-
-- Blocking commands (BLPOP, BRPOP, XREADGROUP with BLOCK) - tie up the connection
-- WATCH/UNWATCH - requires connection-level isolation
-- Large value transfers - prevents head-of-line blocking
-- PubSub subscribers - dedicated listener, cannot share with command traffic
-
----
-
-## TCP Tuning
-
-GLIDE enables TCP_NODELAY by default (Nagle's algorithm disabled). Commands are sent immediately rather than buffered. Only disable after benchmarking confirms TCP-level batching improves throughput for your workload.
-
-```typescript
-const client = await GlideClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    advancedConfiguration: { tcpNoDelay: true }, // default
-});
-```
+GLIDE offers transparent value compression on the core side, configured via the connection config - see [features-connection](features-connection.md). Monitor effect via `client.getStatistics()` keys `total_bytes_compressed` vs `total_original_bytes` vs `compression_skipped_count`.
 

--- a/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/best-practices-production.md
+++ b/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/best-practices-production.md
@@ -1,137 +1,74 @@
-# Production Deployment
+# Production deployment (Node.js)
 
-Use when deploying GLIDE Node.js to production, configuring timeouts, managing connections, or setting up observability.
+Use when deploying GLIDE Node to production. Covers GLIDE-specific defaults and pitfalls that matter for operators. For basic setup examples see [features-connection](features-connection.md).
 
-## Connection Management
+## One client per process
 
-### Single Client Per Application
+Do not pool `GlideClient` / `GlideClusterClient`. The multiplexer is the pool. Creating N clients opens N sets of TCP connections to every node and defeats the connection-state tracking the core does.
 
-GLIDE multiplexes all requests over one connection per node. Do not create client pools.
+Use `lazyConnect: true` if your app must start before Valkey is reachable - the first command pays the connection cost. Always call `client.close()` on shutdown (synchronous - returns `void`, not a Promise); pending promises get `ClosingError`.
 
-```typescript
-// Correct: one client shared across the application
-const client = await GlideClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-});
+## GLIDE defaults agents should know
 
-// Wrong: do not pool GLIDE clients
-// const clients = await Promise.all(Array(10).fill(null).map(() => GlideClient.createClient(config)));
-```
+| Knob | Default | Config |
+|------|---------|--------|
+| Request timeout | 250 ms | `requestTimeout` |
+| Connection timeout | 2000 ms | `advancedConfiguration.connectionTimeout` |
+| Inflight request cap | 1000 | `inflightRequestsLimit` |
+| Topology check interval (cluster) | default configs | `periodicChecks: { duration_in_sec: n }` for manual; note `duration_in_sec` is snake_case |
+| Backoff retries | (infinite; cap only on sequence length) | `connectionBackoff` |
+| Protocol | RESP3 | `protocol: ProtocolVersion.RESP2` to downgrade |
+| TCP_NODELAY | true | `advancedConfiguration.tcpNoDelay` |
+| Default decoder | `Decoder.String` | `defaultDecoder: Decoder.Bytes` for Buffer returns |
 
-### Lazy Connect
+Blocking-command timeout auto-extension: 0.5 s beyond the block duration. No tuning required.
 
-Defers connection until the first command. Allows startup when the server is not yet available.
+## Timeout tuning
 
-```typescript
-const client = await GlideClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    lazyConnect: true,
-});
-// No connection yet - first command triggers it
-await client.ping();
-```
+The 250 ms default is tight. Raise per-workload, not globally:
 
-### Client Cleanup
+| Workload | Recommended |
+|----------|-------------|
+| Cache lookup (GET, HGET) | 250-500 ms |
+| Writes (SET, HSET, ZADD) | 250-500 ms |
+| Complex (SORT, SCAN, ZRANGEBYSCORE large) | 1-5 s |
+| Lua scripts | 5-30 s |
+| Blocking commands | Auto-extended - do not raise |
 
-Always close clients on shutdown. Pending promises are rejected with `ClosingError`.
+## Cluster: seed nodes and AZ affinity
 
-```typescript
-client.close();
-client.close("Shutting down gracefully"); // custom error message
-```
+Provide multiple seed addresses for redundancy. Topology is auto-discovered.
 
----
-
-## Timeout Configuration
-
-| Timeout | Default | Config Property |
-|---------|---------|----------------|
-| Request timeout | 250ms | `requestTimeout` |
-| Connection timeout | 2000ms | `advancedConfiguration.connectionTimeout` |
-
-### Tuning by Workload
-
-| Workload | Recommended Timeout |
-|----------|-------------------|
-| Cache lookups (GET, HGET) | 250-500ms |
-| Write operations (SET, HSET) | 250-500ms |
-| Complex operations (SORT, SCAN) | 1000-5000ms |
-| Lua scripts (EVALSHA) | 5000-30000ms |
-| Blocking commands (BLPOP, XREADGROUP) | Handled automatically |
-
-GLIDE extends blocking command timeouts by 500ms beyond the block duration.
-
-```typescript
-const client = await GlideClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    requestTimeout: 1000,
-    advancedConfiguration: { connectionTimeout: 5000 },
-});
-```
-
----
-
-## Cluster Configuration
-
-Provide multiple seed nodes for redundancy. GLIDE discovers the full topology automatically.
-
-### AZ Affinity
-
-Route reads to same-AZ replicas to reduce latency and cross-AZ costs:
-
-```typescript
-const client = await GlideClusterClient.createClient({
-    addresses: [{ host: "node1.example.com", port: 6379 }],
-    readFrom: "AZAffinity",
-    clientAz: "us-east-1a",
-});
-```
+`readFrom` strategies:
 
 | Strategy | Behavior |
 |----------|----------|
 | `"primary"` | All reads to primary (default) |
-| `"preferReplica"` | Round-robin replicas, fallback to primary |
-| `"AZAffinity"` | Prefer same-AZ replicas |
-| `"AZAffinityReplicasAndPrimary"` | Same-AZ replicas, then primary, then remote |
+| `"preferReplica"` | Round-robin replicas, fall back to primary |
+| `"AZAffinity"` | Same-AZ replicas preferred, then other replicas, then primary |
+| `"AZAffinityReplicasAndPrimary"` | Same-AZ replicas, then same-AZ primary, then any replica, then primary |
 
-Requires Valkey 8.0+ with `availability-zone` configured on each server node.
-
----
+AZ-affinity strategies require `clientAz` AND the server exposing availability-zone metadata in `CLUSTER SHARDS` - otherwise falls back to primary.
 
 ## OpenTelemetry
 
-OTel is initialized globally before creating any clients:
+Initialize once, globally, before creating any clients:
 
 ```typescript
 import { OpenTelemetry } from "@valkey/valkey-glide";
 
 OpenTelemetry.init({
-    traces: {
-        endpoint: "http://otel-collector:4317",
-        samplePercentage: 1,  // 1% for production
-    },
-    metrics: {
-        endpoint: "http://otel-collector:4317",
-    },
+    traces: { endpoint: "http://otel-collector:4317", samplePercentage: 1 },
+    metrics: { endpoint: "http://otel-collector:4317" },
     flushIntervalMs: 5000,
 });
 ```
 
-| Environment | Sample Rate |
-|-------------|------------|
-| Production | 1-2% |
-| Staging | 5-10% |
-| Debugging | 50-100% |
+Rough sampling rates: 1-2% prod, 5-10% staging, 50-100% debugging.
 
----
+## Platform constraints
 
-## Connection Defaults
-
-| Parameter | Default |
-|-----------|---------|
-| Request timeout | 250ms |
-| Connection timeout | 2000ms |
-| Inflight request limit | 1000 |
-| Connections per node | 2 (data + management) |
-| Topology check | 60s |
-| Protocol | RESP3 |
+- **glibc 2.17+** required on Linux. Alpine (musl) is NOT supported out of the box - use Debian/Ubuntu-based images. Prebuilt wheels for musl exist in some distributions but are not part of the official matrix.
+- **Native binding**: `@valkey/valkey-glide` ships a platform-specific `@valkey/valkey-glide-<os>-<arch>` native package. Lockfile regeneration on different OS/arch combos can pull the wrong native binary - keep `npm ci` in CI aligned with the target platform.
+- **Proxies / connection inspectors**: GLIDE sends `CLIENT SETNAME`, `CLIENT SETINFO`, `INFO REPLICATION` during setup. Transparent proxies that strip or rewrite these will break topology detection.
+- **Protocol**: RESP3 is the default. RESP2 is accepted but static PubSub subscriptions require RESP3 and raise `ConfigurationError` otherwise.

--- a/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-advanced.md
+++ b/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-advanced.md
@@ -1,187 +1,93 @@
-# Advanced Features
+# Advanced features (Node.js)
 
-Use when configuring TLS, authentication, Lua scripting, protocol version, response decoding, or handling error types in the GLIDE Node.js client.
+Use when configuring TLS, IAM authentication, Lua scripts, Valkey Functions, the decoder, or handling error types. Covers GLIDE-specific divergence from ioredis; basic setup examples are in [features-connection](features-connection.md).
 
-## Contents
+## TLS and mTLS
 
-- TLS Configuration (line 16)
-- Authentication (line 45)
-- Lua Scripting (line 98)
-- Error Types (line 151)
-- Decoder Options (line 186)
-- Protocol Version (line 210)
-- Valkey Functions (7.0+) (line 228)
-- Client Statistics (line 282)
-
-## TLS Configuration
-
-Enable TLS with `useTLS`. The server must also be configured for TLS.
+Basic TLS is `useTLS: true` at the top of the config. Everything else (custom CA, insecure dev mode) is in `advancedConfiguration.tlsAdvancedConfiguration`:
 
 ```typescript
-const client = await GlideClient.createClient({
-    addresses: [{ host: "valkey.example.com", port: 6380 }],
-    useTLS: true,
-});
-```
-
-Custom CA certificates and insecure mode are set via `advancedConfiguration`:
-
-```typescript
-import { readFileSync } from "fs";
-
-const client = await GlideClient.createClient({
-    addresses: [{ host: "valkey.example.com", port: 6380 }],
-    useTLS: true,
-    advancedConfiguration: {
-        connectionTimeout: 5000, // ms, default 2000
-        tlsAdvancedConfiguration: {
-            rootCertificates: readFileSync("/path/to/ca.pem"), // string or Buffer, PEM format
-            // insecure: true, // skip cert verification - dev only, throws ConfigurationError without useTLS
-        },
+advancedConfiguration: {
+    connectionTimeout: 5000,
+    tlsAdvancedConfiguration: {
+        rootCertificates: readFileSync("/path/to/ca.pem"),  // string | Buffer, PEM
+        insecure: false,  // true bypasses cert verification; throws ConfigurationError without useTLS
     },
-});
+}
 ```
 
-## Authentication
+## IAM auth (AWS ElastiCache / MemoryDB)
 
-### Password-Based
-
-Pass `credentials` with `password` and optional `username`. If `username` is omitted, Valkey uses `"default"`.
+GLIDE-only, no ioredis equivalent. Password and IAM are mutually exclusive on one `credentials` object; IAM requires TLS and a username.
 
 ```typescript
-const client = await GlideClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    credentials: { username: "myuser", password: "mypass" },
-});
-```
+import { ServiceType } from "@valkey/valkey-glide";
 
-### IAM Authentication (AWS)
-
-For ElastiCache or MemoryDB. Requires `username`, `iamConfig`, and TLS. Password and IAM are mutually exclusive.
-
-```typescript
-import { GlideClient, ServiceType } from "@valkey/valkey-glide";
-
-const client = await GlideClient.createClient({
-    addresses: [{ host: "my-cluster.amazonaws.com", port: 6379 }],
-    useTLS: true,
-    credentials: {
-        username: "myIamUser",
-        iamConfig: {
-            clusterName: "my-cluster",
-            service: ServiceType.Elasticache, // or ServiceType.MemoryDB
-            region: "us-east-1",
-            refreshIntervalSeconds: 300, // optional, default 300
-        },
+credentials: {
+    username: "iam-user",
+    iamConfig: {
+        clusterName: "my-cluster",
+        service: ServiceType.Elasticache,  // or ServiceType.MemoryDB (PascalCase!)
+        region: "us-east-1",
+        refreshIntervalSeconds: 300,  // optional; default 300
     },
-});
+}
 ```
 
-### Runtime Password Update
-
-Update the stored password without recreating the client. Not supported with IAM.
+Runtime credential updates:
 
 ```typescript
-await client.updateConnectionPassword("newpass", true); // true = re-auth immediately
+await client.updateConnectionPassword("newpass");          // stored; used on next reconnect
+await client.updateConnectionPassword("newpass", true);    // re-AUTH immediately
+await client.updateConnectionPassword(null);               // clear stored password
+await client.refreshIamToken();                            // force IAM refresh; throws ConfigurationError if IAM not configured
 ```
-
-### Manual IAM Token Refresh
-
-Force an immediate IAM token refresh outside the automatic interval. Only available when IAM authentication is configured.
-
-```typescript
-await client.refreshIamToken(); // => "OK"
-```
-
-**Signature:** `refreshIamToken() => Promise<GlideString>` - throws `ConfigurationError` if IAM is not enabled.
 
 ## Lua Scripting
 
-The `Script` class manages Lua script caching via `EVALSHA` with automatic `EVAL` fallback. Script objects are NOT garbage collected - call `release()` when done.
+Replaces ioredis's `defineCommand` pattern. The `Script` class wraps `EVALSHA` with automatic `EVAL` fallback.
+
+**Critical**: `Script` objects are NOT garbage collected - always call `.release()` when done, or you leak native memory.
 
 ```typescript
 import { Script } from "@valkey/valkey-glide";
 
 const script = new Script("return { KEYS[1], ARGV[1] }");
-const result = await client.invokeScript(script, {
-    keys: ["mykey"],
-    args: ["myvalue"],
-});
-console.log(result); // ["mykey", "myvalue"]
-script.release();
-```
-
-Server-side logic example:
-
-```typescript
-const script = new Script(`
-    redis.call('SET', KEYS[1], ARGV[1])
-    return redis.call('GET', KEYS[1])
-`);
-const result = await client.invokeScript(script, {
-    keys: ["counter"],
-    args: ["42"],
-});
-script.release();
-```
-
-In cluster mode, all keys must map to the same hash slot. For keyless scripts use `invokeScriptWithRoute` on `GlideClusterClient`:
-
-```typescript
-const result = await clusterClient.invokeScriptWithRoute(script, { args: ["bar"] });
-```
-
-| Method | Description |
-|--------|-------------|
-| `new Script(code)` | Create script, compute SHA1, store in memory |
-| `script.getHash()` | Return the SHA1 hash string |
-| `script.release()` | Decrement ref count; free memory when zero |
-
-Retrieve a cached script's source (Valkey 8.0+):
-
-```typescript
-const source = await client.scriptShow(script.getHash());
-// Returns the original Lua source code
-```
-
-**Signature:** `scriptShow(sha1, options?) => Promise<GlideString>` - throws if SHA1 not in cache.
-
-Scripts are NOT supported in batch operations. Use `customCommand(["EVAL", ...])` in batches instead.
-
-## Error Types
-
-All errors extend `ValkeyError`. Import from `@valkey/valkey-glide`.
-
-| Error | Parent | When |
-|-------|--------|------|
-| `RequestError` | `ValkeyError` | Server-side or protocol error |
-| `TimeoutError` | `RequestError` | Request exceeded `requestTimeout` (default 250ms) |
-| `ConnectionError` | `RequestError` | Connection lost; auto-reconnect in progress |
-| `ExecAbortError` | `RequestError` | Atomic batch aborted (WATCH conflict) |
-| `ConfigurationError` | `RequestError` | Invalid config (TLS mismatch, missing params) |
-| `ClosingError` | `ValkeyError` | Client closed; must create a new client |
-
-```typescript
-import {
-    ClosingError, ConnectionError, RequestError, TimeoutError,
-} from "@valkey/valkey-glide";
-
 try {
-    const value = await client.get("key");
-} catch (error) {
-    if (error instanceof TimeoutError) {
-        // Increase requestTimeout or check server load
-    } else if (error instanceof ConnectionError) {
-        // Transient - GLIDE is auto-reconnecting
-    } else if (error instanceof ClosingError) {
-        // Terminal - create a new client
-    } else if (error instanceof RequestError) {
-        // General failure
-    }
+    const result = await client.invokeScript(script, {
+        keys: ["mykey"],
+        args: ["myvalue"],
+    });
+} finally {
+    script.release();
 }
 ```
 
-Check specific subclasses before `RequestError` - `TimeoutError`, `ConnectionError`, `ExecAbortError`, and `ConfigurationError` all extend it.
+Cluster: keyed scripts require all keys in one hash slot. For keyless scripts with explicit routing:
+
+```typescript
+await clusterClient.invokeScriptWithRoute(script, { args: ["bar"], route: "randomNode" });
+```
+
+Retrieve cached source (Valkey 8.0+): `await client.scriptShow(script.getHash())`.
+
+**Scripts are NOT usable inside a Batch.** For scripts in a batch, call `batch.customCommand(["EVAL", ...])` instead.
+
+## Error hierarchy
+
+Subclass tree in `@valkey/valkey-glide`:
+
+```
+ValkeyError (abstract)           # Node's base is ValkeyError, NOT GlideError (Python uses GlideError)
+├── ClosingError                 # client closed; must create a new client
+└── RequestError                 # catches everything below too
+    ├── TimeoutError             # request exceeded requestTimeout (default 250ms)
+    ├── ExecAbortError           # atomic batch aborted (WATCH conflict, MULTI errors)
+    ├── ConnectionError          # temporary - auto-reconnect in progress
+    └── ConfigurationError       # invalid config (TLS mismatch, RESP2+PubSub, etc.)
+```
+
+**Common mistake**: catching `RequestError` also catches `TimeoutError`, `ConnectionError`, `ConfigurationError`, `ExecAbortError` - they are subclasses, not siblings. Check specific subclasses first. Use `ValkeyError` only when you also want `ClosingError`.
 
 ## Decoder Options
 
@@ -227,65 +133,33 @@ const client = await GlideClient.createClient({
 
 ## Valkey Functions (7.0+)
 
-Server-side functions loaded from libraries. Unlike Lua scripts, functions persist across restarts and support named invocation. These methods are on `GlideClient` (standalone) and `GlideClusterClient` (cluster).
+ioredis has no first-class Functions support - this is entirely new territory for migrating agents. Functions persist across restarts (unlike scripts) and support named invocation.
+
+Methods on `GlideClient` and `GlideClusterClient`:
+
+| Method | Purpose |
+|--------|---------|
+| `functionLoad(code, { replace? })` | Load a library; returns library name |
+| `functionDelete(libName)` | Delete one library |
+| `functionList({ libNamePattern?, withCode? })` | List libraries / functions |
+| `functionStats({ route? })` | Running function info + engine stats |
+| `functionFlush(mode?)` | Delete all libraries; mode `FlushMode.SYNC` / `ASYNC` |
+| `functionKill()` | Kill a running read-only function |
+| `functionDump()` → `Buffer` | Serialize all libraries |
+| `functionRestore(payload, policy?)` | Restore from dump; `FunctionRestorePolicy.APPEND`/`FLUSH`/`REPLACE` |
+| `fcall(func, keys, args, options?)` | Invoke a loaded function |
+| `fcallReadonly(func, keys, args, options?)` | Read-only variant (replica-safe) |
+
+Cluster-only variants route explicitly: `fcallWithRoute` / `fcallReadonlyWithRoute` on `GlideClusterClient`.
+
+Example library shebang: `"#!lua name=mylib\nredis.register_function('myfunc', function(keys, args) return args[1] end)"`.
+
+## Client statistics
+
+Returns internal GLIDE core telemetry (multiplexer counters, compression ratios, PubSub sync). **Synchronous** - it's a local accessor, not a server call (unlike Python which exposes the same as an async method).
 
 ```typescript
-import { GlideClient, FlushMode, FunctionRestorePolicy } from "@valkey/valkey-glide";
-
-// Load a library with a function
-const code = "#!lua name=mylib \n redis.register_function('myfunc', function(keys, args) return args[1] end)";
-const libName = await client.functionLoad(code, { replace: true });
-// "mylib"
-
-// Call the function
-const result = await client.fcall("myfunc", ["key1"], ["hello"]);
-// "hello"
-
-// Read-only variant - safe for replicas
-const roResult = await client.fcallReadonly("myfunc", ["key1"], ["hello"]);
-
-// List libraries and their functions
-const libs = await client.functionList({ libNamePattern: "mylib*", withCode: true });
-// [{ library_name: "mylib", engine: "LUA", functions: [{ name: "myfunc", ... }], library_code: "..." }]
-
-// Stats - running function info and engine stats
-const stats = await client.functionStats();
-// { "127.0.0.1:6379": { running_script: null, engines: { LUA: { libraries_count: 1, functions_count: 1 } } } }
-
-// Delete a library
-await client.functionDelete("mylib"); // "OK"
-
-// Flush all libraries
-await client.functionFlush(FlushMode.SYNC); // "OK"
-
-// Kill a running read-only function
-await client.functionKill(); // "OK"
-
-// Dump/Restore for migration
-const payload = await client.functionDump();      // Buffer
-await client.functionRestore(payload, FunctionRestorePolicy.REPLACE); // "OK"
+const stats = client.getStatistics();  // { total_connections: "1", ... } - all values stringified
 ```
 
-| Method | Signature | Description |
-|--------|-----------|-------------|
-| `functionLoad` | `(code, options?) => Promise<GlideString>` | Load library; `options.replace` overwrites |
-| `functionDelete` | `(libraryName) => Promise<"OK">` | Delete a library and its functions |
-| `functionList` | `(options?) => Promise<FunctionListResponse>` | List libraries; filter with `libNamePattern` |
-| `functionStats` | `(options?) => Promise<FunctionStatsFullResponse>` | Running function and engine info |
-| `functionFlush` | `(mode?) => Promise<"OK">` | Delete all libraries |
-| `functionKill` | `() => Promise<"OK">` | Kill running read-only function |
-| `functionDump` | `() => Promise<Buffer>` | Serialize all libraries |
-| `functionRestore` | `(payload, policy?) => Promise<"OK">` | Restore from dump; policy: APPEND, FLUSH, REPLACE |
-| `fcall` | `(func, keys, args, options?) => Promise<GlideReturnType>` | Invoke a loaded function |
-| `fcallReadonly` | `(func, keys, args, options?) => Promise<GlideReturnType>` | Invoke read-only function (replica-safe) |
-
-## Client Statistics
-
-Returns internal GLIDE core statistics. Synchronous - not a server command.
-
-```typescript
-const stats = client.getStatistics();
-console.log(stats); // { total_connections: 1, ... }
-```
-
-**Signature:** `getStatistics() => object`
+Keys: `total_connections`, `total_clients`, `total_values_compressed`, `total_values_decompressed`, `total_original_bytes`, `total_bytes_compressed`, `total_bytes_decompressed`, `compression_skipped_count`, `subscription_out_of_sync_count`, `subscription_last_sync_timestamp`.

--- a/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-batching.md
+++ b/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-batching.md
@@ -1,209 +1,90 @@
-# Batching - Pipelines and Transactions (Node.js)
+# Batching - pipelines and transactions (Node.js)
 
-Use when you need to send multiple commands in a single round-trip for throughput or atomicity - pipelines for bulk operations, transactions for atomic multi-command blocks.
+Use when sending multiple commands in one round-trip. Pipelines for bulk throughput, transactions for atomicity. Covers what differs from ioredis's `pipeline()` / `multi()` pattern - the basic "queue commands, run them" shape is similar and not covered here.
 
-Requires: `@valkey/valkey-glide` 2.0+.
+## Divergence from ioredis
 
-## Contents
+| ioredis | GLIDE |
+|---------|-------|
+| `client.pipeline().set("k","v").exec()` | `client.exec(new Batch(false).set("k","v"), true)` |
+| `client.multi().set("k","v").exec()` | `client.exec(new Batch(true).set("k","v"), true)` |
+| Pipeline is chainable on the client | `Batch` / `ClusterBatch` are standalone objects handed to the client's `exec()` |
+| Separate pipeline vs transaction methods | Unified `Batch` / `ClusterBatch` with constructor `isAtomic` flag |
+| Errors via tuple `[err, result]` per command | Errors via `raiseOnError` - `true` throws on first, `false` puts `RequestError` in the results array inline |
+| Cluster pipelining: manual slot split | `ClusterBatch(false)` auto-splits per-slot; multi-node batches dispatched automatically |
+| `Transaction` / `ClusterTransaction` classes | Deprecated aliases for `new Batch(true)` / `new ClusterBatch(true)`; migrating code may still reference them |
 
-- How Batching Differs from ioredis pipeline() (line 17)
-- Batch vs ClusterBatch vs Transaction vs ClusterTransaction (line 32)
-- Creating a Batch, Adding Commands, Executing (line 43)
-- Error Handling in Batch Results (line 93)
-- Complete Example: Batch Write 50 Products (line 140)
-- Cluster Routing Behavior (line 201)
-- Standalone-Only Commands (line 207)
+## Classes
 
-## How Batching Differs from ioredis pipeline()
+| Class | Client | Mode |
+|-------|--------|------|
+| `Batch` | `GlideClient` | `new Batch(isAtomic: boolean)`; has `.select(index)` for DB switching (not on cluster) |
+| `ClusterBatch` | `GlideClusterClient` | `new ClusterBatch(isAtomic: boolean)`; has sharded `.publish()` |
+| `Transaction` | `GlideClient` | Deprecated alias for `new Batch(true)` |
+| `ClusterTransaction` | `GlideClusterClient` | Deprecated alias for `new ClusterBatch(true)` |
 
-In ioredis you call `client.pipeline()` to get a chainable pipeline, then `.exec()`. In GLIDE, you construct a `Batch` or `ClusterBatch` object with an `isAtomic` flag, chain commands on it, then pass it to `client.exec()`. The same class handles both pipelines and transactions - the `isAtomic` constructor argument controls the mode.
+All four extend `BaseBatch<T>` with fluent chaining - every command method returns `this`.
 
-| ioredis | GLIDE equivalent |
-|---------|-----------------|
-| `client.pipeline().set("k","v").get("k").exec()` | `client.exec(new Batch(false).set("k","v").get("k"), true)` |
-| `client.multi().set("k","v").get("k").exec()` | `client.exec(new Batch(true).set("k","v").get("k"), true)` |
-
-Key differences:
-
-- GLIDE batches are standalone objects - you construct them, add commands, then hand them to the client.
-- The `raiseOnError` parameter on `exec()` controls whether errors throw or appear inline in the results array.
-- `Transaction` and `ClusterTransaction` still exist as deprecated aliases. Prefer `Batch` and `ClusterBatch`.
-
-## Batch vs ClusterBatch vs Transaction vs ClusterTransaction
-
-| Class | Client | isAtomic | Notes |
-|-------|--------|----------|-------|
-| `Batch` | `GlideClient` (standalone) | Constructor arg | Has `select()` for DB switching |
-| `ClusterBatch` | `GlideClusterClient` | Constructor arg | Has `publish()` with sharded mode, `pubsubShardChannels()` |
-| `Transaction` | `GlideClient` | Always `true` | **Deprecated** - alias for `new Batch(true)` |
-| `ClusterTransaction` | `GlideClusterClient` | Always `true` | **Deprecated** - alias for `new ClusterBatch(true)` |
-
-All four extend `BaseBatch<T>` which provides the full command set (GET, SET, HSET, LPUSH, ZADD, etc.) with fluent chaining - every command method returns `this`.
-
-## Creating a Batch, Adding Commands, Executing
+## Minimal shape
 
 ```typescript
-import { GlideClient, Batch } from "@valkey/valkey-glide";
+import { Batch, RequestError } from "@valkey/valkey-glide";
 
-const client = await GlideClient.createClient({ addresses: [{ host: "localhost", port: 6379 }] });
-
-// Non-atomic pipeline
-const result = await client.exec(
-    new Batch(false).set("key1", "value1").set("key2", "value2").get("key1").get("key2"),
-    true,
+const results = await client.exec(
+    new Batch(false).set("k1", "v1").incr("k1").get("k1"),
+    true,  // raiseOnError
 );
-// result: ["OK", "OK", "value1", "value2"]
-
-// Atomic transaction
-const txResult = await client.exec(
-    new Batch(true).set("account:src", "100").incrBy("account:src", 50),
-    true,
-);
-// txResult: ["OK", 150]
 ```
 
-### Cluster mode
+Cluster atomic batches require all keys to share a hash slot (use `{tag}` hash tags). Cluster non-atomic batches split per-slot automatically.
+
+## `exec()` signatures
 
 ```typescript
-import { GlideClusterClient, ClusterBatch } from "@valkey/valkey-glide";
-
-const clusterClient = await GlideClusterClient.createClient({
-    addresses: [{ host: "localhost", port: 7000 }],
-});
-
-// Non-atomic - keys can span different hash slots
-const result = await clusterClient.exec(
-    new ClusterBatch(false).set("user:1:name", "Alice").set("user:2:name", "Bob").get("user:1:name"),
-    true,
-);
-// result: ["OK", "OK", "Alice"]
+// GlideClient:        exec(batch, raiseOnError, options?) - options: BatchOptions
+// GlideClusterClient: exec(batch, raiseOnError, options?) - options: ClusterBatchOptions
+// returns Promise<GlideReturnType[] | null>
 ```
 
-### exec() signature
+`BatchOptions`: `{ timeout?: number }` (ms).
+`ClusterBatchOptions`: adds `route` (single-node routing) and `retryStrategy` (non-atomic only).
+
+Returns `null` when an atomic batch fails due to a WATCH conflict.
+
+## `raiseOnError` semantics
+
+- `true` - throws `RequestError` on first failure.
+- `false` - errors appear inline as `RequestError` instances in the results array:
 
 ```typescript
-// GlideClient
-client.exec(batch: Batch, raiseOnError: boolean, options?: BatchOptions): Promise<GlideReturnType[] | null>
-// GlideClusterClient
-clusterClient.exec(batch: ClusterBatch, raiseOnError: boolean, options?: ClusterBatchOptions): Promise<GlideReturnType[] | null>
-```
-
-`BatchOptions` has a `timeout` field (milliseconds). `ClusterBatchOptions` adds `route` (single-node routing) and `retryStrategy`. If an atomic batch fails due to a `WATCH` command, `exec()` returns `null`.
-
-## Error Handling in Batch Results
-
-The `raiseOnError` parameter controls error behavior:
-
-| Value | Behavior |
-|-------|----------|
-| `true` | Throws `RequestError` on the first error encountered in the batch |
-| `false` | Errors appear as `RequestError` instances in the results array |
-
-```typescript
-import { RequestError, Batch } from "@valkey/valkey-glide";
-
-const batch = new Batch(false)
-    .set("key", "value")
-    .lpush("key", ["oops"])  // WRONGTYPE - key holds a string
-    .get("key");
-
-// raiseOnError = false: errors inline
 const results = await client.exec(batch, false);
-for (const item of results!) {
-    if (item instanceof RequestError) {
-        console.log(`Command failed: ${item.message}`);
-    } else {
-        console.log(`Success: ${item}`);
-    }
+for (const r of results!) {
+    if (r instanceof RequestError) { /* handle */ }
 }
-// Success: OK
-// Command failed: WRONGTYPE Operation against a key holding the wrong kind of value
-// Success: value
-
-// raiseOnError = true: throws on first error
-try { await client.exec(batch, true); }
-catch (err) { if (err instanceof RequestError) console.log(err.message); }
 ```
 
-### Cluster retry strategy (non-atomic only)
+## Cluster retry strategy (non-atomic only)
 
 ```typescript
-const result = await clusterClient.exec(
-    new ClusterBatch(false).set("k1", "v1").set("k2", "v2"), true,
-    {
-        timeout: 5000, route: "randomNode",
-        retryStrategy: { retryServerError: true, retryConnectionError: false },
+await clusterClient.exec(batch, true, {
+    timeout: 5000,
+    route: "randomNode",
+    retryStrategy: {
+        retryServerError: true,       // retry on TRYAGAIN etc.
+        retryConnectionError: false,  // retry batch on connection failure
     },
-);
+});
 ```
 
-## Complete Example: Batch Write 50 Products
+Hazards:
 
-```typescript
-import { GlideClusterClient, ClusterBatch, RequestError } from "@valkey/valkey-glide";
+- `retryServerError: true` may reorder commands targeting the same slot.
+- `retryConnectionError: true` may cause duplicate executions - the server may have already processed the request before the connection died.
+- Not supported on atomic batches.
+- Raise `timeout` when enabling retries.
 
-interface Product {
-    id: number;
-    name: string;
-    price: number;
-    category: string;
-    stock: number;
-}
+MOVED / ASK redirections are always handled automatically - non-atomic redirects only the affected commands; atomic redirects the entire transaction.
 
-async function batchWriteProducts(
-    client: GlideClusterClient,
-    products: Product[],
-): Promise<void> {
-    // Use non-atomic batch - products have different hash slots
-    const batch = new ClusterBatch(false);
+## WATCH
 
-    for (const p of products) {
-        const key = `product:{catalog}:${p.id}`;
-        batch.hset(key, {
-            name: p.name,
-            price: String(p.price),
-            category: p.category,
-            stock: String(p.stock),
-        });
-        // Add to category set for lookups
-        batch.sadd(`category:{catalog}:${p.category}`, [key]);
-    }
-
-    const results = await client.exec(batch, false, { timeout: 10000 });
-
-    if (!results) {
-        throw new Error("Batch returned null");
-    }
-
-    let errors = 0;
-    for (const r of results) {
-        if (r instanceof RequestError) errors++;
-    }
-
-    if (errors > 0) {
-        console.log(`[WARN] ${errors} commands failed out of ${results.length}`);
-    } else {
-        console.log(`[OK] Wrote ${products.length} products (${results.length} commands)`);
-    }
-}
-
-// Usage
-const products: Product[] = Array.from({ length: 50 }, (_, i) => ({
-    id: i + 1, name: `Widget ${i + 1}`, price: 9.99 + i,
-    category: ["electronics", "clothing", "home"][i % 3], stock: 100 + i * 10,
-}));
-await batchWriteProducts(client, products);
-// [OK] Wrote 50 products (100 commands)
-```
-
-The `{catalog}` hash tag ensures HSET and SADD for each product route to the same slot, which matters if you later wrap them in an atomic batch. For non-atomic batches, hash tags are optional - GLIDE auto-splits commands across nodes.
-
-## Cluster Routing Behavior
-
-- **Atomic (transaction)**: routed to the slot owner of the first key. All keys must share the same slot or the transaction fails.
-- **Non-atomic (pipeline)**: each command routes independently by key slot. Multi-node commands are split across nodes and responses are reassembled in order.
-- MOVED/ASK redirections are handled automatically. Non-atomic batches redirect only the affected commands; atomic batches redirect the entire transaction.
-
-## Standalone-Only Commands
-
-`Batch` (standalone) exposes `select(index)` for switching databases within a batch. This is not available on `ClusterBatch`.
+WATCH needs a dedicated client - it's a connection-state command and leaks across callers on the shared multiplexer. Inside a dedicated client, WATCH followed by an atomic batch returns `null` from `exec()` if a watched key was modified before the transaction runs.

--- a/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-connection.md
+++ b/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-connection.md
@@ -1,21 +1,18 @@
-# Connection and Configuration
+# Connection and configuration (Node.js)
 
-Use when creating a GLIDE client, choosing between standalone and cluster mode, configuring authentication, TLS, timeouts, reconnection backoff, read strategy, or closing connections.
+Use when creating clients, configuring auth, TLS, timeouts, reconnection, read strategy, or closing connections. Covers what differs from `ioredis` / `node-redis` - basic `new Redis({ host, port })` patterns are assumed knowable from training.
 
-## Contents
+## Divergence from ioredis / node-redis
 
-- GlideClient vs GlideClusterClient (line 20)
-- Creating a Standalone Client (line 33)
-- Creating a Cluster Client (line 73)
-- BaseClientConfiguration - Shared Options (line 87)
-- ServerCredentials (line 107)
-- ReadFrom Strategy (line 131)
-- Connection Backoff (line 150)
-- AdvancedBaseClientConfiguration (line 163)
-- GlideClusterClient-Specific Options (line 174)
-- Lazy Connect (line 186)
-- Protocol Version (line 199)
-- Closing Connections (line 203)
+| ioredis / node-redis | GLIDE Node |
+|---------------------|-----------|
+| `new Redis({ host, port })` constructs immediately | `await GlideClient.createClient(config)` - async static factory |
+| `new Redis.Cluster([{host, port}])` | `await GlideClusterClient.createClient({ addresses })` - distinct type, not a pool wrapper |
+| Connection pool with `maxRetriesPerRequest` | Single multiplexed connection per node - no pool knob |
+| `client.on('error', ...)` event emitter | Errors surface per-Promise via `await`; no emitter |
+| `client.disconnect()` / `client.quit()` | `client.close()` - synchronous, returns `void`, not Promise |
+| `retryStrategy: (times) => ...` function | `connectionBackoff` object with `numberOfRetries`, `factor`, `exponentBase`, `jitterPercent` |
+| `lazyConnect: true` on ioredis defers implicit connect | `lazyConnect: true` on GLIDE defers the first TCP connect to the first command |
 
 ## GlideClient vs GlideClusterClient
 

--- a/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-pubsub.md
+++ b/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-pubsub.md
@@ -1,23 +1,23 @@
 # Pub/Sub (Node.js)
 
-Use when you need real-time message broadcasting between clients - chat, notifications, event distribution, or live data feeds.
+Use when working with publish/subscribe. Covers what diverges from `ioredis` - the `r.subscribe()` / `r.on('message', ...)` event-emitter pattern does NOT translate. The publish/message-receive loop is similar in shape but the subscription model is different.
 
-## Contents
+## Divergence from ioredis
 
-- Key Difference from ioredis (line 16)
-- PubSubChannelModes (line 59)
-- PubSubSubscriptions Interface (line 69)
-- PubSubMsg Interface (line 87)
-- Message Delivery: Callback (line 101)
-- Message Delivery: Polling (line 124)
-- Complete Example: Publisher + Subscriber (line 161)
-- Important Notes (line 199)
+| ioredis | GLIDE |
+|---------|-------|
+| `sub = redis.duplicate(); sub.subscribe('ch')` then `sub.on('message', (ch, msg) => ...)` | Either static config in `pubsubSubscriptions`, or `await client.subscribe(new Set(['ch']))` (GLIDE 2.3+) |
+| EventEmitter (`sub.on('message', ...)`, `sub.on('pmessage', ...)`) | Callback in config OR `await client.getPubSubMessage()` / `client.tryGetPubSubMessage()` polling - cannot mix |
+| `redis.publish(channel, message)` | `await client.publish(message, channel)` - **arguments REVERSED**; top silent-bug source during migration |
+| Subscriber client can't issue other commands | GLIDE multiplexes - subscribing client CAN still run regular commands (dedicated client still recommended for high-throughput subscribers) |
+| Manual resubscribe on reconnect | Automatic via synchronizer; `getSubscriptions()` exposes desired vs actual state |
+| Sharded pub/sub via standalone client (supported in 7.0+) | `PubSubChannelModes.Sharded` requires `GlideClusterClient` |
 
-## Key Difference from ioredis
+Static subscriptions require RESP3 (the default). Setting `protocol: ProtocolVersion.RESP2` with subscriptions throws `ConfigurationError`.
 
-GLIDE PubSub differs from ioredis in two ways: (1) no event emitters - use callbacks or polling instead, (2) RESP3 protocol required.
+## Subscription approaches
 
-All subscriptions must be declared at client creation time. Node.js GLIDE does NOT have runtime `subscribe()` / `psubscribe()` methods. To change subscriptions, close the client and create a new one.
+### Static (creation-time, any GLIDE version)
 
 ```typescript
 import { GlideClusterClient, GlideClusterClientConfiguration } from "@valkey/valkey-glide";
@@ -26,188 +26,101 @@ const subscriber = await GlideClusterClient.createClient({
     addresses: [{ host: "localhost", port: 6379 }],
     pubsubSubscriptions: {
         channelsAndPatterns: {
-            [GlideClusterClientConfiguration.PubSubChannelModes.Exact]: new Set(["news", "events"]),
-            [GlideClusterClientConfiguration.PubSubChannelModes.Pattern]: new Set(["events:*"]),
+            [GlideClusterClientConfiguration.PubSubChannelModes.Exact]:   new Set(["chat"]),
+            [GlideClusterClientConfiguration.PubSubChannelModes.Pattern]: new Set(["news:*"]),
         },
-        callback: (msg) => {
-            console.log(`${msg.channel}: ${msg.message}`);
+        callback: (msg, context) => {
+            console.log(`[${msg.channel}] ${msg.message} (pattern: ${msg.pattern ?? "none"})`);
         },
+        context: { /* arbitrary */ },
     },
 });
 ```
 
-### ioredis migration pattern
+### Dynamic (GLIDE 2.3+ - Node includes full support)
+
+Node.js at v2.3.1 has the full dynamic pubsub API. Methods on the client:
 
 ```typescript
-// ioredis (old) - runtime subscribe with event emitter
-const sub = redis.duplicate();
-sub.psubscribe("events:*");
-sub.on("pmessage", (pattern, channel, message) => { ... });
+// Blocking variants wait for server ack; optional timeout (ms)
+await client.subscribe(new Set(["channel1", "channel2"]), /* timeoutMs? */ 5000);
+await client.psubscribe(new Set(["news:*"]), 5000);
+await client.ssubscribe(new Set(["shard-topic"]), 5000);  // GlideClusterClient only
 
-// GLIDE (new) - subscriptions at creation time, callback or polling
-const sub = await GlideClusterClient.createClient({
-    addresses,
-    pubsubSubscriptions: {
-        channelsAndPatterns: {
-            [GlideClusterClientConfiguration.PubSubChannelModes.Pattern]: new Set(["events:*"]),
-        },
-        callback: (msg) => { /* msg.channel, msg.message, msg.pattern */ },
-    },
-});
+// Lazy variants return immediately; reconciliation is async
+await client.subscribeLazy(new Set(["channel1"]));
+await client.psubscribeLazy(new Set(["news:*"]));
+await client.ssubscribeLazy(new Set(["shard-topic"]));
+
+await client.unsubscribe(new Set(["channel1"]));   // or unsubscribe() for all exact
+await client.unsubscribeLazy();
 ```
 
-## PubSubChannelModes
+## Receiving messages
 
-Each client type defines its own enum. The cluster client supports three modes; the standalone client supports two.
+### Callback model
 
-| Value | Name | Description | Cluster | Standalone |
-|-------|------|-------------|---------|------------|
-| 0 | `Exact` | Subscribe to specific channel names (SUBSCRIBE) | Yes | Yes |
-| 1 | `Pattern` | Subscribe using glob patterns like `news.*` (PSUBSCRIBE) | Yes | Yes |
-| 2 | `Sharded` | Slot-scoped channels, Valkey 7.0+ (SSUBSCRIBE) | Yes | No |
-
-## PubSubSubscriptions Interface
-
-Defined in both `GlideClusterClientConfiguration` and `GlideClientConfiguration` namespaces:
-
-```typescript
-interface PubSubSubscriptions {
-    channelsAndPatterns: Partial<Record<PubSubChannelModes, Set<string>>>;
-    callback?: (msg: PubSubMsg, context: any) => void;
-    context?: any;
-}
-```
-
-- `channelsAndPatterns` - map from mode to a `Set<string>` of channel names or patterns
-- `callback` - optional function invoked on each incoming message
-- `context` - arbitrary value passed as the second argument to the callback
-
-If no callback is provided, messages queue internally and must be retrieved via polling.
-
-## PubSubMsg Interface
+Pass `callback` in `pubsubSubscriptions`. Must not block. Receives `PubSubMsg`:
 
 ```typescript
 interface PubSubMsg {
     message: GlideString;
     channel: GlideString;
-    pattern?: GlideString | null;
+    pattern?: GlideString | null;  // set only for pattern subscriptions
 }
 ```
 
-- `message` - the published payload
-- `channel` - the channel the message was published to
-- `pattern` - the pattern that matched (only set for pattern subscriptions)
+### Polling model
 
-## Message Delivery: Callback
-
-Provide a `callback` in `pubsubSubscriptions`. The callback must not block.
-
-```typescript
-import { GlideClusterClient, GlideClusterClientConfiguration } from "@valkey/valkey-glide";
-
-const subscriber = await GlideClusterClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    pubsubSubscriptions: {
-        channelsAndPatterns: {
-            [GlideClusterClientConfiguration.PubSubChannelModes.Pattern]: new Set(["user:*"]),
-            [GlideClusterClientConfiguration.PubSubChannelModes.Exact]: new Set(["system"]),
-        },
-        callback: (msg, context) => {
-            context.count++;
-            console.log(`[${msg.channel}] ${msg.message} (pattern: ${msg.pattern ?? "none"})`);
-        },
-        context: { count: 0 },
-    },
-});
-```
-
-## Message Delivery: Polling
-
-Omit the `callback` to use polling. Two methods are available on the client:
+Omit `callback` in config. Use the client's message methods:
 
 | Method | Returns | Behavior |
 |--------|---------|----------|
-| `getPubSubMessage()` | `Promise<PubSubMsg>` | Awaits until a message arrives |
-| `tryGetPubSubMessage()` | `PubSubMsg \| null` | Returns immediately, `null` if empty |
+| `await client.getPubSubMessage()` | `Promise<PubSubMsg>` | Awaits until a message arrives |
+| `client.tryGetPubSubMessage()` | `PubSubMsg \| null` | Returns immediately, `null` if queue empty |
 
-Both methods throw `ConfigurationError` if a callback is configured, or if no subscriptions exist.
+Both throw `ConfigurationError` if a callback is configured, or if the client has no subscriptions. Drain the queue regularly - it is unbounded.
 
-```typescript
-import { GlideClusterClient, GlideClusterClientConfiguration } from "@valkey/valkey-glide";
-
-const subscriber = await GlideClusterClient.createClient({
-    addresses: [{ host: "localhost", port: 6379 }],
-    pubsubSubscriptions: {
-        channelsAndPatterns: {
-            [GlideClusterClientConfiguration.PubSubChannelModes.Exact]: new Set(["orders"]),
-        },
-        // No callback - use polling
-    },
-});
-
-// Async wait - blocks until a message arrives
-const msg = await subscriber.getPubSubMessage();
-console.log(`${msg.channel}: ${msg.message}`);
-
-// Non-blocking poll - returns null if no message queued
-const next = subscriber.tryGetPubSubMessage();
-if (next) {
-    console.log(`${next.channel}: ${next.message}`);
-}
-```
-
-Drain the queue regularly - the internal buffer is unbounded and grows if not consumed.
-
-## Complete Example: Publisher + Subscriber
+## Subscription state inspection
 
 ```typescript
-import {
-    GlideClusterClient,
-    GlideClusterClientConfiguration,
-} from "@valkey/valkey-glide";
-
-const addresses = [{ host: "localhost", port: 6379 }];
-
-// Subscriber client - subscriptions declared at creation
-const subscriber = await GlideClusterClient.createClient({
-    addresses,
-    pubsubSubscriptions: {
-        channelsAndPatterns: {
-            [GlideClusterClientConfiguration.PubSubChannelModes.Exact]: new Set(["chat"]),
-            [GlideClusterClientConfiguration.PubSubChannelModes.Sharded]: new Set(["shard-topic"]),
-        },
-        callback: (msg) => {
-            console.log(`[${msg.channel}] ${msg.message}`);
-        },
-    },
-});
-
-// Publisher client - separate instance, no subscriptions needed
-const publisher = await GlideClusterClient.createClient({ addresses });
-
-// Publish to exact channel
-await publisher.publish("Hello from GLIDE!", "chat");
-
-// Publish to sharded channel (third argument = true for sharded mode)
-await publisher.publish("Sharded hello!", "shard-topic", true);
-
-// Cleanup
-publisher.close();
-subscriber.close();
+const state = await client.getSubscriptions();
+// Standalone returns StandalonePubSubState
+// Cluster    returns ClusterPubSubState
+// Both expose desired vs actual subscriptions per channel mode
 ```
 
-## Important Notes
+Track sync health:
 
-1. **RESP3 is the default.** `protocol` defaults to `ProtocolVersion.RESP3`. PubSub works out of the box. If you explicitly set `protocol: ProtocolVersion.RESP2`, PubSub push notifications will not be delivered.
+```typescript
+const stats = await client.getStatistics();
+const outOfSync = stats["subscription_out_of_sync_count"];       // all values are strings
+const lastSyncMs = stats["subscription_last_sync_timestamp"];    // ms since epoch
+```
 
-2. **Separate clients for pub and sub.** A subscribing client is in a special mode. Use one client for publishing and a different client for subscribing.
+## `PubSubChannelModes`
 
-3. **No runtime subscribe/unsubscribe in Node.js.** Java/Python/Go have dynamic `subscribe()`/`psubscribe()` methods (GLIDE 2.3+). Node.js support is in progress. Declare all subscriptions at creation time. To change subscriptions, close and recreate the client.
+Each client type defines its own enum under the config namespace. Same numeric values in both, but `Sharded` is cluster-only:
 
-4. **Callback vs polling - pick one.** If a callback is configured, `getPubSubMessage()` and `tryGetPubSubMessage()` throw `ConfigurationError`. If no callback is configured, messages must be polled.
+| Value | Name | Cluster | Standalone | Server command |
+|-------|------|---------|------------|----------------|
+| 0 | `Exact` | Yes | Yes | SUBSCRIBE |
+| 1 | `Pattern` | Yes | Yes | PSUBSCRIBE |
+| 2 | `Sharded` | Yes | No | SSUBSCRIBE (Valkey 7.0+) |
 
-5. **Sharded PubSub requires cluster mode.** `PubSubChannelModes.Sharded` is only available on `GlideClusterClient` (not `GlideClient`). Requires Valkey 7.0+.
+## Publishing
 
-6. **publish() signature differs by client type.** `GlideClusterClient.publish(message, channel, sharded?)` accepts an optional boolean for sharded mode. `GlideClient.publish(message, channel)` does not.
+**GOTCHA: argument order is REVERSED from ioredis.** ioredis is `r.publish(channel, message)`; GLIDE is `await client.publish(message, channel)`. Silent mis-routing if you don't notice - this is the #1 `publish()` bug in migration code.
 
-7. **Automatic resubscription on reconnect.** When the connection drops, GLIDE reconnects and reissues the configured SUBSCRIBE/PSUBSCRIBE/SSUBSCRIBE commands automatically.
+```typescript
+// Standalone: publish(message, channel) -> number of receivers
+await client.publish("hello world", "chat");
+
+// Cluster: publish(message, channel, sharded?) -> number of receivers
+await client.publish("hello world", "chat");
+await client.publish("hello shard", "shard-topic", true);  // sharded mode, Valkey 7.0+
+```
+
+## Automatic resubscription
+
+On reconnect or cluster topology change, the synchronizer reissues SUBSCRIBE / PSUBSCRIBE / SSUBSCRIBE automatically. No manual handling. Tune cadence via `advancedConfiguration.pubsubReconciliationInterval` (ms).

--- a/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-streams.md
+++ b/skills/valkey-glide-nodejs/skills/valkey-glide-nodejs/reference/features-streams.md
@@ -1,272 +1,52 @@
-# Valkey Streams
+# Streams (Node.js)
 
-Use when you need durable, ordered message processing with consumer groups, replay capability, or event sourcing in Node.js/TypeScript. For fire-and-forget messaging, see [Pub/Sub](features-pubsub.md).
+Use when working with Valkey streams. Command names match Valkey's XADD/XREAD/consumer-group set and are similar to ioredis - the divergence is in argument shape (tuple lists, typed range bounds, option objects) and a couple of API-split choices.
 
-## Contents
+## Divergence from ioredis
 
-- XADD - Adding Entries (line 21)
-- XREAD - Reading Without Consumer Groups (line 45)
-- XGROUP CREATE (line 58)
-- XREADGROUP - Reading With Consumer Groups (line 69)
-- XACK - Acknowledging Messages (line 87)
-- XLEN, XRANGE, XINFO (line 96)
-- Group Management (line 129)
-- XPENDING - Inspecting Pending Messages (line 140)
-- XCLAIM - Changing Message Ownership (line 165)
-- XAUTOCLAIM - Automatic Pending Transfer (6.2+) (line 184)
-- Complete Example: Producer/Consumer With Consumer Group (line 205)
-- Blocking Commands Warning (line 257)
-- Related Features (line 268)
+| ioredis | GLIDE |
+|---------|-------|
+| `r.xadd(key, "*", "f", "v")` (flat varargs) | `client.xadd(key, [["f", "v"]])` (array of `[field, value]` tuples) |
+| `r.xadd(key, "MAXLEN", "~", 1000, "*", ...)` | `client.xadd(key, entries, { trim: { method: "maxlen", threshold: 1000, exact: false, limit? } })` |
+| `start="-"`, `end="+"` sentinel strings | `InfBoundary.NegativeInfinity` / `InfBoundary.PositiveInfinity`, or `{ value: "1-0", isInclusive?: false }` bounds |
+| `r.xread("COUNT", 10, "BLOCK", 5000, "STREAMS", "s1", "s2", "0-0", "0-0")` | `client.xread({ s1: "0-0", s2: "0-0" }, { count: 10, block: 5000 })` |
+| `r.xgroup("CREATE", key, group, id, "MKSTREAM")` | `client.xgroupCreate(key, group, id, { mkStream: true, entriesRead? })` |
+| `r.xclaim(..., "JUSTID")` flag | Separate methods: `xclaim` vs `xclaimJustId`, `xautoclaim` vs `xautoclaimJustId` |
+| `r.xpending(key, group)` / `r.xpending(key, group, "-", "+", 10)` | Two methods: `xpending(key, group)` (summary) vs `xpendingWithOptions(key, group, { start, end, count, consumer?, minIdleTime? })` |
+| `r.xreadgroup(..., "NOACK")` flag | `client.xreadgroup(group, consumer, { stream: ">" }, { count?, block?, noAck?: true })` |
+| `decode_responses`-like bytes-vs-str control | `Decoder.String` default; switch to `Decoder.Bytes` globally via `defaultDecoder` or per-command |
+| Cluster multi-stream read: manual slot split | Multi-key `xread` / `xreadgroup` must hash to one slot; use hash tags |
 
-## XADD - Adding Entries
+## Key GLIDE types
 
-```typescript
-import { GlideClient } from "@valkey/valkey-glide";
+- `InfBoundary.NegativeInfinity`, `InfBoundary.PositiveInfinity` - replace `"-"` / `"+"`
+- `{ value: "1-0" }` - inclusive bound
+- `{ value: "1-0", isInclusive: false }` - exclusive bound (Valkey 6.2+)
+- Trim option: `{ method: "maxlen" | "minid", threshold, exact, limit? }`
 
-const id = await client.xadd("mystream", [["sensor", "temp"], ["value", "23.5"]]);
-// id: "1234567890123-0"
+## Split xclaim / xautoclaim
 
-// Explicit ID
-await client.xadd("mystream", [["event", "click"]], { id: "1000-0" });
+`xclaim` returns `{ "1-0": [[field, value], ...] }`; `xclaimJustId` returns `string[]` of IDs only. Same split for `xautoclaim` / `xautoclaimJustId`. Matches Python's split; replaces ioredis's `JUSTID` flag.
 
-// With approximate MAXLEN trim
-await client.xadd("mystream", [["data", "v"]], {
-    trim: { method: "maxlen", threshold: 1000, exact: false },
-});
+`xautoclaim*` (Valkey 6.2+) returns `[nextStart, entriesOrIds, deletedIds?]` (deletedIds populated on 7.0+).
 
-// NOMKSTREAM - returns null if stream does not exist
-await client.xadd("mystream", [["k", "v"]], { makeStream: false });
-```
+## Split xpending / xpendingWithOptions
 
-**Signature:** `xadd(key, values: [GlideString, GlideString][], options?) => Promise<string | null>`
-- `options.id`: explicit entry ID; `options.makeStream`: false for NOMKSTREAM
-- `options.trim`: `{ method: "maxlen"|"minid", threshold, exact, limit? }`
+`xpending(key, group)` returns the summary tuple `[count, minId, maxId, [[consumer, count], ...]]`.
+`xpendingWithOptions(key, group, { start, end, count, consumer?, minIdleTime? })` returns per-entry detail `[[entryId, consumer, idleMs, deliveryCount], ...]`.
 
-## XREAD - Reading Without Consumer Groups
+Replaces ioredis's overloaded `r.xpending(...)` where argument count determined summary vs detail.
+
+## Cluster: multi-stream reads must share a slot
+
+`xread` / `xreadgroup` over multiple stream keys goes to a single node - all keys must hash to the same slot. Use hash tags:
 
 ```typescript
-const result = await client.xread({ mystream: "0-0" });
-// [{ key: "mystream", value: { "1234-0": [["sensor", "temp"], ["value", "23.5"]] } }]
-
-// Multiple streams, count limit, blocking
-const result2 = await client.xread({ s1: "0-0", s2: "0-0" }, { count: 10, block: 5000 });
+await client.xadd("{app}.events", [["type", "click"]]);
+await client.xadd("{app}.logs",   [["level", "info"]]);
+await client.xread({ "{app}.events": "0-0", "{app}.logs": "0-0" });
 ```
 
-**Signature:** `xread(keys_and_ids: Record<string, string>, options?) => Promise<GlideRecord<StreamEntryDataType> | null>`
-- `options.count`: max entries per stream; `options.block`: ms to block (0 = indefinite)
+## Blocking reads need a dedicated client
 
-## XGROUP CREATE
-
-```typescript
-await client.xgroupCreate("mystream", "mygroup", "0");           // from beginning
-await client.xgroupCreate("mystream", "mygroup", "$");           // new entries only
-await client.xgroupCreate("mystream", "mygroup", "0", { mkStream: true }); // create stream
-```
-
-**Signature:** `xgroupCreate(key, groupName, id, options?) => Promise<"OK">`
-- `options.mkStream`: create stream if absent; `options.entriesRead`: logical counter (7.0+)
-
-## XREADGROUP - Reading With Consumer Groups
-
-```typescript
-// Read new messages
-const msgs = await client.xreadgroup("mygroup", "consumer1", { mystream: ">" });
-// [{ key: "mystream", value: { "1234-0": [["sensor", "temp"]] } }]
-
-// With count, block, noAck
-await client.xreadgroup("mygroup", "c1", { mystream: ">" }, { count: 10, block: 5000, noAck: true });
-
-// Re-read pending messages (use "0" instead of ">")
-await client.xreadgroup("mygroup", "c1", { mystream: "0" });
-```
-
-**Signature:** `xreadgroup(group, consumer, keys_and_ids, options?) => Promise<...| null>`
-- `">"` = only new messages; `"0"` = re-read pending
-- `options.noAck`: skip PEL (auto-acknowledge on read)
-
-## XACK - Acknowledging Messages
-
-```typescript
-const acked = await client.xack("mystream", "mygroup", ["1234567890123-0"]);
-// acked: 1
-```
-
-**Signature:** `xack(key, group, ids: string[]) => Promise<number>`
-
-## XLEN, XRANGE, XINFO
-
-```typescript
-import { InfBoundary } from "@valkey/valkey-glide";
-
-// Length
-const len = await client.xlen("mystream"); // 42
-
-// Forward range - all entries
-const entries = await client.xrange("mystream", InfBoundary.NegativeInfinity, InfBoundary.PositiveInfinity);
-// { "0-1": [["f", "v"]], "0-2": [["f2", "v2"]] }
-
-// With count limit and specific ID range
-await client.xrange("mystream", { value: "1000-0" }, { value: "2000-0" }, { count: 10 });
-
-// Exclusive boundary (Valkey 6.2+)
-await client.xrange("mystream", { value: "1000-0", isInclusive: false }, InfBoundary.PositiveInfinity);
-
-// Reverse range
-await client.xrevrange("mystream", InfBoundary.PositiveInfinity, InfBoundary.NegativeInfinity);
-
-// Stream info
-const info = await client.xinfoStream("mystream");
-// { length: 2, "first-entry": [...], "last-entry": [...], groups: 1, ... }
-
-// Verbose with PEL
-await client.xinfoStream("mystream", { fullOptions: true });
-
-// Group and consumer info
-const groups = await client.xinfoGroups("mystream");
-const consumers = await client.xinfoConsumers("mystream", "mygroup");
-```
-
-## Group Management
-
-```typescript
-await client.xgroupCreateConsumer("mystream", "mygroup", "c1");   // true
-await client.xgroupDelConsumer("mystream", "mygroup", "c1");      // pending count
-await client.xgroupDestroy("mystream", "mygroup");                // true
-await client.xgroupSetId("mystream", "mygroup", "0");             // "OK"
-await client.xdel("mystream", ["1234-0", "1234-1"]);             // deleted count
-await client.xtrim("mystream", { method: "maxlen", threshold: 1000, exact: false }); // trimmed count
-```
-
-## XPENDING - Inspecting Pending Messages
-
-```typescript
-// Summary: total pending, min/max ID, per-consumer counts
-const summary = await client.xpending("mystream", "mygroup");
-// [42, "1722643465939-0", "1722643484626-0", [["consumer1", 10], ["consumer2", 32]]]
-
-// Detailed: filter by range, count, and optionally consumer
-import { InfBoundary } from "@valkey/valkey-glide";
-
-const detailed = await client.xpendingWithOptions("mystream", "mygroup", {
-    start: InfBoundary.NegativeInfinity,
-    end: InfBoundary.PositiveInfinity,
-    count: 10,
-    consumer: "consumer1",       // optional filter
-    minIdleTime: 60000,          // optional, ms idle threshold (6.2+)
-});
-// [["1722643465939-0", "consumer1", 174431, 1], ...]
-// Each tuple: [entryId, consumer, idleTimeMs, deliveryCount]
-```
-
-**Signatures:**
-- `xpending(key, group) => Promise<[number, GlideString, GlideString, [GlideString, number][]]>`
-- `xpendingWithOptions(key, group, options: StreamPendingOptions) => Promise<[GlideString, GlideString, number, number][]>`
-
-## XCLAIM - Changing Message Ownership
-
-```typescript
-// Claim entries idle for at least 60000ms, reassign to "consumer2"
-const claimed = await client.xclaim("mystream", "mygroup", "consumer2", 60000,
-    ["1-0", "2-0"], { idle: 500, retryCount: 3, isForce: true });
-// { "2-0": [["field", "value"]] }
-
-// JUSTID variant - returns only IDs, no entry data
-const ids = await client.xclaimJustId("mystream", "mygroup", "consumer2", 60000,
-    ["1-0", "2-0"]);
-// ["2-0"]
-```
-
-**Signatures:**
-- `xclaim(key, group, consumer, minIdleTime, ids, options?) => Promise<StreamEntryDataType>`
-- `xclaimJustId(key, group, consumer, minIdleTime, ids, options?) => Promise<string[]>`
-- `options`: `{ idle?, idleUnixTime?, retryCount?, isForce? }`
-
-## XAUTOCLAIM - Automatic Pending Transfer (6.2+)
-
-```typescript
-// Automatically claim entries idle > 60000ms, scanning from "0-0"
-const [nextStart, entries, deleted] = await client.xautoclaim(
-    "mystream", "mygroup", "consumer2", 60000, "0-0", { count: 25 });
-// nextStart: "1609338788321-0" (use as start for next call)
-// entries: { "1609338752495-0": [["field", "value"]] }
-// deleted: ["1594324506465-0"] (IDs no longer in stream, 7.0+ only)
-
-// JUSTID variant - returns only IDs
-const [nextId, claimedIds, deletedIds] = await client.xautoclaimJustId(
-    "mystream", "mygroup", "consumer2", 60000, "0-0", { count: 25 });
-// claimedIds: ["1609338752495-0", "1609338752495-1"]
-```
-
-**Signatures:**
-- `xautoclaim(key, group, consumer, minIdleTime, start, options?) => Promise<[GlideString, StreamEntryDataType, GlideString[]?]>`
-- `xautoclaimJustId(key, group, consumer, minIdleTime, start, options?) => Promise<[string, string[], string[]?]>`
-- `options`: `{ count?: number }` (default 100)
-
-## Complete Example: Producer/Consumer With Consumer Group
-
-```typescript
-import { GlideClient } from "@valkey/valkey-glide";
-
-const client = await GlideClient.createClient({ addresses: [{ host: "localhost", port: 6379 }] });
-const STREAM = "orders";
-const GROUP = "order-processors";
-
-// Setup
-await client.xgroupCreate(STREAM, GROUP, "0", { mkStream: true });
-
-// Producer
-async function produce() {
-    for (let i = 0; i < 5; i++) {
-        const id = await client.xadd(STREAM, [
-            ["order_id", `ORD-${i}`],
-            ["item", `widget-${i}`],
-            ["qty", String(i + 1)],
-        ]);
-        console.log(`Produced: ${id}`);
-    }
-}
-
-// Consumer - each entry delivered to exactly one consumer in the group
-async function consume(name: string) {
-    while (true) {
-        const result = await client.xreadgroup(GROUP, name, { [STREAM]: ">" }, { count: 2, block: 5000 });
-        if (!result) continue;
-
-        for (const stream of result) {
-            for (const [entryId, fields] of Object.entries(stream.value)) {
-                if (!fields) continue;
-                console.log(`[${name}] Processing ${entryId}:`, fields);
-                await client.xack(STREAM, GROUP, [entryId]);
-            }
-        }
-    }
-}
-
-await produce();
-await Promise.all([consume("worker-1"), consume("worker-2")]);
-
-// Inspect
-console.log(`Length: ${await client.xlen(STREAM)}`);
-console.log("Groups:", await client.xinfoGroups(STREAM));
-
-// Cleanup
-await client.xgroupDestroy(STREAM, GROUP);
-client.close();
-```
-
-## Blocking Commands Warning
-
-`xread` and `xreadgroup` with `block` hold the multiplexed connection. Use a dedicated client for blocking reads so other commands are not stalled.
-
-```typescript
-const blockingClient = await GlideClient.createClient(config);
-const commandClient = await GlideClient.createClient(config);
-await blockingClient.xreadgroup(GROUP, "c1", { [STREAM]: ">" }, { block: 5000 });
-await commandClient.set("key", "value"); // unaffected
-```
-
-## Related Features
-
-- [Pub/Sub](features-pubsub.md) - fire-and-forget broadcast without durability
-- [Batching](features-batching.md) - stream commands work in Batch and ClusterBatch
-- [Scripting](features-advanced.md) - Lua scripts can call stream commands atomically
+`xread` / `xreadgroup` with `block` occupies the multiplexed connection for the block duration. Use a dedicated client so other coroutines are not stalled. Same rule as `BLPOP` etc. - see [performance](best-practices-performance.md).


### PR DESCRIPTION
## Summary

Two-pass validation of `valkey-glide-nodejs` and `migrate-ioredis` against Valkey GLIDE `v2.3.1` (commit `9601a7695`). Applies the divergence-only skill-writing rule captured in [docs/SKILL_WRITING_RULES.md](docs/SKILL_WRITING_RULES.md).

## Size reduction

- `valkey-glide-nodejs`: 1577 -> 876 lines (44% cut), plugin 2.0.0 -> 2.1.0
- `migrate-ioredis`: 399 -> 350 lines (12% cut), plugin 1.0.0 -> 1.1.0

Cuts: removed command-by-command mirrors, the 50-line "Batch Write 50 Products" example, the old Node-PubSub-is-creation-time-only section, and TOC-with-line-numbers blocks.

## Pass-2 correctness fixes (stale claims and source-verified bugs)

1. **MAJOR: stale Node PubSub claim.** Both `features-pubsub.md` and `migrate-ioredis/SKILL.md` claimed "Node.js GLIDE does NOT have runtime subscribe()/psubscribe() methods" and "Node.js support is in progress". Verified at v2.3.1 Node has the full API: `subscribe`, `subscribeLazy`, `psubscribe`, `psubscribeLazy`, `ssubscribe`, `ssubscribeLazy`, `unsubscribe`, `unsubscribeLazy`, plus `getSubscriptions()` returning `StandalonePubSubState` / `ClusterPubSubState`. Rewrote both files with the real API.

2. **`zrangeWithScores` signature bug.** `migrate-ioredis/api-mapping.md` claimed `{ start: 0, end: -1 }`. Source at `node/src/BaseClient.ts:5645` shows the field is `stop`, not `end`. Fixed.

3. **`lazyConnect` default wrong.** `migrate-ioredis/SKILL.md` claimed "lazyConnect: true - default behavior in GLIDE". GLIDE's `lazyConnect` defaults to `false`; the old mapping was conflating two different semantics (ioredis's implicit-connect-on-first-command vs GLIDE's TCP-connect-on-first-command). Corrected.

4. **Error base class:** Node's abstract base is `ValkeyError`, NOT `GlideError` (which is Python's). Added explicit grep hazard. No `LoggerError` in Node's `Errors.ts` (Python has one).

5. **Fabricated "2 connections per node (data + management)"** removed from production defaults - grep shows that text only in Python test code; no Node/user-facing concept exists.

6. **Blocking command list completed** per `glide-core/src/client/mod.rs:374-380`: `BLPOP`, `BRPOP`, `BLMOVE`, `BZPOPMAX`, `BZPOPMIN`, `BRPOPLPUSH`, `BLMPOP`, `BZMPOP`, plus `XREAD`/`XREADGROUP` with `BLOCK` and `WAIT`/`WAITAOF`.

7. **TimeUnit enum verified** as `Seconds`, `Milliseconds`, `UnixSeconds`, `UnixMilliseconds` - no upstream typo (unlike Python's `MILLSEC`/`UNIX_MILLSEC`, which is Python-specific).

## Pass-1 editorial changes

- Rewrote `SKILL.md` with multiplexer-first framing and 14-point grep hazards block
- Replaced command-by-command API mirrors in both skills with divergence-from-ioredis tables (only where signatures differ)
- Streams: cut basic xadd/xread/xreadgroup examples; kept typed option objects, split `xclaim` / `xclaimJustId`, split `xpending` / `xpendingWithOptions`, cluster multi-stream slot constraint
- Batching: cut verbose examples; kept `isAtomic` flag, `raiseOnError` semantics, cluster retry-strategy hazards, WATCH-needs-dedicated-client rule, `Transaction` / `ClusterTransaction` deprecated aliases noted
- Error: subclass-tree diagram makes it clear that catching `RequestError` catches the subclass set
- Performance: one-client-per-process, blocking-command exceptions, inflight cap, TCP_NODELAY, compression metrics
- Production: defaults table, AZ-affinity `ReadFrom`, OTel init-once, platform constraints (glibc, native binding, proxies)

## Verified against v2.3.1 source

- Config types: `BaseClientConfiguration`, `ServerCredentials`, `IamAuthConfig { clusterName, service, region, refreshIntervalSeconds }`, `ServiceType.Elasticache` / `ServiceType.MemoryDB` (PascalCase), `ReadFrom` (four strategies), `ProtocolVersion`, `BackoffStrategy { numberOfRetries, factor, exponentBase, jitterPercent }`, `PeriodicChecks` with snake_case `duration_in_sec` field, `AdvancedBaseClientConfiguration { connectionTimeout, tcpNoDelay (default true), pubsubReconciliationInterval }`, `AdvancedGlideClusterClientConfiguration` adds `refreshTopologyFromInitialNodes`
- `TimeUnit.Seconds` / `.Milliseconds` / `.UnixSeconds` / `.UnixMilliseconds`
- `conditionalSet: "onlyIfExists" | "onlyIfDoesNotExist" | "onlyIfEqual"` string literals for `set()`; `ConditionalChange.ONLY_IF_EXISTS` / `.ONLY_IF_DOES_NOT_EXIST` enum for `zadd()`
- Error classes: `ValkeyError` abstract -> `ClosingError`, `RequestError` -> `TimeoutError`, `ExecAbortError`, `ConnectionError`, `ConfigurationError`
- Full v2.3.1 pub/sub API (subscribe/psubscribe/ssubscribe variants with Lazy + sync, getSubscriptions, getPubSubMessage/tryGetPubSubMessage)
- Valkey Functions: `fcall`, `fcallReadonly`, `fcallWithRoute`, `fcallReadonlyWithRoute`, `functionLoad/Delete/List/Stats/Flush/Kill/Dump/Restore`
- `Script` class with required `.release()`, `scriptShow(sha1)`, `invokeScript` / `invokeScriptWithRoute`
- `Batch` + `ClusterBatch` with `isAtomic` constructor, `BaseBatch<T>` parent, `Transaction` / `ClusterTransaction` deprecated aliases, `BatchRetryStrategy`, `ClusterBatchOptions { timeout, route, retryStrategy }`
- `getStatistics()` synchronous returning `object` with string values
- `close(errorMessage?: string): void` synchronous
- Defaults: `inflightRequestsLimit: 1000`, `requestTimeout: 250ms`, `connectionTimeout: 2000ms`, blocking-command timeout auto-extension 0.5 s

## Test plan

- [x] All 8 Node reference files read end-to-end after edits
- [x] Both migration files read end-to-end after edits
- [x] Pass 1: general source verification against v2.3.1
- [x] Pass 2: targeted correctness audit - caught 3 real fabrications / stale claims pass 1 missed (Node dynamic pubsub exists, `zrangeWithScores` uses `stop` not `end`, `lazyConnect` default wrong)
- [x] Cross-file consistency: blocking commands, error classes, TimeUnit values all match source in SKILL.md + reference files + migration
- [ ] Ecosystem reviewers (Gemini)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates, but they correct several previously wrong migration guidance points (notably Node PubSub capabilities and signature gotchas) that could affect users following the docs.
> 
> **Overview**
> Updates the `migrate-ioredis` and `valkey-glide-nodejs` skills to a *divergence-only* format and bumps versions (`migrate-ioredis` to `1.1.0`, `valkey-glide-nodejs` to `2.1.0`). Content is streamlined by removing command-by-command mirrors and large examples, and refocusing on the specific API/behavior differences that commonly break ioredis-to-GLIDE migrations.
> 
> Corrects and expands several Node GLIDE v2.3.1 behavioral details: **dynamic PubSub APIs are supported** (static vs dynamic subscription paths are documented), `publish()` argument order is emphasized as reversed, `lazyConnect` semantics are clarified, `Script.release()` is made explicit as required, error guidance is aligned around the `ValkeyError`→`RequestError` subclass tree, and batching/streams docs highlight signature/option-shape divergences and multiplexer-related dedicated-client exceptions (blocking ops, WATCH, long polling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c699343ee5ba82306c66041018cb0f4b0b46cbbc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->