### PR TITLE
go + migrate-go-redis: validate against v2.3.1, apply divergence-only lens

### DIFF
--- a/skills/migrate-go-redis/.claude-plugin/plugin.json
+++ b/skills/migrate-go-redis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-go-redis",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use when migrating Go from go-redis to Valkey GLIDE. Covers Result[T] nil handling, CGO dependency, PubSub, SetWithOptions, Alpine/MUSL gotchas. Not for greenfield Go apps - use valkey-glide-go instead.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/migrate-go-redis/skills/migrate-go-redis/SKILL.md
+++ b/skills/migrate-go-redis/skills/migrate-go-redis/SKILL.md
@@ -1,116 +1,114 @@
 ---
 name: migrate-go-redis
-description: "Use when migrating Go from go-redis to Valkey GLIDE. Covers Result[T] nil handling, CGO dependency, PubSub, SetWithOptions, Alpine/MUSL gotchas. Not for greenfield Go apps - use valkey-glide-go instead."
-version: 1.0.0
+description: "Use when migrating Go from go-redis to Valkey GLIDE. Covers Result[T] nil handling (no redis.Nil), slice args, typed SET/ZADD options, flat error model, CGO requirement. Publish arg order is UNCHANGED. Not for greenfield Go apps - use valkey-glide-go."
+version: 1.1.0
 argument-hint: "[API or pattern to migrate]"
 ---
 
 # Migrating from go-redis to Valkey GLIDE (Go)
 
-Use when migrating a Go application from `go-redis/redis` to the GLIDE client library.
+Use when moving an existing `go-redis/redis` app to GLIDE. Assumes you already know go-redis. Covers what breaks or changes shape; commands that translate literally (same method names, `ctx` first arg) are not listed here.
 
-## Routing
+## Divergences that actually matter
 
-- String, hash, list, set, sorted set, delete, exists, cluster -> API Mapping
-- Pipeline, transaction, Batch API, TxPipelined -> Advanced Patterns
-- PubSub, subscribe, publish, queue-based polling -> Advanced Patterns
+| Area | go-redis | GLIDE Go |
+|------|----------|---------|
+| Construction | `redis.NewClient(&redis.Options{Addr: "host:6379"})` | `glide.NewClient(cfg)` returning `(*Client, error)` |
+| Cluster | `redis.NewClusterClient(&redis.ClusterOptions{...})` | `glide.NewClusterClient(cfg)` |
+| Config style | Struct literal | Builder chain: `config.NewClientConfiguration().WithAddress(...).With...()` |
+| Return types | `*StatusCmd`, `*StringCmd`, etc.; call `.Result()` | Direct `(Result[T], error)` from command; `.IsNil()` + `.Value()` on the Result |
+| Nil handling | `if err == redis.Nil` sentinel for missing key | `err` is only real errors; `val.IsNil()` for missing key - two orthogonal checks |
+| Error types | `redis.Error` types in one package with `errors.Is` | FLAT model - `*ConnectionError`, `*TimeoutError`, `*DisconnectError`, `*ExecAbortError`, `*ClosingError`, `*ConfigurationError`, `*BatchError` - independent structs. Most operational errors fall through to generic `errors.New(msg)`. |
+| Multi-arg commands | Varargs: `Del(ctx, "k1", "k2")` | Slice: `Del(ctx, []string{"k1", "k2"})` - same for `Exists`, `LPush`, `SAdd`, `SRem` |
+| SET expiry | Duration arg: `Set(ctx, k, v, 60*time.Second)` | `SetWithOptions(ctx, k, v, *options.NewSetOptions().SetExpiry(options.NewExpiryIn(60*time.Second)))` - `NewExpiryIn` for duration, `NewExpiryAt` for absolute `time.Time`, `NewExpiryKeepExisting()` for KEEPTTL |
+| ZADD | `ZAdd(ctx, key, redis.Z{Score, Member})` varargs | `ZAdd(ctx, key, map[string]float64{"alice": 1.0})` or with `options.NewZAddOptions().SetConditionalChange(...)` |
+| Pipeline | `rdb.Pipeline()` + `.Set(...)` + `.Exec(ctx)` chain | `pipeline.NewStandaloneBatch(false)` + `batch.Set(...)` + `client.Exec(ctx, *batch, raiseOnError)` |
+| Transaction | `rdb.TxPipelined(ctx, func(pipe Pipeliner) error { ... })` closure | `pipeline.NewStandaloneBatch(true)` + `client.Exec(ctx, *batch, raiseOnError)` - same class, `isAtomic` flag |
+| Pipeline results | `[]redis.Cmder` - iterate `.Err()` and `.Val()` | `[]any` - iterate with `glide.IsError(item)` check |
+| `Publish` | `rdb.Publish(ctx, channel, message)` | `client.Publish(ctx, channel, message)` - **SAME ORDER** (unlike Python/Node GLIDE which reverses) |
+| PubSub | `pubsub := rdb.Subscribe(ctx, ch); pubsub.ReceiveMessage(ctx)` | Static config OR dynamic `Subscribe(ctx, ...)` (GLIDE 2.3+); callback in config OR polling |
+| Connection pool | `Options.PoolSize`, `MinIdleConns`, `PoolTimeout` | Multiplexer - no pool knobs; blocking commands need a dedicated client |
+| Retries | `Options.MaxRetries`, `MinRetryBackoff` | Reconnection is INFINITE; `config.NewBackoffStrategy(n, factor, base)` caps backoff sequence length only |
+| TLS | `Options.TLSConfig *tls.Config` | `WithUseTLS(true)` + `config.NewTlsConfiguration().WithRootCertificates(...)` in advanced config |
+| IAM (not in go-redis) | N/A | `config.NewIamAuthConfig("cluster", config.ElastiCache, "us-east-1")` + `NewServerCredentialsWithIam` |
+| `redis.Nil`-style empty returns | Sentinel error | N/A - use `IsNil()` or check for empty map/slice |
+| Cluster topology | `ClusterOptions.Addrs`, `RouteByLatency`, `RouteRandomly` | `WithAddress(...)` (multiple OK; seeds), `WithReadFrom(config.PreferReplica / AzAffinity / ...)` |
 
-## Key Differences
+## Error handling - THE biggest change
 
-| Area | go-redis | GLIDE |
-|------|----------|-------|
-| Return types | `*StatusCmd`, `*StringCmd` with `.Result()` | `models.Result[T]` with `.Value()` and `.IsNil()` |
-| Nil handling | `redis.Nil` sentinel error | `val.IsNil()` method |
-| Configuration | `redis.Options{}` struct | `config.NewClientConfiguration()` builder chain |
-| Multi-arg commands | Varargs: `Del(ctx, "k1", "k2")` | Slice args: `Del(ctx, []string{"k1", "k2"})` |
-| Expiry | Duration arg: `Set(ctx, "k", "v", 60*time.Second)` | `SetWithOptions` + `options.SetOptions` |
-| Transactions | `TxPipelined()` closure | `pipeline.NewStandaloneBatch(true)` + `client.Exec()` |
-| Pipelines | `Pipelined()` closure | `pipeline.NewStandaloneBatch(false)` + `client.Exec()` |
-| Connection model | Pool with configurable size | Single multiplexed connection per node |
-| API style | Synchronous with goroutine safety | Synchronous with goroutine safety (via CGO bridge) |
-
-## Error Handling - The Biggest Change
-
-**go-redis:**
 ```go
+// go-redis: Nil is a sentinel error
 val, err := rdb.Get(ctx, "key").Result()
-if err == redis.Nil {
-    fmt.Println("key does not exist")
-} else if err != nil {
-    fmt.Println("error:", err)
-} else {
-    fmt.Println("value:", val)
-}
-```
+if err == redis.Nil { /* missing */ }
+else if err != nil  { /* real error */ }
+else                { /* val is the value */ }
 
-**GLIDE:**
-```go
+// GLIDE: Nil is not an error
 val, err := client.Get(ctx, "key")
-if err != nil {
-    fmt.Println("error:", err)
-    return
-}
-if val.IsNil() {
-    fmt.Println("key does not exist")
-} else {
-    fmt.Println("value:", val.Value())
-}
+if err != nil { /* real error - typed or generic errors.New */ ; return }
+if val.IsNil() { /* missing */ }
+else           { /* val.Value() is the value */ }
 ```
 
-go-redis uses `redis.Nil` as an error sentinel for missing keys. GLIDE separates nil from errors - `err` is only for actual errors, `val.IsNil()` checks for key absence.
+Importantly, GLIDE's error model is FLAT - you can't catch "all request errors" with one type check. See [error-handling reference](../../valkey-glide-go/skills/valkey-glide-go/reference/best-practices-error-handling.md) (or the greenfield skill) for the full picture.
 
-## Quick Start - Connection Setup
+## Config translation
 
-**go-redis:**
 ```go
-rdb := redis.NewClient(&redis.Options{Addr: "localhost:6379", Password: "", DB: 0})
-```
+// go-redis:
+rdb := redis.NewClient(&redis.Options{
+    Addr: "h:6379", Password: "pw", DB: 0,
+    DialTimeout: 5 * time.Second, TLSConfig: &tls.Config{},
+    PoolSize: 10, MaxRetries: 3,
+})
 
-**GLIDE:**
-```go
+// GLIDE:
 cfg := config.NewClientConfiguration().
-    WithAddress(&config.NodeAddress{Host: "localhost", Port: 6379})
+    WithAddress(&config.NodeAddress{Host: "h", Port: 6379}).
+    WithCredentials(config.NewServerCredentialsWithDefaultUsername("pw")).
+    WithDatabaseId(0).
+    WithRequestTimeout(5 * time.Second).
+    WithUseTLS(true).
+    WithReconnectStrategy(config.NewBackoffStrategy(5, 100, 2))
 client, err := glide.NewClient(cfg)
-defer client.Close()
 ```
 
-## Configuration Mapping
+Drop `PoolSize`, `MinIdleConns`, `PoolTimeout`, `IdleTimeout`, `MaxConnAge` - GLIDE has no pool.
 
-| go-redis field | GLIDE equivalent |
-|----------------|------------------|
-| `Addr: "host:port"` | `WithAddress(&config.NodeAddress{Host, Port})` |
-| `Password` | `WithCredentials(&config.ServerCredentials{Password: "..."})` |
-| `DB` | `WithDatabaseId(0)` |
-| `DialTimeout` | `WithRequestTimeout(ms)` |
-| `TLSConfig` | `WithUseTLS(true)` |
-| `PoolSize` | Not needed - single multiplexed connection |
-| `MaxRetries` | Built-in reconnection via `WithReconnectStrategy` |
+## Migration strategy
 
-## Incremental Migration Strategy
+No compatibility layer. Migrate incrementally:
 
-No drop-in compatibility layer exists for Go. Migration approach:
-
-1. Add `github.com/valkey-io/valkey-glide/go/v2` to your `go.mod` alongside `go-redis`
-2. Define a repository or store interface that abstracts the Redis client
-3. Create a GLIDE implementation alongside the go-redis one
-4. Replace `redis.Nil` error checks with `Result[T].IsNil()` at each call site
-5. Run tests after each package migration to catch nil-handling regressions
-6. Remove `go-redis` from `go.mod` once all implementations are migrated
+1. Add `github.com/valkey-io/valkey-glide/go/v2` alongside `go-redis` in `go.mod`.
+2. Define a repository interface that abstracts the Redis client. Implement both sides.
+3. Swap implementations behind a build tag or config flag per package.
+4. **Rewrite nil-handling at every call site** - `redis.Nil` checks become `Result[T].IsNil()` checks. This is the biggest chunk of mechanical work.
+5. Run tests after each package - nil handling regressions are the most common failure.
+6. Remove `go-redis` from `go.mod` when all implementations are migrated.
 
 ## Reference
 
 | Topic | File |
 |-------|------|
-| Command-by-command API mapping (strings, hashes, lists, sets, sorted sets, delete, exists, cluster) | [api-mapping](reference/api-mapping.md) |
-| Transactions, pipelines, Pub/Sub, Go API maturity timeline | [advanced-patterns](reference/advanced-patterns.md) |
+| Slice args, SET typed options, ZADD map form, cluster, per-command divergences | [api-mapping](reference/api-mapping.md) |
+| Pipeline/transaction mapping, PubSub (static + dynamic 2.3+), platform / CGO / Alpine notes | [advanced-patterns](reference/advanced-patterns.md) |
 
-## Gotchas
+## Gotchas (the short list)
 
-1. **`Result[T]` instead of `redis.Nil`.** Check `IsNil()` before calling `Value()`.
-2. **Slice args, not varargs.** Multi-key commands take `[]string` slices.
-3. **Separate `Set` and `SetWithOptions`.** go-redis combines expiry into `Set()`. GLIDE has separate methods.
-4. **CGO dependency.** GLIDE for Go uses CGO to call the Rust core. Cross-compilation requires Docker-based builds or platform-native compilation.
-5. **Alpine Linux / MUSL.** Requires the `musl` build tag: `export GOFLAGS=-tags=musl`.
-6. **No connection pool tuning.** Drop all `PoolSize`, `MinIdleConns` configuration.
-7. **Import path.** Module is `github.com/valkey-io/valkey-glide/go/v2` with subpackages `config`, `options`, `pipeline`, `models`, `constants`.
-8. **`go mod vendor` support.** Added in GLIDE 2.2 - earlier versions did not work with vendor mode.
+1. **`Result[T].IsNil()` not `redis.Nil`.** Two orthogonal checks: `err` for transport, `IsNil()` for missing key.
+2. **Flat error model.** `ConnectionError`, `TimeoutError`, `DisconnectError`, `ExecAbortError`, etc. are independent structs with no base class; `errors.As(err, &connErr)` catches ONLY that specific type. Most runtime errors fall through to `errors.New(msg)`.
+3. **Most "connection lost" errors arrive as `*DisconnectError`, not `*ConnectionError`.** Subtle. `ConnectionError` is mostly setup-time.
+4. **Slice args for multi-key** - `Del(ctx, []string{"k1","k2"})`, not varargs.
+5. **`SetWithOptions` for expiry** - the simple `Set` has no duration parameter; use `options.NewSetOptions().SetExpiry(options.NewExpiryIn(d))` (`In` for duration, `At` for timestamp, `KeepExisting` for KEEPTTL).
+6. **`Publish(ctx, channel, message)` order is UNCHANGED from go-redis.** Python/Node GLIDE reverse this; Go does not.
+7. **No pool tuning.** Delete `PoolSize`, `MinIdleConns`, `PoolTimeout` etc. Blocking commands (`BLPop`, `BRPop`, `BLMove`, `BZPopMax`/`Min`, `BRPopLPush`, `BLMPop`, `BZMPop`, `XRead`/`XReadGroup` with block, WATCH) need a dedicated client instead.
+8. **Reconnection is infinite** - no `MaxRetries` equivalent.
+9. **CGO is mandatory.** Requires a C toolchain and glibc 2.17+. Alpine needs `musl-gcc` / `CGO_ENABLED=1`.
+10. **`inflightRequestsLimit` is NOT exposed** in Go at v2.3.1 (Python/Node expose it). Core cap of 1000 applies.
+11. **`go mod vendor`** works from GLIDE 2.2+. Older versions had vendor-mode issues.
+12. **Import root** - `github.com/valkey-io/valkey-glide/go/v2` with subpackages `config`, `options`, `pipeline`, `models`, `constants`.
+
+## Cross-references
+
+- `valkey-glide-go` - full Go skill for GLIDE features beyond the migration scope
+- `glide-dev` - GLIDE core internals (Rust + CGO bridge) if you need to debug binding-level issues

--- a/skills/migrate-go-redis/skills/migrate-go-redis/SKILL.md
+++ b/skills/migrate-go-redis/skills/migrate-go-redis/SKILL.md
@@ -50,7 +50,7 @@ if val.IsNil() { /* missing */ }
 else           { /* val.Value() is the value */ }
 ```
 
-Importantly, GLIDE's error model is FLAT - you can't catch "all request errors" with one type check. See [error-handling reference](../../valkey-glide-go/skills/valkey-glide-go/reference/best-practices-error-handling.md) (or the greenfield skill) for the full picture.
+Importantly, GLIDE's error model is FLAT - you can't catch "all request errors" with one type check. See the `valkey-glide-go` skill's error-handling reference for the full picture.
 
 ## Config translation
 
@@ -99,7 +99,7 @@ No compatibility layer. Migrate incrementally:
 2. **Flat error model.** `ConnectionError`, `TimeoutError`, `DisconnectError`, `ExecAbortError`, etc. are independent structs with no base class; `errors.As(err, &connErr)` catches ONLY that specific type. Most runtime errors fall through to `errors.New(msg)`.
 3. **Most "connection lost" errors arrive as `*DisconnectError`, not `*ConnectionError`.** Subtle. `ConnectionError` is mostly setup-time.
 4. **Slice args for multi-key** - `Del(ctx, []string{"k1","k2"})`, not varargs.
-5. **`SetWithOptions` for expiry** - the simple `Set` has no duration parameter; use `options.NewSetOptions().SetExpiry(options.NewExpiryIn(d))` (`In` for duration, `At` for timestamp, `KeepExisting` for KEEPTTL).
+5. **`SetWithOptions` for expiry** - the simple `Set` has no duration parameter; use `*options.NewSetOptions().SetExpiry(options.NewExpiryIn(d))` (note the `*` dereference - `SetWithOptions` takes the value, builder returns pointer). `NewExpiryIn` for duration, `NewExpiryAt` for timestamp, `NewExpiryKeepExisting` for KEEPTTL.
 6. **`Publish(ctx, channel, message)` order is UNCHANGED from go-redis.** Python/Node GLIDE reverse this; Go does not.
 7. **No pool tuning.** Delete `PoolSize`, `MinIdleConns`, `PoolTimeout` etc. Blocking commands (`BLPop`, `BRPop`, `BLMove`, `BZPopMax`/`Min`, `BRPopLPush`, `BLMPop`, `BZMPop`, `XRead`/`XReadGroup` with block, WATCH) need a dedicated client instead.
 8. **Reconnection is infinite** - no `MaxRetries` equivalent.

--- a/skills/migrate-go-redis/skills/migrate-go-redis/reference/advanced-patterns.md
+++ b/skills/migrate-go-redis/skills/migrate-go-redis/reference/advanced-patterns.md
@@ -75,29 +75,36 @@ subscriber, err := glide.NewClient(cfg)
 ```
 
 **GLIDE (dynamic subscriptions - GLIDE 2.3+):**
-```go
-// Non-blocking subscribe (lazy)
-err := client.Subscribe(ctx, []string{"channel"})
-err = client.PSubscribe(ctx, []string{"events:*"})
 
-// Blocking subscribe - waits for server confirmation
-err = client.SubscribeBlocking(ctx, []string{"channel"}, 5000)
-err = client.PSubscribeBlocking(ctx, []string{"events:*"}, 5000)
+Go uses a single method name with a `timeoutMs` parameter for blocking, and `*Lazy` variants for non-blocking. There is no separate `SubscribeBlocking` for exact channels; the blocking variant is just `Subscribe(ctx, channels, timeoutMs)`:
+
+```go
+// Blocking - waits for server confirmation; timeoutMs=0 blocks indefinitely
+err := client.Subscribe(ctx, []string{"channel"}, 5000)
+err = client.PSubscribe(ctx, []string{"events:*"}, 5000)
+err = clusterClient.SSubscribe(ctx, []string{"shard-topic"}, 5000)  // cluster only
+
+// Non-blocking - returns immediately; reconciliation happens async
+err = client.SubscribeLazy(ctx, []string{"channel"})
+err = client.PSubscribeLazy(ctx, []string{"events:*"})
+err = clusterClient.SSubscribeLazy(ctx, []string{"shard-topic"})
+
+// Unsubscribe variants mirror the same pattern
+err = client.Unsubscribe(ctx, []string{"channel"}, 5000)          // nil = unsubscribe all
+err = client.UnsubscribeLazy(ctx, []string{"channel"})
+err = client.PUnsubscribe(ctx, []string{"events:*"}, 5000)
+err = client.PUnsubscribeLazy(ctx, nil)                            // all patterns
 
 // Receive via queue (when no callback configured)
 queue, err := client.GetQueue()
 msg := queue.Pop()                    // non-blocking, returns nil if empty
-msgCh := queue.WaitForMessage()       // blocking, returns a channel
+msgCh := queue.WaitForMessage()       // blocking - returns receive-only channel
 msg = <-msgCh
-
-// Unsubscribe
-err = client.Unsubscribe(ctx, []string{"channel"})
-err = client.PUnsubscribe(ctx, []string{"events:*"})
-err = client.UnsubscribeAll(ctx)      // all exact channels
-err = client.PUnsubscribeAll(ctx)     // all patterns
 ```
 
-go-redis uses a Go channel-based approach (`pubsub.Channel()`). GLIDE uses callbacks (set at creation time) or queue-based polling (`GetQueue` + `Pop` / `WaitForMessage`). Use a dedicated client for subscriptions. GLIDE automatically resubscribes on reconnection.
+go-redis uses a Go channel-based approach (`pubsub.Channel()`). GLIDE uses callbacks (set at creation time via `WithCallback`) OR queue-based polling (`GetQueue` + `Pop` / `WaitForMessage`). They are mutually exclusive on one client.
+
+GLIDE multiplexes subscriptions alongside commands - a dedicated subscriber client is recommended for high-volume subscriptions but not strictly required. Auto-resubscribe on reconnect + topology change is handled by the synchronizer.
 
 ---
 

--- a/skills/valkey-glide-go/.claude-plugin/plugin.json
+++ b/skills/valkey-glide-go/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "valkey-glide-go",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Use when building Go apps with Valkey GLIDE - synchronous API, Client/ClusterClient, CGO bridge, Result[T] types, Batch, streams, TLS, OpenTelemetry, Lua scripting. Not for go-redis migration - use migrate-go-redis skill.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/valkey-glide-go/skills/valkey-glide-go/SKILL.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/SKILL.md
@@ -44,7 +44,7 @@ Large values are NOT an exception - they pipeline through the multiplexer fine.
 6. **`ResetConnectionPassword(ctx)` is a separate method**, unlike Python's `update_connection_password(None)`. The `UpdateConnectionPassword(ctx, pw, immediateAuth)` method does not accept an empty string to clear.
 7. **CGO is mandatory.** Requires glibc 2.17+ and a C toolchain. No pure-Go build. Alpine needs `musl-gcc` or use Debian base.
 8. **`context.Context` is the first arg to every command method.** Unlike go-redis's `rdb.Get(ctx, key)` (same pattern) but unlike Python/Node (no ctx).
-9. **`AzAffinityReplicaAndPrimary`** - singular `Replica` in the enum name (`go/config/config.go:169`). Matches the protobuf name `AZAffinityReplicasAndPrimary` internally despite the user-facing enum being singular.
+9. **`AzAffinityReplicaAndPrimary`** - singular `Replica` in the Go-side user-facing enum (in `go/config`). Matches the protobuf name `AZAffinityReplicasAndPrimary` internally despite the Go constant being singular.
 10. **Configure deadlines via `context.WithTimeout`**, not just `WithRequestTimeout`. Both work; context takes precedence and is Go-idiomatic.
 
 ## Cross-references

--- a/skills/valkey-glide-go/skills/valkey-glide-go/SKILL.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/SKILL.md
@@ -1,28 +1,54 @@
 ---
 name: valkey-glide-go
-description: "Use when building Go apps with Valkey GLIDE - synchronous API, Client/ClusterClient, CGO bridge, Result[T] types, Batch, streams, TLS, OpenTelemetry, Lua scripting. Not for go-redis migration - use migrate-go-redis skill."
-version: 2.0.0
+description: "Use when building Go apps with Valkey GLIDE - synchronous API, Client / ClusterClient, CGO bridge, Result[T] nil handling, Batch, streams, multiplexer behavior, IAM, AZ affinity, OpenTelemetry. Covers the divergence from go-redis; basic command shapes are assumed knowable from training. Not for go-redis migration - use migrate-go-redis."
+version: 2.1.0
 argument-hint: "[API or config question]"
 ---
 
 # Valkey GLIDE Go Client
 
-Synchronous Go client for Valkey built on the GLIDE Rust core via CGO bridge.
+Agent-facing skill for GLIDE Go. Assumes the reader can already write basic go-redis from training (`rdb.Get(ctx, key).Result()`, pipelines, consumer groups, pubsub loop). Covers only what diverges from go-redis and what GLIDE adds on top.
 
 ## Routing
 
 | Question | Reference |
 |----------|-----------|
-| Install, setup, client creation, TLS, auth, reconnect | [connection](reference/features-connection.md) |
-| PubSub, subscribe, publish, sharded channels | [pubsub](reference/features-pubsub.md) |
-| Batching, transactions, pipelines | [batching](reference/features-batching.md) |
-| Streams, consumer groups, XADD, XREAD | [streams](reference/features-streams.md) |
-| Connection timeouts, TLS certificates, TCP_NODELAY, cluster topology refresh, request routing, custom commands, scan iteration | [advanced](reference/features-advanced.md) |
-| Error types, retry, reconnection patterns | [error-handling](reference/best-practices-error-handling.md) |
-| Benchmarks, throughput, batching perf | [performance](reference/best-practices-performance.md) |
-| Timeouts, connection management, cloud defaults | [production](reference/best-practices-production.md) |
+| `Client` vs `ClusterClient`, TLS, auth, IAM, lazy connect, AZ affinity, DB selection, `ResetConnectionPassword` | [connection](reference/features-connection.md) |
+| PubSub: static config vs dynamic `Subscribe` (2.3+), callback vs polling, `GetSubscriptionConfig`, sharded | [pubsub](reference/features-pubsub.md) |
+| `Batch` / `ClusterBatch`, atomic vs pipeline, `BatchOptions`, `RetryStrategy`, WATCH | [batching](reference/features-batching.md) |
+| Streams typed options, split `XClaim` / `XClaimJustId`, `XAutoClaimResponse` struct, multi-stream slot constraint | [streams](reference/features-streams.md) |
+| Custom commands, routing (`AllNodes`, `SlotKeyRoute`, ...), OpenTelemetry, cluster SCAN, Lua `Script` | [advanced](reference/features-advanced.md) |
+| Go-specific flat error model, `GoError` mapping (only 3 types auto-mapped), `BatchError` | [error-handling](reference/best-practices-error-handling.md) |
+| Multiplexer discipline, batching as top optimization, inflight cap, `GetStatistics()` uint64 | [performance](reference/best-practices-performance.md) |
+| Production defaults, timeout tuning, AZ affinity, OTel setup, CGO / glibc constraints | [production](reference/best-practices-production.md) |
 
-## Cross-References
+## Multiplexer rule (the #1 agent mistake)
 
-- `valkey-glide` skill - shared architecture, cluster topology, connection model
-- `valkey` skill - Valkey server commands, data types, patterns
+One `*Client` / `*ClusterClient` per process, shared across every goroutine. Do not create per-request clients. Do not pool them.
+
+**Exceptions that need a dedicated client:**
+
+- Blocking commands: `BLPop`, `BRPop`, `BLMove`, `BZPopMax`, `BZPopMin`, `BRPopLPush`, `BLMPop`, `BZMPop`, plus `XRead` / `XReadGroup` with block, and `Wait` / `WaitAof`. They occupy the multiplexed connection for the block duration.
+- `Watch` / `Multi` / `Exec` transactions (connection-state commands).
+- PubSub clients doing high-volume subscriptions.
+
+Large values are NOT an exception - they pipeline through the multiplexer fine.
+
+## Grep hazards
+
+1. **`Publish(ctx, channel, message)` - NOT reversed like Python/Node.** Go matches the Redis / go-redis convention. If you've read the Python or Node skill's "REVERSED publish" gotcha - that does NOT apply to Go.
+2. **`Result[T]` wraps nil.** Methods returning `Result[T]` (Get, HGet, etc.) require `.IsNil()` check before `.Value()`. Unlike go-redis where `.Result()` returns `(T, error)` with `redis.Nil` as a sentinel error.
+3. **Flat error model - no hierarchy.** `ConnectionError`, `TimeoutError`, `DisconnectError`, `ExecAbortError`, `ClosingError`, `ConfigurationError`, `BatchError` are independent structs. Python's `except RequestError:` pattern does NOT translate - you can't catch a whole category with one `errors.As`.
+4. **Only 3 errors auto-typed.** `go/errors.go:GoError()` maps ONLY `ExecAbort`, `Timeout`, `Disconnect` to typed errors. Everything else falls through to generic `errors.New(msg)`. So `errors.As(err, &connErr)` with `*ConnectionError` may miss most "connection lost" cases that arrive as `*DisconnectError` or plain strings.
+5. **`GetStatistics() map[string]uint64`.** Typed uint64 values, not strings like Python/Node. Still exposes the same counter keys (`total_connections`, `total_clients`, compression counters, `subscription_out_of_sync_count`, etc.).
+6. **`ResetConnectionPassword(ctx)` is a separate method**, unlike Python's `update_connection_password(None)`. The `UpdateConnectionPassword(ctx, pw, immediateAuth)` method does not accept an empty string to clear.
+7. **CGO is mandatory.** Requires glibc 2.17+ and a C toolchain. No pure-Go build. Alpine needs `musl-gcc` or use Debian base.
+8. **`context.Context` is the first arg to every command method.** Unlike go-redis's `rdb.Get(ctx, key)` (same pattern) but unlike Python/Node (no ctx).
+9. **`AzAffinityReplicaAndPrimary`** - singular `Replica` in the enum name (`go/config/config.go:169`). Matches the protobuf name `AZAffinityReplicasAndPrimary` internally despite the user-facing enum being singular.
+10. **Configure deadlines via `context.WithTimeout`**, not just `WithRequestTimeout`. Both work; context takes precedence and is Go-idiomatic.
+
+## Cross-references
+
+- `migrate-go-redis` - migrating from go-redis
+- `glide-dev` - GLIDE core internals (Rust), binding mechanics
+- `valkey` - Valkey commands and app patterns

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/best-practices-error-handling.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/best-practices-error-handling.md
@@ -80,7 +80,7 @@ strategy := config.NewBackoffStrategy(5, 100, 2)  // numOfRetries, factor_ms, ex
 strategy.WithJitterPercent(20)
 ```
 
-- Delay formula: `rand_jitter * factor * (exponentBase ** attempt)`, clamped at a ceiling.
+- Delay formula: `rand_jitter * factor * (exponentBase ^ attempt)` (conceptual; Go doesn't have an exponentiation operator - the math is done in the Rust core), clamped at a ceiling.
 - After `numOfRetries` the delay plateaus and reconnection continues infinitely until close.
 - Initial-connect permanent errors (`AuthenticationFailed`, `InvalidClientConfig`, `RESP3NotSupported`, plus `NOAUTH` / `WRONGPASS` string matches) are not retried. After initial connect, the core keeps reconnecting and surfaces `DisconnectError` / generic error per command until the server recovers.
 - PubSub channels resubscribe automatically via the synchronizer.

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/best-practices-error-handling.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/best-practices-error-handling.md
@@ -1,135 +1,92 @@
-# Error Handling
+# Error handling (Go)
 
-Use when implementing error handling, retry logic, or batch error semantics in the GLIDE Go client.
+Covers what differs from go-redis's `redis.Nil` sentinel + typed errors in `redis` package. GLIDE Go has a fundamentally different error model you need to understand.
 
-## Error Types
+## Divergence from go-redis
 
-Go GLIDE uses typed error structs with the standard `errors.As` pattern:
+| go-redis | GLIDE Go |
+|----------|---------|
+| `val, err := rdb.Get(ctx, key).Result()`; `errors.Is(err, redis.Nil)` for missing key | `val, err := client.Get(ctx, key)` returns `(Result[string], error)`; check `err` for transport errors first, THEN `val.IsNil()` for missing key |
+| Typed errors in `redis` package, pointer to base | FLAT error model - independent structs, no base class. `*ConnectionError`, `*TimeoutError`, `*DisconnectError`, `*ExecAbortError`, `*ClosingError`, `*ConfigurationError`, `*BatchError` - each unrelated |
+| `redis.Nil` sentinel for missing key | `Result[T].IsNil()` - separate API, no error at all |
+| `MaxRetries` caps request retries | Reconnection is INFINITE - `numOfRetries` on `BackoffStrategy` only caps backoff sequence length |
+
+## Go's flat error model - the subtle gotcha
 
 ```go
 import (
     "errors"
     glide "github.com/valkey-io/valkey-glide/go/v2"
 )
-```
 
-| Error | When It Occurs | Recovery |
-|-------|---------------|----------|
-| `*glide.ConnectionError` | Connection lost | GLIDE auto-reconnects; retry the operation |
-| `*glide.TimeoutError` | Request exceeded `WithRequestTimeout` (default 250ms) | Increase timeout or check server load |
-| `*glide.ExecAbortError` | Atomic batch aborted (WATCH key changed) | Retry the transaction |
-| `*glide.ClosingError` | Client was closed | Create a new client |
-| `*glide.ConfigurationError` | Invalid client configuration | Fix config and recreate |
-| `*glide.DisconnectError` | Connection problem between client and server | Check network; GLIDE may reconnect |
-| `*glide.BatchError` | Multiple errors in a batch response | Inspect individual errors via `.Error()` |
-
-## Basic Error Handling
-
-```go
 val, err := client.Get(ctx, "key")
 if err != nil {
     var connErr *glide.ConnectionError
+    var discErr *glide.DisconnectError
     var timeoutErr *glide.TimeoutError
-    if errors.As(err, &connErr) {
-        // Connection lost - GLIDE is already reconnecting
-        // Retry the operation after a brief delay
-    } else if errors.As(err, &timeoutErr) {
-        // Request exceeded timeout - check server load or increase timeout
-    } else {
-        // General error
-        fmt.Println("Error:", err)
+    var closingErr *glide.ClosingError
+    switch {
+    case errors.As(err, &connErr):
+        // rare - only at setup-type errors
+    case errors.As(err, &discErr):
+        // MOST "connection lost" scenarios arrive as DisconnectError, not ConnectionError
+    case errors.As(err, &timeoutErr):
+        // request exceeded requestTimeout
+    case errors.As(err, &closingErr):
+        // client is closed - create a new one
+    default:
+        // generic errors.New(msg) - the majority of operational errors
     }
     return
 }
-// Check for nil result (key not found is NOT an error)
-if val.IsNil() {
-    fmt.Println("Key does not exist")
-} else {
-    fmt.Println("Value:", val.Value())
-}
+if val.IsNil() { /* key not found - not an error */ }
 ```
 
-Go separates nil-check from error-check. A nil result (key not found) is not an error - check `val.IsNil()` after confirming `err == nil`.
+### Why this differs from Python / Node
 
----
+Only three errors are auto-typed by `GoError()` in `go/errors.go`: `ExecAbort`, `Timeout`, `Disconnect`. Everything else falls through to generic `errors.New(msg)`. So most operational errors do NOT match a typed struct. This is a bigger behavioral gap than it looks.
 
-## Batch Error Handling
+Python's `except RequestError:` / Node's `instanceof RequestError` catch the whole timeout+connection+config+exec-abort family. Go has no equivalent - you either list each `errors.As` check or resort to string matching on the message.
 
-The `raiseOnError` parameter on `client.Exec()` controls how batch errors surface:
+### Typed errors reference
 
-### raiseOnError = true
+| Type | Source |
+|------|--------|
+| `*ConnectionError` | Explicit throws in client setup |
+| `*DisconnectError` | Auto-mapped from core's `Disconnect` - actual "connection lost" signal |
+| `*TimeoutError` | Auto-mapped from core's `Timeout` |
+| `*ExecAbortError` | Auto-mapped from atomic-batch WATCH conflicts / MULTI errors |
+| `*ClosingError` | Explicit throws when client is closed |
+| `*ConfigurationError` | Explicit throws in config validation |
+| `*BatchError` | Wraps multiple prep-time batch errors (`[]error` collected during command construction) |
 
-First error in results is returned as the `error` return value.
+## Batch error handling
 
-```go
-import "github.com/valkey-io/valkey-glide/go/v2/pipeline"
-
-tx := pipeline.NewStandaloneBatch(true)
-tx.Set("key", "val")
-tx.Get("key")
-results, err := client.Exec(ctx, *tx, true)
-if err != nil {
-    fmt.Println("Batch failed:", err)
-    return
-}
-```
-
-### raiseOnError = false
-
-Errors appear inline as `error` values in the `[]any` slice. Use `glide.IsError()` to check:
+`raiseOnError=true` returns the first inline error as `err`; `raiseOnError=false` embeds errors inline in the results slice - use `glide.IsError(item)` to check:
 
 ```go
-pipe := pipeline.NewStandaloneBatch(false)
-pipe.Set("key", "value")
-pipe.LPush("key", []string{"oops"})  // WRONGTYPE error
-pipe.Get("key")
-
-results, err := client.Exec(ctx, *pipe, false)
+results, err := client.Exec(ctx, *batch, false)
 for i, item := range results {
-    if e := glide.IsError(item); e != nil {
-        fmt.Printf("Command %d failed: %v\n", i, e)
-    } else {
-        fmt.Printf("Command %d OK: %v\n", i, item)
-    }
+    if e := glide.IsError(item); e != nil { /* handle command i */ }
 }
 ```
 
-Atomic batches with WATCH return `nil, nil` (nil results, no error) if a watched key was modified. Retry the transaction in a loop.
+Atomic batches with WATCH return `nil, nil` on conflict (not an error).
 
----
-
-## Reconnection Behavior
-
-GLIDE reconnects automatically on connection loss with exponential backoff:
+## Reconnection behavior
 
 ```go
-import "github.com/valkey-io/valkey-glide/go/v2/config"
-
-strategy := config.NewBackoffStrategy(5, 100, 2)  // retries, factor(ms), exponentBase
+strategy := config.NewBackoffStrategy(5, 100, 2)  // numOfRetries, factor_ms, exponentBase
 strategy.WithJitterPercent(20)
-
-cfg := config.NewClientConfiguration().
-    WithAddress(&config.NodeAddress{Host: "localhost", Port: 6379}).
-    WithReconnectStrategy(strategy)
 ```
 
-- Delay formula: `factor * (exponentBase ^ attempt)` with optional jitter
-- After `numOfRetries`, delay stays at the ceiling indefinitely
-- PubSub channels are automatically resubscribed on reconnect
-- Permanent errors (NOAUTH, WRONGPASS) are not retried
+- Delay formula: `rand_jitter * factor * (exponentBase ** attempt)`, clamped at a ceiling.
+- After `numOfRetries` the delay plateaus and reconnection continues infinitely until close.
+- Initial-connect permanent errors (`AuthenticationFailed`, `InvalidClientConfig`, `RESP3NotSupported`, plus `NOAUTH` / `WRONGPASS` string matches) are not retried. After initial connect, the core keeps reconnecting and surfaces `DisconnectError` / generic error per command until the server recovers.
+- PubSub channels resubscribe automatically via the synchronizer.
 
----
+## Failover and timeout
 
-## Failover and Timeout
+During cluster failover expect error bursts for 1-5 seconds while the slot map refreshes. Retry is the right response.
 
-During cluster failover, expect `ConnectionError` bursts for 1-5 seconds. GLIDE refreshes the slot map and re-routes automatically. Retry failed operations.
-
-Frequent `TimeoutError` indicates server load - verify before increasing timeout:
-
-```go
-cfg := config.NewClientConfiguration().
-    WithAddress(&config.NodeAddress{Host: "localhost", Port: 6379}).
-    WithRequestTimeout(1 * time.Second)  // default 250ms
-```
-
-GLIDE auto-extends timeouts for blocking commands (BLPOP, XREADGROUP BLOCK) by 500ms beyond the block duration.
+Frequent `*TimeoutError` usually indicates server load, not a too-tight timeout. GLIDE auto-extends the effective timeout for blocking commands (BLPOP/BRPOP/BLMOVE/BZPopMax/BZPopMin/BRPopLPush/BLMPop/BZMPop and XRead/XReadGroup with block, WAIT/WAITAOF) by 0.5 s beyond the block duration - no tuning required.

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/best-practices-performance.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/best-practices-performance.md
@@ -1,118 +1,65 @@
-# Performance Tuning
+# Performance tuning (Go)
 
-Use when optimizing GLIDE Go throughput and latency, tuning inflight limits, or choosing batching strategies.
+Use when optimizing GLIDE Go throughput and latency. Covers GLIDE-specific discipline; general Go concurrency (goroutines, sync.WaitGroup, channel patterns) is the same as any Go app and not covered here.
 
-## Batching Is the Top Optimization
+## Client model: one client per process, not per goroutine
 
-Batching amortizes the CGO FFI overhead across all commands - one crossing per batch instead of one per command. Batched workloads are competitive with go-redis.
+GLIDE is a multiplexer. One `*Client` / `*ClusterClient` serves every goroutine concurrently - requests are tagged with IDs and demuxed. `client.Get(ctx, ...)` is goroutine-safe; call from any number of goroutines without a mutex. Creating a client per goroutine wastes allocation and opens fresh TCP handshakes to every cluster node.
 
-### Non-Atomic Pipeline
+**Exceptions - use a dedicated client:**
+
+- Blocking commands: `BLPop`, `BRPop`, `BLMove`, `BZPopMax`, `BZPopMin`, `BRPopLPush`, `BLMPop`, `BZMPop`, plus `XRead` / `XReadGroup` with block, and `Wait` / `WaitAof`. They occupy the multiplexed connection for the block duration.
+- `Watch` / atomic batch with WATCH - connection-state command; leaks across goroutines on the shared multiplexer.
+- PubSub subscribers doing high-volume subscriptions.
+
+Large values are NOT an exception - they pipeline through the multiplexer fine.
+
+## Batching is the top optimization
+
+Batching amortizes the CGO crossing across all commands - one crossing per batch instead of one per command. This is the single biggest throughput knob.
 
 ```go
 import "github.com/valkey-io/valkey-glide/go/v2/pipeline"
 
-pipe := pipeline.NewStandaloneBatch(false)
+batch := pipeline.NewStandaloneBatch(false)
 for i := 0; i < 100; i++ {
-    pipe.Set(fmt.Sprintf("key:%d", i), fmt.Sprintf("value:%d", i))
+    batch.Set(fmt.Sprintf("k:%d", i), fmt.Sprintf("v:%d", i))
 }
-results, err := client.Exec(ctx, *pipe, true)
-// One round-trip for 100 commands
+client.Exec(ctx, *batch, true)  // one CGO crossing, one multiplexer slot
 ```
 
-### Atomic Transaction
+In cluster mode, atomic batches require all keys to share a hash slot: `batch.Set("{account}:src", ...)`.
 
-```go
-tx := pipeline.NewStandaloneBatch(true)
-tx.Set("{account}:src", "100")
-tx.Set("{account}:dst", "0")
-tx.IncrBy("{account}:dst", 50)
-tx.DecrBy("{account}:src", 50)
-results, err := client.Exec(ctx, *tx, true)
-```
+Rough batch-size guidelines:
 
-All keys must share a hash slot in cluster mode. Use `{tag}` hash tags.
+| Size | Trade-off |
+|------|-----------|
+| 10-50 | Good default; low latency, solid throughput gain |
+| 50-200 | Best throughput; slight per-batch latency increase |
+| 200-1000 | Diminishing returns, large response buffers |
+| 1000+ | Memory pressure, long parsing - avoid |
 
-### Cluster Batch
+## Inflight request limit
 
-```go
-pipe := pipeline.NewClusterBatch(false)
-pipe.Set("user:1:name", "Alice")
-pipe.Set("user:2:name", "Bob")
-pipe.Get("user:1:name")
-results, err := clusterClient.Exec(ctx, *pipe, false)
-```
+The multiplexer caps concurrent inflight requests at 1000 per client. Requests beyond the cap fail with an error - rejected, not queued.
 
-Non-atomic cluster batches auto-route each command by key slot across nodes.
+**Go-specific:** `inflightRequestsLimit` is NOT exposed via the Go client config at v2.3.1 (Python/Node expose it). The default of 1000 is baked in. If you hit it, first batch commands (one batch = one slot), then consider whether 1000 concurrent in-flight is actually the bottleneck (usually server-side). Only as a last resort create a second client - doubling clients doubles the TCP footprint and breaks the single-multiplexer invariant.
 
-### Batch Size Guidelines
+## CGO overhead
 
-| Batch Size | Trade-off |
-|------------|-----------|
-| 10-50 | Good default. Low latency, solid throughput gain |
-| 50-200 | Best throughput. Slight increase in per-batch latency |
-| 200-1000 | Diminishing returns. Risk of large response buffers |
-| 1000+ | Avoid. Memory pressure and long parsing time |
+Every client command crosses the CGO boundary. Batching amortizes this. Avoid tight per-command loops; prefer `Exec` with a populated `Batch`.
 
----
+## Compression
 
-## Goroutine Concurrency
+Transparent value compression can reduce network bytes for large string / hash values. Configure via connection config - see [features-connection](features-connection.md). Monitor effect via `GetStatistics()`: compare `total_bytes_compressed` with `total_original_bytes` and watch `compression_skipped_count`.
 
-GLIDE is safe for concurrent goroutine access. Use goroutines for parallel independent operations:
-
-```go
-var wg sync.WaitGroup
-keys := []string{"key1", "key2", "key3"}
-results := make([]glide.Result[string], len(keys))
-
-for i, key := range keys {
-    wg.Add(1)
-    go func(idx int, k string) {
-        defer wg.Done()
-        results[idx], _ = client.Get(ctx, k)
-    }(i, key)
-}
-wg.Wait()
-```
-
-For bulk loads, prefer batching over individual goroutine calls - fewer FFI crossings and network round-trips.
-
----
-
-## Inflight Request Limit
-
-GLIDE caps concurrent inflight requests at 1000 per client. Requests beyond the limit are rejected immediately.
-
-The Go client does not yet expose an `inflightRequestsLimit` configuration option. The default of 1000 applies. If hitting the limit:
-1. Batch commands - one batch counts as one inflight request
-2. Create additional client instances - each gets its own 1000-request budget
-3. Review concurrency - 1000+ concurrent requests usually means the bottleneck is server-side
-
----
-
-## Connection Model
-
-GLIDE uses two multiplexed connections per node (data + management). No connection pools to size or manage. All data requests pipeline through the data connection using Valkey's built-in pipelining.
-
-### When to Create Multiple Clients
-
-- Blocking commands (BLPOP, BRPOP, XREADGROUP with BLOCK) - tie up the connection
-- WATCH/UNWATCH - requires connection-level isolation
-- Large value transfers - prevents head-of-line blocking
-- PubSub subscribers - dedicated listener, cannot share with command traffic
-
----
-
-## Resource Cleanup
-
-Always defer `Close()` immediately after creating a client:
+## Resource cleanup
 
 ```go
 client, err := glide.NewClient(cfg)
-if err != nil {
-    panic(err)
-}
+if err != nil { return err }
 defer client.Close()
 ```
 
-`Close()` is safe to call multiple times. It drains pending requests with `ClosingError`.
+`Close()` is safe to call multiple times. Pending requests get `ClosingError`.
 

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/best-practices-production.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/best-practices-production.md
@@ -1,149 +1,74 @@
-# Production Deployment
+# Production deployment (Go)
 
-Use when deploying GLIDE Go to production, configuring timeouts, managing connections, or setting up observability.
+Use when deploying GLIDE Go to production. Covers GLIDE-specific defaults and pitfalls that matter for operators. For basic setup examples see [features-connection](features-connection.md).
 
-## Connection Management
+## One client per process
 
-### Single Client Per Application
+Do not pool `*Client` / `*ClusterClient`. The multiplexer is the pool. Creating N clients opens N sets of TCP connections to every node. `defer client.Close()` immediately after creation.
 
-GLIDE multiplexes all requests over one connection per node. Do not create client pools.
+Use `WithLazyConnect(true)` if your app must start before Valkey is reachable - the first command pays the TCP connect cost.
 
-```go
-import (
-    glide "github.com/valkey-io/valkey-glide/go/v2"
-    "github.com/valkey-io/valkey-glide/go/v2/config"
-)
+## GLIDE Go defaults agents should know
 
-// Correct: one client shared across the application
-cfg := config.NewClientConfiguration().
-    WithAddress(&config.NodeAddress{Host: "localhost", Port: 6379})
-client, err := glide.NewClient(cfg)
-if err != nil {
-    panic(err)
-}
-defer client.Close()
+| Knob | Default | Config |
+|------|---------|--------|
+| Request timeout | 250 ms | `WithRequestTimeout(d time.Duration)` |
+| Connection timeout | 2000 ms | Advanced: `WithConnectionTimeout(d)` |
+| Inflight request cap | 1000 (NOT configurable in Go at v2.3.1) | - |
+| Topology check interval (cluster) | default | `WithPeriodicChecks` / `WithPeriodicChecksManualInterval` |
+| Backoff retries | (infinite; cap only on sequence length) | `WithReconnectStrategy(NewBackoffStrategy(...))` |
+| Protocol | RESP3 | via `protocol` enum in advanced config |
+| TCP_NODELAY | true | advanced config `WithTcpNoDelay` |
 
-// Wrong: do not pool GLIDE clients
-```
+Blocking-command timeout auto-extension: 0.5 s beyond the block duration. No tuning required.
 
-### Lazy Connect
+## Timeout tuning
 
-Defers connection until the first command. Allows startup when the server is not yet available.
+The 250 ms default is tight. Raise per-workload, not globally:
 
-```go
-cfg := config.NewClientConfiguration().
-    WithAddress(&config.NodeAddress{Host: "localhost", Port: 6379}).
-    WithLazyConnect(true)
+| Workload | Recommended |
+|----------|-------------|
+| Cache lookup (GET, HGET) | 250-500 ms |
+| Writes (SET, HSET, ZADD) | 250-500 ms |
+| Complex (SORT, SCAN, ZRANGEBYSCORE large) | 1-5 s |
+| Lua scripts | 5-30 s |
+| Blocking commands | Auto-extended - do not raise |
 
-client, err := glide.NewClient(cfg) // Returns immediately
-// Connection established on first command
-```
+Go-idiomatic alternative: use `context.WithTimeout(ctx, d)` per-call. Context deadline takes precedence and is the standard Go pattern.
 
-### Client Cleanup
+## Cluster: seed nodes and AZ affinity
 
-Always defer `Close()` after client creation. It drains pending requests with `ClosingError` and is safe to call multiple times.
+Provide multiple seed addresses. Topology is auto-discovered.
 
-```go
-defer client.Close()
-```
+`config.ReadFrom` values:
 
----
-
-## Timeout Configuration
-
-| Timeout | Default | Config Method |
-|---------|---------|--------------|
-| Request timeout | 250ms | `WithRequestTimeout(d time.Duration)` |
-| Connection timeout | 2000ms | Advanced config: `WithConnectionTimeout(d time.Duration)` |
-
-### Tuning by Workload
-
-| Workload | Recommended Timeout |
-|----------|-------------------|
-| Cache lookups (GET, HGET) | 250-500ms |
-| Write operations (SET, HSET) | 250-500ms |
-| Complex operations (SORT, SCAN) | 1-5s |
-| Lua scripts (EVALSHA) | 5-30s |
-| Blocking commands (BLPOP, XREADGROUP) | Handled automatically |
-
-GLIDE extends blocking command timeouts by 500ms beyond the block duration.
-
-```go
-advanced := config.NewAdvancedClientConfiguration().
-    WithConnectionTimeout(5 * time.Second)
-
-cfg := config.NewClientConfiguration().
-    WithAddress(&config.NodeAddress{Host: "localhost", Port: 6379}).
-    WithRequestTimeout(1 * time.Second).
-    WithAdvancedConfiguration(advanced)
-```
-
----
-
-## Cluster Configuration
-
-### Seed Nodes
-
-Provide multiple seed nodes for redundancy. GLIDE discovers the full topology automatically.
-
-```go
-cfg := config.NewClusterClientConfiguration().
-    WithAddress(&config.NodeAddress{Host: "node1.example.com", Port: 6379}).
-    WithAddress(&config.NodeAddress{Host: "node2.example.com", Port: 6379}).
-    WithAddress(&config.NodeAddress{Host: "node3.example.com", Port: 6379})
-
-client, err := glide.NewClusterClient(cfg)
-```
-
-### AZ Affinity
-
-Route reads to same-AZ replicas to reduce latency and cross-AZ costs.
-
-```go
-cfg := config.NewClusterClientConfiguration().
-    WithAddress(&config.NodeAddress{Host: "node1.example.com", Port: 6379}).
-    WithReadFrom(config.AzAffinity).
-    WithClientAZ("us-east-1a")
-```
-
-| Strategy | Behavior |
+| Constant | Behavior |
 |----------|----------|
 | `config.Primary` | All reads to primary (default) |
-| `config.PreferReplica` | Round-robin replicas, fallback to primary |
-| `config.AzAffinity` | Prefer same-AZ replicas |
-| `config.AzAffinityReplicaAndPrimary` | Same-AZ replicas, then primary, then remote |
+| `config.PreferReplica` | Round-robin replicas, fall back to primary |
+| `config.AzAffinity` | Same-AZ replicas preferred, then other replicas, then primary |
+| `config.AzAffinityReplicaAndPrimary` | Same-AZ replicas, then same-AZ primary, then any replica, then primary - note `Replica` is singular in the user-facing constant |
 
-Requires Valkey 8.0+ with `availability-zone` configured on each server node.
+AZ-affinity requires `WithClientAZ("<zone>")` AND the server exposing availability-zone metadata in `CLUSTER SHARDS` - otherwise falls back to primary.
 
----
+## Batch options in production
 
-## Batch Options in Production
-
-Use `ExecWithOptions` to set timeouts and retry strategies for batches:
+Timeouts and retry strategies via `ExecWithOptions`:
 
 ```go
-import "github.com/valkey-io/valkey-glide/go/v2/pipeline"
-
 opts := pipeline.NewClusterBatchOptions().
     WithTimeout(5 * time.Second).
     WithRetryStrategy(*pipeline.NewClusterBatchRetryStrategy().
         WithRetryServerError(true).
         WithRetryConnectionError(true))
-
-results, err := clusterClient.ExecWithOptions(ctx, *pipe, false, *opts)
+results, err := clusterClient.ExecWithOptions(ctx, *batch, false, *opts)
 ```
 
-Retry strategies are only supported for non-atomic batches.
+Retry strategies supported on non-atomic batches only. See [features-batching](features-batching.md) for hazards.
 
----
+## Platform constraints
 
-## Connection Defaults
-
-| Parameter | Default |
-|-----------|---------|
-| Request timeout | 250ms |
-| Connection timeout | 2000ms |
-| Inflight request limit | 1000 |
-| Connections per node | 2 (data + management) |
-| Topology check | 60s |
-| Protocol | RESP3 |
+- **CGO required.** Needs a C toolchain and glibc 2.17+. Alpine needs `musl-gcc` or `CGO_ENABLED=1` with the right toolchain.
+- **No static binary.** Go + GLIDE produces a dynamically linked executable.
+- **Cross-compilation** needs a matching C toolchain for the target (`CC=x86_64-linux-gnu-gcc` etc.).
+- **Proxies / connection inspectors**: GLIDE sends `CLIENT SETNAME`, `CLIENT SETINFO`, `INFO REPLICATION` during setup. Transparent proxies that strip these break topology detection.

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-advanced.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-advanced.md
@@ -1,21 +1,8 @@
-# Advanced Configuration
+# Advanced features (Go)
 
-Use when tuning connection timeouts, TLS certificates, TCP_NODELAY, cluster topology refresh, request routing, custom commands, or scan iteration.
+Use for routing, custom commands, scripting, Functions, OpenTelemetry, and advanced TLS / advanced config. Covers GLIDE-specific API with no direct go-redis equivalent.
 
-Packages: `github.com/valkey-io/valkey-glide/go/v2/config`, `github.com/valkey-io/valkey-glide/go/v2/options`, `github.com/valkey-io/valkey-glide/go/v2/constants`.
-
-## Contents
-
-- AdvancedClientConfiguration (Standalone) (line 20)
-- AdvancedClusterClientConfiguration (line 45)
-- TLS Configuration (line 64)
-- Request Routing (Cluster) (line 95)
-- Custom Commands (line 121)
-- Scan Iteration (line 142)
-- Server Management (line 178)
-- Lua Scripting (EVAL/EVALSHA) (line 188)
-- Functions API (Valkey 7.0+) (line 219)
-- OpenTelemetry Integration (line 249)
+Packages: `github.com/valkey-io/valkey-glide/go/v2/config`, `.../options`, `.../constants`, `.../models`.
 
 ## AdvancedClientConfiguration (Standalone)
 

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-batching.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-batching.md
@@ -1,40 +1,24 @@
-# Batching - Pipelines and Transactions
+# Batching - pipelines and transactions (Go)
 
-Use when you need to send multiple commands in a single round-trip for throughput or atomicity - pipelines for bulk operations, transactions for atomic multi-command blocks.
+Use when sending multiple commands in one round-trip. Covers what differs from go-redis's `rdb.Pipeline()` / `rdb.TxPipeline()`. Package: `github.com/valkey-io/valkey-glide/go/v2/pipeline`.
 
-Package: `github.com/valkey-io/valkey-glide/go/v2/pipeline`.
+## Divergence from go-redis
 
-## Contents
+| go-redis | GLIDE Go |
+|----------|---------|
+| `pipe := rdb.Pipeline(); pipe.Set(ctx, ...); pipe.Exec(ctx)` | `batch := pipeline.NewStandaloneBatch(false); batch.Set(...); client.Exec(ctx, *batch, true)` |
+| `rdb.TxPipeline()` for transactions | `pipeline.NewStandaloneBatch(true)` - same class, `isAtomic` flag in constructor |
+| Pipeline returns `[]redis.Cmder` - iterate calling `.Err()` and typed accessors | `[]any` with elements per command; errors inline if `raiseOnError=false`, or first error thrown if `true` |
+| Cluster pipelining: hand-split by slot | `NewClusterBatch(false)` auto-routes per-slot; multi-node batches dispatched automatically |
 
-- Core Concepts (line 21)
-- Batch Types (line 30)
-- Standalone Batch (line 39)
-- Cluster Batch (line 67)
-- Exec Signatures (line 85)
-- Error Handling (line 119)
-- Batch Options (line 141)
-- WATCH for Optimistic Locking (line 167)
-- Cluster Routing for Batches (line 187)
-- Retry Strategies (Non-Atomic Cluster Batches) (line 199)
-- Batch Command Set (line 206)
+Two batch types:
 
-## Core Concepts
+| Type | Client | Command set |
+|------|--------|-------------|
+| `pipeline.StandaloneBatch` | `Client` | Includes `Select(index)` for DB switching |
+| `pipeline.ClusterBatch` | `ClusterClient` | Includes sharded `Publish` |
 
-| Mode | Constructor | Protocol | Slot Constraint |
-|------|-------------|----------|-----------------|
-| Atomic (transaction) | `NewStandaloneBatch(true)` / `NewClusterBatch(true)` | MULTI/EXEC | All keys same hash slot in cluster |
-| Non-atomic (pipeline) | `NewStandaloneBatch(false)` / `NewClusterBatch(false)` | Pipelined | Can span multiple slots and nodes |
-
-Atomic batches guarantee no interleaving. Non-atomic batches maximize throughput across the cluster.
-
-## Batch Types
-
-| Type | Client | Usage |
-|------|--------|-------|
-| `pipeline.StandaloneBatch` | `Client` | Standalone server |
-| `pipeline.ClusterBatch` | `ClusterClient` | Cluster mode |
-
-Both extend `BaseBatch` which provides the full command set (Get, Set, Incr, XAdd, etc.).
+Both extend `BaseBatch` with full command set via fluent chaining.
 
 ## Standalone Batch
 
@@ -43,113 +27,47 @@ Both extend `BaseBatch` which provides the full command set (Get, Set, Incr, XAd
 ```go
 import "github.com/valkey-io/valkey-glide/go/v2/pipeline"
 
-tx := pipeline.NewStandaloneBatch(true)
-tx.Set("account:src", "100")
-tx.Set("account:dst", "0")
-tx.IncrBy("account:dst", 50)
-tx.DecrBy("account:src", 50)
-results, err := client.Exec(ctx, *tx, true) // raiseOnError=true
-// results: ["OK", "OK", 50, 50]
+batch := pipeline.NewStandaloneBatch(false)
+batch.Set("k1", "v1")
+batch.Incr("k1")
+batch.Get("k1")
+results, err := client.Exec(ctx, *batch, true)  // raiseOnError=true; first error -> err return
 ```
 
-### Non-Atomic Pipeline
+Cluster atomic batches require all keys in one hash slot (use `{tag}` hash tags). Cluster non-atomic batches split per-slot automatically.
+
+## `Exec` vs `ExecWithOptions`
 
 ```go
-pipe := pipeline.NewStandaloneBatch(false)
-pipe.Set("key1", "value1")
-pipe.Set("key2", "value2")
-pipe.Get("key1")
-pipe.Get("key2")
-results, err := client.Exec(ctx, *pipe, false)
-// results: ["OK", "OK", "value1", "value2"]
+// Signatures (both clients):
+client.Exec(ctx, batch, raiseOnError)                          // ([]any, error)
+client.ExecWithOptions(ctx, batch, raiseOnError, options)      // ([]any, error)
 ```
 
-## Cluster Batch
+Pass the batch by value via `*batch` to `Exec`. Options types:
+
+- `pipeline.StandaloneBatchOptions` - `WithTimeout(d)`
+- `pipeline.ClusterBatchOptions` - adds `WithRoute(r)` and `WithRetryStrategy(s)`
+
+Returns `nil, nil` when an atomic batch fails due to a WATCH conflict.
+
+## `raiseOnError` semantics
+
+- `true` - first inline error is returned as the `err`.
+- `false` - errors embedded inline as `error` values in the `[]any` slice:
 
 ```go
-// Atomic: all keys must hash to same slot
-tx := pipeline.NewClusterBatch(true)
-tx.Set("{user}:name", "Alice")
-tx.Set("{user}:email", "alice@example.com")
-tx.Get("{user}:name")
-results, err := clusterClient.Exec(ctx, *tx, true)
-
-// Non-atomic: commands auto-routed across nodes
-pipe := pipeline.NewClusterBatch(false)
-pipe.Set("user:1:name", "Alice")
-pipe.Set("user:2:name", "Bob")
-pipe.Get("user:1:name")
-results, err := clusterClient.Exec(ctx, *pipe, false)
-```
-
-## Exec Signatures
-
-```go
-// Standalone
-func (client *Client) Exec(
-    ctx context.Context,
-    batch pipeline.StandaloneBatch,
-    raiseOnError bool,
-) ([]any, error)
-
-func (client *Client) ExecWithOptions(
-    ctx context.Context,
-    batch pipeline.StandaloneBatch,
-    raiseOnError bool,
-    options pipeline.StandaloneBatchOptions,
-) ([]any, error)
-
-// Cluster
-func (client *ClusterClient) Exec(
-    ctx context.Context,
-    batch pipeline.ClusterBatch,
-    raiseOnError bool,
-) ([]any, error)
-
-func (client *ClusterClient) ExecWithOptions(
-    ctx context.Context,
-    batch pipeline.ClusterBatch,
-    raiseOnError bool,
-    options pipeline.ClusterBatchOptions,
-) ([]any, error)
-```
-
-Pass the batch by value (`*tx` not `tx`) to `Exec`.
-
-## Error Handling
-
-The `raiseOnError` parameter controls batch error behavior:
-
-| Value | Behavior |
-|-------|----------|
-| `true` | First error in results returned as the `error` return value |
-| `false` | Errors embedded inline as `error` values in the `[]any` slice |
-
-```go
-results, err := client.Exec(ctx, *pipe, false)
+results, err := client.Exec(ctx, *batch, false)
 for i, item := range results {
     if e := glide.IsError(item); e != nil {
-        fmt.Printf("Command %d failed: %v\n", i, e)
-    } else {
-        fmt.Printf("Command %d: %v\n", i, item)
+        // handle
     }
 }
 ```
 
-If an atomic batch fails due to a WATCH conflict, `Exec` returns `nil, nil` (nil results, no error).
+`BatchError` wraps multiple per-command errors when `raiseOnError=true` and several commands fail prep-time. See [error-handling](best-practices-error-handling.md).
 
-## Batch Options
-
-### StandaloneBatchOptions
-
-```go
-opts := pipeline.NewStandaloneBatchOptions().
-    WithTimeout(5 * time.Second)
-
-results, err := client.ExecWithOptions(ctx, *tx, true, *opts)
-```
-
-### ClusterBatchOptions
+## Cluster retry strategy (non-atomic only)
 
 ```go
 opts := pipeline.NewClusterBatchOptions().
@@ -157,54 +75,27 @@ opts := pipeline.NewClusterBatchOptions().
     WithRoute(config.RandomRoute).
     WithRetryStrategy(*pipeline.NewClusterBatchRetryStrategy().
         WithRetryServerError(true).
-        WithRetryConnectionError(true))
-
-results, err := clusterClient.ExecWithOptions(ctx, *pipe, false, *opts)
+        WithRetryConnectionError(false))
 ```
 
-Retry strategy is not supported for atomic batches - `ExecWithOptions` returns an error if you set `RetryStrategy` on an atomic `ClusterBatch`.
+Hazards:
+- `RetryServerError` can reorder commands within a slot.
+- `RetryConnectionError` can cause duplicate executions - the server may have already processed before the connection died.
+- Not supported on atomic batches; `ExecWithOptions` errors if you try.
 
-## WATCH for Optimistic Locking
+MOVED / ASK redirects are always handled automatically - non-atomic redirects only the affected commands; atomic redirects the entire transaction.
 
-Standalone-only. Monitor keys for changes before executing an atomic batch:
+## WATCH (standalone only)
 
 ```go
-_, err := client.Watch(ctx, []string{"balance"})
-// Read current value
-val, _ := client.Get(ctx, "balance")
-
+client.Watch(ctx, []string{"balance"})
+// read current, decide new value...
 tx := pipeline.NewStandaloneBatch(true)
-tx.Set("balance", "new-value")
+tx.Set("balance", "new")
 results, err := client.Exec(ctx, *tx, true)
-if results == nil {
-    // WATCH key was modified by another client, retry
-}
+if results == nil { /* WATCH conflict - retry */ }
 
-// Discard watches without executing
-_, err = client.Unwatch(ctx)
+client.Unwatch(ctx)  // discard without executing
 ```
 
-## Cluster Routing for Batches
-
-Non-atomic cluster batches:
-1. GLIDE computes hash slots for each key-based command
-2. Groups commands by target node into sub-pipelines
-3. Dispatches sub-pipelines in parallel
-4. Reassembles responses in original command order
-
-Atomic cluster batches route to the slot owner of the first key. If no key is found, sent to a random node.
-
-Redirection errors (MOVED, ASK) are always handled automatically.
-
-## Retry Strategies (Non-Atomic Cluster Batches)
-
-| Field | Behavior | Caveat |
-|-------|----------|--------|
-| `RetryServerError` | Retry on TRYAGAIN errors | May cause out-of-order execution |
-| `RetryConnectionError` | Retry batch on connection failure | May cause duplicate executions |
-
-## Batch Command Set
-
-`BaseBatch` exposes the same commands as the client: `Get`, `Set`, `SetWithOptions`, `Incr`, `Decr`, `HSet`, `HGet`, `LPush`, `RPush`, `SAdd`, `ZAdd`, `XAdd`, `XRead`, and all other data-type commands. Each returns `*T` (the batch itself) for method chaining.
-
-Standalone-only batch commands: `Select(index)`. See also [Streams](features-streams.md) and [Connection](features-connection.md) for WATCH/UNWATCH.
+WATCH is a connection-state command - run it on a dedicated client to avoid leaking state across goroutines on the shared multiplexer.

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-connection.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-connection.md
@@ -1,22 +1,21 @@
-# Connection Management
+# Connection and configuration (Go)
 
-Use when creating, configuring, or managing Valkey GLIDE Go client connections - standalone or cluster, TLS, authentication, reconnection, password rotation, lazy connect, or database selection.
+Use when creating clients, configuring auth, TLS, timeouts, reconnection, read strategy, or closing connections. Covers what differs from `go-redis` - basic `redis.NewClient(&redis.Options{...})` patterns are assumed knowable from training.
 
-## Contents
+## Divergence from go-redis
 
-- Client Types (line 21)
-- Standalone Connection (line 30)
-- Cluster Connection (line 56)
-- Configuration Methods (line 73)
-- Authentication (line 95)
-- Password Rotation (line 115)
-- Reconnection Strategy (line 135)
-- ReadFrom Strategies (line 151)
-- Lazy Connect (line 162)
-- Database Selection (line 174)
-- Connection Info Commands (line 187)
-- Error Types (line 198)
-- Statistics and Close (line 219)
+| go-redis | GLIDE Go |
+|----------|---------|
+| `redis.NewClient(&redis.Options{Addr: "host:6379"})` - single call, sync | `glide.NewClient(cfg)` returning `(*Client, error)` - sync but error-returning |
+| `redis.NewClusterClient(&redis.ClusterOptions{})` | `glide.NewClusterClient(cfg)` - distinct type |
+| Connection pool with `PoolSize: 10` | Multiplexer - single multiplexed connection per node, no pool knob |
+| `rdb.Get(ctx, key).Result() -> (string, error)` with `redis.Nil` sentinel | `client.Get(ctx, key) -> (Result[string], error)`; check `.IsNil()` then `.Value()` - no sentinel error |
+| `rdb.OnConnect` hook, retries via `MaxRetries` | `WithReconnectStrategy(NewBackoffStrategy(...))`; retries are INFINITE, `numOfRetries` caps backoff sequence length only |
+| `rdb.Close() error` | `client.Close()` - returns nothing; safe to call multiple times |
+| IAM auth is not supported | GLIDE-only via `config.NewIamAuthConfig(clusterName, ElastiCache, region)` + `NewServerCredentialsWithIam` |
+| Password via `Options.Password` string | `config.NewServerCredentials(user, pw)` or `NewServerCredentialsWithDefaultUsername(pw)` struct |
+| `DialTimeout`, `ReadTimeout`, `WriteTimeout` separate | Single `WithRequestTimeout` + `WithConnectionTimeout` via advanced config |
+| `ClusterOptions.RouteByLatency` / `RouteRandomly` | `WithReadFrom(config.PreferReplica / AzAffinity / ...)` |
 
 ## Client Types
 
@@ -195,27 +194,24 @@ info, err := client.Info(ctx)                 // server info string
 count, err := client.DBSize(ctx)              // key count in current DB
 ```
 
-## Error Types
+## Error types (quick reference - see [error-handling](best-practices-error-handling.md) for the gotchas)
+
+Go's error model is FLAT - independent structs, no base class. Unlike Python's `except RequestError:` or Node's `ValkeyError` subclass tree, each error is its own type:
 
 | Error | When |
 |-------|------|
-| `*ConnectionError` | Connection lost (auto-reconnects) |
-| `*TimeoutError` | Request exceeded timeout |
+| `*ConnectionError` | Connection issue at setup time |
+| `*TimeoutError` | Auto-mapped from core |
+| `*DisconnectError` | **Most "connection lost" errors surface as this, not `ConnectionError`** - auto-mapped from core's `Disconnect` |
+| `*ExecAbortError` | Transaction aborted (WATCH key changed, EXEC error) - auto-mapped |
 | `*ClosingError` | Client closed, no longer usable |
 | `*ConfigurationError` | Invalid client configuration |
-| `*DisconnectError` | Connection problem between client and server |
-| `*ExecAbortError` | Transaction aborted (WATCH key changed) |
+| `*BatchError` | Wrapper for multiple errors returned from a Batch |
 
-```go
-var connErr *glide.ConnectionError
-var timeoutErr *glide.TimeoutError
-if errors.As(err, &connErr) {
-    // Client is reconnecting automatically
-} else if errors.As(err, &timeoutErr) {
-    // Increase WithRequestTimeout or investigate server
-}
-```
+Only `ExecAbort`, `Timeout`, and `Disconnect` are auto-typed by `GoError()` in `go/errors.go`. Most other errors from the Rust core come through as generic `errors.New(msg)` - not typed. So `errors.As(err, &connErr)` will miss most operational errors.
 
 ## Statistics and Close
 
-`client.GetStatistics()` returns `map[string]uint64` with keys: `total_connections`, `total_clients`, `subscription_out_of_sync_count`, `subscription_last_sync_timestamp`, plus compression counters. `Close()` is safe to call multiple times - it drains pending requests with `ClosingError`.
+`client.GetStatistics() map[string]uint64` - typed uint64 values (Python/Node return stringified values). Keys: `total_connections`, `total_clients`, `total_values_compressed`, `total_values_decompressed`, `total_original_bytes`, `total_bytes_compressed`, `total_bytes_decompressed`, `compression_skipped_count`, `subscription_out_of_sync_count`, `subscription_last_sync_timestamp`.
+
+`Close()` returns nothing. Safe to call multiple times. Pending requests get `ClosingError`.

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-pubsub.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-pubsub.md
@@ -10,7 +10,7 @@ Use when working with publish/subscribe. Covers what differs from `go-redis`'s `
 | `msg, err := pubsub.ReceiveMessage(ctx)` loop | Callback on the subscription config OR `client.GetPubSubMessage(ctx)` / `client.TryGetPubSubMessage()` - cannot mix |
 | `rdb.Publish(ctx, channel, message)` | `client.Publish(ctx, channel, message)` - **SAME ORDER** (Go matches the Redis convention; Python/Node reverse it, Go does NOT) |
 | Manual reconnect + resubscribe in your loop | Automatic via synchronizer; `client.GetSubscriptions(ctx)` exposes desired vs actual state |
-| `ClusterClient.Subscribe` does sharded differently | `ClusterClient` with `ShardedClusterChannelMode` + `Publish(ctx, ch, msg, sharded bool)` 4th-arg flag |
+| `ClusterClient.Subscribe` does sharded differently | Sharded subscriptions: `ShardedClusterChannelMode` in config, `SSubscribe` / `SSubscribeLazy` for runtime (`ClusterClient` only); sharded publishing: `Publish(ctx, channel, message, sharded bool)` 4th-arg flag |
 
 Static subscriptions require RESP3 (default). Using RESP2 causes client creation to fail with `ConfigurationError`.
 

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-pubsub.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-pubsub.md
@@ -1,21 +1,18 @@
-# Pub/Sub
+# Pub/Sub (Go)
 
-Use when you need real-time message broadcasting between Go clients - chat, notifications, event distribution, or live data feeds. For durable message processing with consumer groups and replay, see [Streams](features-streams.md) instead.
+Use when working with publish/subscribe. Covers what differs from `go-redis`'s `rdb.Subscribe(ctx, channels...)` + `pubsub.ReceiveMessage(ctx)` pattern - the subscription model diverges significantly.
 
-GLIDE supports Valkey's publish/subscribe messaging with three subscription modes, automatic reconnection with resubscription, and a synchronizer that continuously reconciles desired vs actual subscription state. Sharded subscriptions require Valkey 7.0+. Dynamic subscribe/unsubscribe requires GLIDE 2.3+.
+## Divergence from go-redis
 
-## Contents
+| go-redis | GLIDE Go |
+|----------|---------|
+| `pubsub := rdb.Subscribe(ctx, "ch1", "ch2")` runtime | Either static config (`WithSubscriptionConfig`) OR dynamic `client.Subscribe(ctx, ...)` (GLIDE 2.3+) |
+| `msg, err := pubsub.ReceiveMessage(ctx)` loop | Callback on the subscription config OR `client.GetPubSubMessage(ctx)` / `client.TryGetPubSubMessage()` - cannot mix |
+| `rdb.Publish(ctx, channel, message)` | `client.Publish(ctx, channel, message)` - **SAME ORDER** (Go matches the Redis convention; Python/Node reverse it, Go does NOT) |
+| Manual reconnect + resubscribe in your loop | Automatic via synchronizer; `client.GetSubscriptions(ctx)` exposes desired vs actual state |
+| `ClusterClient.Subscribe` does sharded differently | `ClusterClient` with `ShardedClusterChannelMode` + `Publish(ctx, ch, msg, sharded bool)` 4th-arg flag |
 
-- Subscription Modes (line 20)
-- Configuration-Time Subscriptions (Immutable) (line 30)
-- Dynamic Subscriptions (GLIDE 2.3+) (line 80)
-- Receiving Messages (line 124)
-- PubSubMessage Type (line 181)
-- Publishing (line 191)
-- Dedicated Subscriber Client (line 202)
-- Introspection (line 206)
-- Subscription State (line 230)
-- Reconciliation and Reconnection (line 243)
+Static subscriptions require RESP3 (default). Using RESP2 causes client creation to fail with `ConfigurationError`.
 
 ## Subscription Modes
 
@@ -199,9 +196,9 @@ count, err := clusterClient.Publish(ctx, "news", "update", false)
 count, err = clusterClient.Publish(ctx, "orders", "new-order", true) // sharded
 ```
 
-## Dedicated Subscriber Client
+## Dedicated subscriber client
 
-Always use separate clients for subscribing and regular commands - PubSub clients enter a special mode where most commands are unavailable.
+Dedicated subscriber client is RECOMMENDED for high-volume subscriptions to avoid head-of-line effects with regular command traffic, but NOT required - GLIDE multiplexes pubsub alongside commands on the core side. The "enters special mode" framing from go-redis / traditional Redis clients does not strictly apply.
 
 ## Introspection
 

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-streams.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-streams.md
@@ -10,12 +10,12 @@ Packages: `github.com/valkey-io/valkey-glide/go/v2/options`, `.../models`.
 |----------|---------|
 | `rdb.XAdd(ctx, &redis.XAddArgs{Stream, ID, Values, MaxLen, Approx})` | `client.XAdd(ctx, stream, []models.FieldValue{{Field, Value}, ...})` or `client.XAddWithOptions(ctx, stream, values, *options.NewXAddOptions().SetId("1-0").SetTrimOptions(...))` |
 | `XAddArgs.MaxLen, Approx` | `options.NewXTrimOptionsWithMaxLen(n).SetNearlyExactTrimming()` / `options.NewXTrimOptionsWithMinID(id)` |
-| `start="-"`, `end="+"` string bounds | Typed boundaries via `options.InfBound...` constants |
+| `start="-"`, `end="+"` string bounds | Typed boundaries via `options.NewInfiniteStreamBoundary(constants.NegativeInfinity / PositiveInfinity)`; bounded via `options.NewStreamBoundary(id, isInclusive)` |
 | `rdb.XRead(ctx, &redis.XReadArgs{Streams: [...], Block: 5*time.Second, Count: 10})` | `client.XReadWithOptions(ctx, map[string]string{...}, *options.NewXReadOptions().SetCount(10).SetBlock(5*time.Second))` |
 | `rdb.XClaim(ctx, &redis.XClaimArgs{}, justId bool)` | Separate methods: `XClaim` vs `XClaimJustId`, `XAutoClaim` vs `XAutoClaimJustId` |
 | `rdb.XPending(...)` returns overloaded struct | `XPending` for summary, `XPendingWithOptions` for detail |
 | Typed response structs from go-redis | `models.StreamResponse`, `models.XAutoClaimResponse { NextEntry, ClaimedEntries, DeletedMessages }`, `models.FieldValue` |
-| Read returns `(result, redis.Nil err)` for no entries | `XReadWithOptions` returns `map[string]models.StreamResponse`; check for empty map or `Result[T].IsNil()` on fields |
+| Read returns `(result, redis.Nil err)` for no entries | `XRead` / `XReadWithOptions` return `map[string]models.StreamResponse` directly (not wrapped in `Result[T]`) - check for empty map or empty entries slice |
 
 ## Key typed builders
 

--- a/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-streams.md
+++ b/skills/valkey-glide-go/skills/valkey-glide-go/reference/features-streams.md
@@ -1,22 +1,53 @@
-# Valkey Streams
+# Streams (Go)
 
-Use when you need durable, ordered message processing with consumer groups, replay capability, or event sourcing in Go. For fire-and-forget broadcast messaging, see [Pub/Sub](features-pubsub.md). Stream commands can be included in [batches](features-batching.md).
+Use when working with Valkey streams. Command names match Valkey's XADD/XREAD set and are similar to go-redis - the divergence is in option builders, typed range bounds, `Result[T]` returns, and a couple of API splits.
 
-Packages: `github.com/valkey-io/valkey-glide/go/v2/options`, `github.com/valkey-io/valkey-glide/go/v2/models`.
+Packages: `github.com/valkey-io/valkey-glide/go/v2/options`, `.../models`.
 
-## Contents
+## Divergence from go-redis
 
-- Adding Entries (line 21)
-- Reading Entries (line 49)
-- Range Queries (line 73)
-- Consumer Groups (line 87)
-- Pending Entries (line 126)
-- Claiming Entries (line 143)
-- Group Management (line 172)
-- Stream Metadata (line 184)
-- Introspection (line 207)
-- Blocking Commands (line 219)
-- Cluster Mode (line 223)
+| go-redis | GLIDE Go |
+|----------|---------|
+| `rdb.XAdd(ctx, &redis.XAddArgs{Stream, ID, Values, MaxLen, Approx})` | `client.XAdd(ctx, stream, []models.FieldValue{{Field, Value}, ...})` or `client.XAddWithOptions(ctx, stream, values, *options.NewXAddOptions().SetId("1-0").SetTrimOptions(...))` |
+| `XAddArgs.MaxLen, Approx` | `options.NewXTrimOptionsWithMaxLen(n).SetNearlyExactTrimming()` / `options.NewXTrimOptionsWithMinID(id)` |
+| `start="-"`, `end="+"` string bounds | Typed boundaries via `options.InfBound...` constants |
+| `rdb.XRead(ctx, &redis.XReadArgs{Streams: [...], Block: 5*time.Second, Count: 10})` | `client.XReadWithOptions(ctx, map[string]string{...}, *options.NewXReadOptions().SetCount(10).SetBlock(5*time.Second))` |
+| `rdb.XClaim(ctx, &redis.XClaimArgs{}, justId bool)` | Separate methods: `XClaim` vs `XClaimJustId`, `XAutoClaim` vs `XAutoClaimJustId` |
+| `rdb.XPending(...)` returns overloaded struct | `XPending` for summary, `XPendingWithOptions` for detail |
+| Typed response structs from go-redis | `models.StreamResponse`, `models.XAutoClaimResponse { NextEntry, ClaimedEntries, DeletedMessages }`, `models.FieldValue` |
+| Read returns `(result, redis.Nil err)` for no entries | `XReadWithOptions` returns `map[string]models.StreamResponse`; check for empty map or `Result[T].IsNil()` on fields |
+
+## Key typed builders
+
+| Builder | Replaces |
+|---------|----------|
+| `options.NewXAddOptions()` with `SetId`, `SetDontMakeNewStream`, `SetTrimOptions` | XAdd kwargs (id, nomkstream, maxlen, minid) |
+| `options.NewXReadOptions()` with `SetCount`, `SetBlock` | XRead kwargs |
+| `options.NewXReadGroupOptions()` with `SetCount`, `SetBlock`, `SetNoAck` | XReadGroup kwargs |
+| `options.NewXGroupCreateOptions()` with `MakeStream`, `EntriesRead` | XGroup CREATE kwargs |
+| `options.NewXTrimOptionsWithMaxLen(n)` / `options.NewXTrimOptionsWithMinID(id)` with `SetExactTrimming` / `SetNearlyExactTrimming` / `SetLimit` | MAXLEN/MINID trim args |
+| `options.NewXClaimOptions()` with `SetIdle`, `SetTime`, `SetRetryCount`, `SetForce` | XCLAIM kwargs |
+| `options.NewXPendingOptions(start, end, count)` with `SetConsumer`, `SetMinIdleTime` | XPENDING filter args |
+
+## Split xclaim / xautoclaim
+
+`XClaim` returns `(map[string][]models.FieldValue, error)`; `XClaimJustId` returns `([]string, error)`. Same split for `XAutoClaim` / `XAutoClaimJustId`. Matches Python/Node split; replaces go-redis's `justid bool` flag.
+
+`XAutoClaim*` (Valkey 6.2+) returns `models.XAutoClaimResponse` with `NextEntry`, `ClaimedEntries`, `DeletedMessages`.
+
+## Cluster: multi-stream reads must share a slot
+
+`XRead` / `XReadGroup` over multiple stream keys goes to a single node - all keys must hash to the same slot. Use hash tags:
+
+```go
+client.XAdd(ctx, "{app}.events", []models.FieldValue{{Field: "type", Value: "click"}})
+client.XAdd(ctx, "{app}.logs",   []models.FieldValue{{Field: "level", Value: "info"}})
+client.XRead(ctx, map[string]string{"{app}.events": "0", "{app}.logs": "0"})
+```
+
+## Blocking reads need a dedicated client
+
+`XReadWithOptions` / `XReadGroupWithOptions` with `SetBlock(...)` hold the multiplexed connection. Use a dedicated client so other goroutines are not stalled. Same rule as `BLPop` - see [performance](best-practices-performance.md).
 
 ## Adding Entries
 


### PR DESCRIPTION
## Summary

Two-pass validation of `valkey-glide-go` and `migrate-go-redis` against Valkey GLIDE `v2.3.1` (commit `9601a7695`). Applies the divergence-only skill-writing rule.

## Size reduction

- `valkey-glide-go`: 1600 -> 1357 lines (15% cut), plugin 2.0.0 -> 2.1.0
- `migrate-go-redis`: 383 -> 388 lines (refocused around Go-specific divergences; minor growth), plugin 1.0.0 -> 1.1.0

Less aggressive cut than Python / Node because the Go skill was already tighter. The value is in the correctness fixes and the actual Go-specific divergence framing.

## Pass-2 correctness fixes (the important stuff)

### 1. publish() argument order is NOT reversed in Go

**Big correction.** Python and Node GLIDE reverse `publish(channel, message)` to `publish(message, channel)`. Go does NOT. Source: `go/glide_client.go:933` and `go/glide_cluster_client.go:2054`:

```go
func (client *Client) Publish(ctx context.Context, channel string, message string) (int64, error)
func (client *ClusterClient) Publish(ctx context.Context, channel string, message string, sharded bool) (int64, error)
```

Updated SKILL.md grep hazards to call this out explicitly ("unlike Python/Node, Go matches the Redis convention"). Updated memory/valkey_fabrications_caught.md: reversed-publish is Python + Node specific, NOT GLIDE-wide.

### 2. GetStatistics returns map[string]uint64

Go returns typed uint64 values; Python/Node return strings. Language-specific divergence worth noting.

### 3. Flat error model - no hierarchy

Go has no abstract base class (no `ValkeyError` / `GlideError` equivalent). Each error is its own independent struct. Python's `except RequestError:` / Node's `instanceof RequestError` pattern does NOT translate.

### 4. Only 3 errors auto-typed

`GoError()` in `go/errors.go` auto-maps ONLY `ExecAbort`, `Timeout`, `Disconnect`. Everything else falls through to `errors.New(msg)`. So most "connection lost" scenarios arrive as `*DisconnectError` or plain strings, NOT `*ConnectionError`. Subtle but important for retry logic.

### 5. DisconnectError and BatchError are Go-only types

Not present in Python/Node.

### 6. ResetConnectionPassword is a separate Go method

Python uses `update_connection_password(None)`; Go splits into `UpdateConnectionPassword(ctx, pw, immediateAuth)` and `ResetConnectionPassword(ctx)`.

### 7. migrate-go-redis: NewExpiryEx was wrong

My initial rewrite had `NewExpiryEx(d)`. Actual Go constructors are `NewExpiryIn(d)` for duration, `NewExpiryAt(t)` for `time.Time`, `NewExpiryKeepExisting()` for KEEPTTL. Source: `go/options/command_options.go:171-197`. Fixed.

### 8. Dynamic pubsub method names wrong in old skill

`migrate-go-redis/advanced-patterns.md` claimed `client.SubscribeBlocking(ctx, channels, 5000)` for exact channels. That method doesn't exist. Actual v2.3.1 API: `Subscribe(ctx, channels, timeoutMs)` is blocking (with `timeoutMs=0` meaning infinite), `SubscribeLazy(ctx, channels)` is non-blocking. (`PSubscribeBlocking` exists as a legacy alias for patterns only.) Rewrote the dynamic-pubsub section.

### 9. inflightRequestsLimit config is NOT exposed in Go at v2.3.1

Python and Node expose it; Go doesn't. The 1000 core cap still applies. Removed misleading suggestion that users can tune it in Go.

### 10. AzAffinityReplicaAndPrimary

Note `Replica` is SINGULAR in the Go user-facing constant (matches protobuf `AZAffinityReplicasAndPrimary` internally despite the UI being singular).

### 11. Removed fabricated "2 connections per node (data + management)"

Same as Python/Node pass-2 findings. Only test-code comment mentions this; no user-facing concept.

## Pass-1 editorial changes

- SKILL.md rewritten with Go-specific grep hazards (Result[T], flat error model, publish NOT reversed, GetStatistics uint64, CGO required, context.Context required)
- Error-handling file rewritten around the flat error model and auto-mapping caveat
- Performance file: full blocking-command list, inflight cap not configurable in Go, CGO overhead explicit
- Production file: CGO / glibc / cross-compile constraints, removed fabricated defaults
- Streams file: divergence-from-go-redis table; typed option builders as the key divergence
- Batching file: condensed to divergence + Exec vs ExecWithOptions + raiseOnError semantics + cluster retry strategy + WATCH
- PubSub file: divergence-from-go-redis table; corrected "special mode" claim
- Connection file: divergence table up top, error types as reference (see error-handling for the real gotchas)
- migrate-go-redis SKILL.md rewritten with comprehensive divergence table (including `Publish` SAME ORDER as a positive call-out), config translation, gotcha list

## Verified against v2.3.1 source

- `config.ElastiCache` / `config.MemoryDB` enum values (`go/config/config.go:43-45`)
- `config.AzAffinity` / `config.AzAffinityReplicaAndPrimary` (note singular)
- `UpdateConnectionPassword(ctx, password string, immediateAuth bool)` / `ResetConnectionPassword(ctx)` / `RefreshIamToken(ctx)` on baseClient
- `Result[T]` with `IsNil()` / `Value()` (`go/models/response_types.go:52-58`)
- `Publish(ctx, channel, message, [sharded])` - channel-first positional
- `GetStatistics() map[string]uint64`
- Dynamic pubsub: `Subscribe`/`SubscribeLazy`, `PSubscribe`/`PSubscribeLazy`, `SSubscribe`/`SSubscribeLazy` (cluster), `Unsubscribe`/`UnsubscribeLazy`, `PUnsubscribe`/`PUnsubscribeLazy`, plus `PSubscribeBlocking` legacy alias
- `GetSubscriptions(ctx)` returning `*models.PubSubState` with `DesiredSubscriptions` / `ActualSubscriptions`
- `GetQueue()` returning `*PubSubMessageQueue` with `Pop()` / `WaitForMessage() <-chan`
- `pipeline.NewStandaloneBatch(isAtomic)` / `pipeline.NewClusterBatch(isAtomic)`, `ClusterBatchOptions` with `WithRetryStrategy`, `NewClusterBatchRetryStrategy().WithRetryServerError()` / `WithRetryConnectionError()`
- Error types: `ConnectionError`, `TimeoutError`, `DisconnectError`, `ExecAbortError`, `ClosingError`, `ConfigurationError`, `BatchError` (all in `go/errors.go`); `GoError()` auto-maps only 3 from C types
- `options.NewExpiryIn`/`At`/`KeepExisting` (not `Ex`), `options.NewSetOptions().SetExpiry(...)`
- `options.NewScript(code)` with `.Close()`, `InvokeScript` / `InvokeScriptWithOptions` / `InvokeScriptWithRoute`
- Functions API: `FCall`, `FCallReadOnly`, `FCallWithKeysAndArgs`, `FCallReadOnlyWithKeysAndArgs`, `FCallWithRoute`, `FunctionLoad/Delete/List/Stats/Flush/FlushSync/FlushAsync/Dump/Restore/RestoreWithPolicy/Kill`
- `AppendPolicy` constant in `constants` package
- OpenTelemetry: `glide.GetOtelInstance().Init(cfg)`, `CreateSpan`, `EndSpan`, `WithSpan(ctx, spanPtr)`

## Test plan

- [x] All 8 Go reference files read end-to-end
- [x] Both migration files read end-to-end
- [x] Pass 1: general source verification
- [x] Pass 2: caught 3 real bugs pass 1 missed - reversed-publish doesn't apply in Go (memory-level correction), `NewExpiryEx` typo, `SubscribeBlocking` method that doesn't exist for exact channels
- [x] Cross-file consistency: error types, pubsub API, blocking command list
- [ ] Ecosystem reviewers (Gemini)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates but they affect migration/operational guidance; incorrect API notes could mislead implementers, though no runtime code is changed.
> 
> **Overview**
> Refocuses the `migrate-go-redis` and `valkey-glide-go` skills around **Go-specific divergences** from go-redis, updating examples and guidance for `Result[T]` nil handling (no `redis.Nil`), slice-based multi-key args, typed `SetWithOptions`/expiry constructors, batch/pipeline semantics, and the Go multiplexer model (one client per process + dedicated clients for blocking/WATCH/high-volume PubSub).
> 
> Corrects/clarifies several API and behavior gotchas in the docs, notably that `Publish(ctx, channel, message)` argument order is **unchanged** in Go, Go’s **flat** error model and limited auto-typing (`GoError()`), `GetStatistics()` returning `map[string]uint64`, `inflightRequestsLimit` not being configurable in Go, and tightened production/CGO platform constraints; bumps skill/plugin versions (`migrate-go-redis` `1.0.0→1.1.0`, `valkey-glide-go` `2.0.0→2.1.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a505cdbe42a597eec348a7c561b91a50482f1d16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->