### PR TITLE
csharp + migrate-stackexchange: validate against Valkey.Glide v1.0.0

### DIFF
--- a/skills/migrate-stackexchange/.claude-plugin/plugin.json
+++ b/skills/migrate-stackexchange/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-stackexchange",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use when migrating C#/.NET from StackExchange.Redis to Valkey GLIDE. Covers API mapping, async/await Task, no IDatabase layer, PubSub, Batch API (.NET 8.0+, preview). Not for greenfield C# apps - use valkey-glide-csharp instead.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/migrate-stackexchange/skills/migrate-stackexchange/SKILL.md
+++ b/skills/migrate-stackexchange/skills/migrate-stackexchange/SKILL.md
@@ -14,10 +14,10 @@ Use when moving an existing StackExchange.Redis app to GLIDE. Assumes you alread
 | Area | StackExchange.Redis | GLIDE C# |
 |------|---------------------|---------|
 | Entry point | `ConnectionMultiplexer.Connect(connString)` | Two options: (1) `ConnectionMultiplexer.ConnectAsync(connString)` - SE.Redis-compat facade, OR (2) `GlideClient.CreateClient(config)` / `GlideClusterClient.CreateClient(config)` with fluent builder |
-| Connect | Synchronous | **Async-only** - no sync Connect |
+| Connect | `Connect(connString)` or `ConnectAsync(...)` | Facade has both `Connect(connString)` and `ConnectAsync(...)`; GLIDE-native `CreateClient(config)` is async-only |
 | Client type | Auto-detects cluster vs standalone | GLIDE-native path requires explicit `GlideClient` vs `GlideClusterClient`. Facade path auto-detects like SE.Redis |
 | Key / value types | `RedisKey`, `RedisValue` | **`ValkeyKey`, `ValkeyValue`** - drop-in equivalents with the same implicit conversions |
-| Access pattern | `IDatabase db = mux.GetDatabase()` then `db.StringSetAsync(...)` | GLIDE-native: methods on `client` directly; facade: `mux.Database` works the same |
+| Access pattern | `IDatabase db = mux.GetDatabase()` then `db.StringSetAsync(...)` | GLIDE-native: methods on `client` directly; facade: `mux.GetDatabase()` works the same |
 | `CommandFlags.FireAndForget` | Supported | **NOT supported** - all commands return `Task<T>`. Use batching for throughput |
 | Configuration | `ConfigurationOptions` or connection string | `StandaloneClientConfigurationBuilder` / `ClusterClientConfigurationBuilder` fluent builder (or connection string through the facade) |
 | `AbortOnConnectFail` | Option | No equivalent - GLIDE retries infinitely; cap backoff sequence with `RetryStrategy` |
@@ -25,7 +25,7 @@ Use when moving an existing StackExchange.Redis app to GLIDE. Assumes you alread
 | Events | `OnConnectionFailed`, `OnConnectionRestored`, etc. | No EventEmitter-style events - errors surface per-Task; track state via `client.GetStatistics()` |
 | Transactions | `ITransaction tx = db.CreateTransaction(); tx.AddCondition(...)` | `Batch(isAtomic: true)` + `client.ExecAsync(batch, raiseOnError)` |
 | Pipelines | `db.Batch()` + chained awaits | `Batch(isAtomic: false)` - same class, flag-selected |
-| `RedisSubscriber` | `var sub = mux.GetSubscriber(); sub.Subscribe(ch, (ch, msg) => ...)` | Static config on builder OR dynamic `client.SubscribeAsync(ch, timeout)` (2.3+); callback OR polling |
+| `RedisSubscriber` | `var sub = mux.GetSubscriber(); sub.Subscribe(ch, (ch, msg) => ...)` | Static config on builder OR dynamic `client.SubscribeAsync(ch, timeout)`; callback OR polling |
 | `sub.Publish(channel, message)` | Channel first | `client.PublishAsync(channel, message)` - **SAME ORDER** (Python/Node GLIDE reverse it; C# matches SE.Redis) |
 | Error types | `RedisException`, `RedisConnectionException`, `RedisTimeoutException`, etc. | Nested in static `Errors` class: `Errors.GlideException` (abstract base), `Errors.RequestException`, `Errors.ValkeyServerException`, `Errors.ExecAbortException`, `Errors.TimeoutException`, `Errors.ConnectionException`, `Errors.ConfigurationError` (note inconsistent "Error" suffix on the last one) |
 | `RedisResult` | Dynamic typed result | Methods return typed `Task<ValkeyValue>`, `Task<bool>`, `Task<long>`, etc. |
@@ -42,7 +42,7 @@ IDatabase db = mux.GetDatabase();
 // GLIDE - facade path (minimal change):
 var mux = await ConnectionMultiplexer.ConnectAsync(
     "localhost:6379,password=pw,ssl=true");
-IDatabase db = mux.Database;
+IDatabase db = mux.GetDatabase();  // standard IConnectionMultiplexer method
 
 // GLIDE - native builder path (more control):
 var config = new StandaloneClientConfigurationBuilder()
@@ -89,7 +89,7 @@ Two routes:
 ## Gotchas (the short list)
 
 1. **GA at v1.0.0** - not preview. Older docs claiming preview status are outdated.
-2. **`ConnectionMultiplexer.Connect` is async-only** - `ConnectAsync`. No synchronous version.
+2. **`ConnectionMultiplexer` facade has both** `Connect(connString)` and `ConnectAsync(...)` - same as SE.Redis. GLIDE-native `GlideClient.CreateClient(config)` is async-only.
 3. **`ValkeyKey` / `ValkeyValue`** (not `RedisKey`/`RedisValue`). Rename, then most code still compiles.
 4. **No `CommandFlags.FireAndForget`** - all commands return `Task<T>`. Use batching for throughput.
 5. **`IDatabase` is ONLY available via the `ConnectionMultiplexer` facade.** GLIDE-native clients expose commands directly on the client.

--- a/skills/migrate-stackexchange/skills/migrate-stackexchange/SKILL.md
+++ b/skills/migrate-stackexchange/skills/migrate-stackexchange/SKILL.md
@@ -1,94 +1,107 @@
 ---
 name: migrate-stackexchange
-description: "Use when migrating C#/.NET from StackExchange.Redis to Valkey GLIDE. Covers API mapping, async/await Task, no IDatabase layer, PubSub, Batch API (.NET 8.0+, preview). Not for greenfield C# apps - use valkey-glide-csharp instead."
-version: 1.0.0
+description: "Use when migrating C# / .NET from StackExchange.Redis to Valkey GLIDE. Covers two entry points (ConnectionMultiplexer facade vs GLIDE-native builder), ValkeyKey/ValkeyValue rename, method-name parity, no fire-and-forget, Errors static class hierarchy. Not for greenfield C# - use valkey-glide-csharp."
+version: 1.1.0
 argument-hint: "[API or pattern to migrate]"
 ---
 
 # Migrating from StackExchange.Redis to Valkey GLIDE (C#)
 
-Use when migrating a .NET application from StackExchange.Redis to the GLIDE client library.
+Use when moving an existing StackExchange.Redis app to GLIDE. Assumes you already know SE.Redis. GLIDE C# is GA at v1.0.0 on NuGet as `Valkey.Glide` and ships a deliberate SE.Redis-compatible surface to minimize migration effort. This skill covers the deltas; most method names already match.
 
-**Status**: The GLIDE C# client is in preview (requires .NET 8.0+). APIs may change before GA.
+## Divergences that actually matter
 
-## Routing
+| Area | StackExchange.Redis | GLIDE C# |
+|------|---------------------|---------|
+| Entry point | `ConnectionMultiplexer.Connect(connString)` | Two options: (1) `ConnectionMultiplexer.ConnectAsync(connString)` - SE.Redis-compat facade, OR (2) `GlideClient.CreateClient(config)` / `GlideClusterClient.CreateClient(config)` with fluent builder |
+| Connect | Synchronous | **Async-only** - no sync Connect |
+| Client type | Auto-detects cluster vs standalone | GLIDE-native path requires explicit `GlideClient` vs `GlideClusterClient`. Facade path auto-detects like SE.Redis |
+| Key / value types | `RedisKey`, `RedisValue` | **`ValkeyKey`, `ValkeyValue`** - drop-in equivalents with the same implicit conversions |
+| Access pattern | `IDatabase db = mux.GetDatabase()` then `db.StringSetAsync(...)` | GLIDE-native: methods on `client` directly; facade: `mux.Database` works the same |
+| `CommandFlags.FireAndForget` | Supported | **NOT supported** - all commands return `Task<T>`. Use batching for throughput |
+| Configuration | `ConfigurationOptions` or connection string | `StandaloneClientConfigurationBuilder` / `ClusterClientConfigurationBuilder` fluent builder (or connection string through the facade) |
+| `AbortOnConnectFail` | Option | No equivalent - GLIDE retries infinitely; cap backoff sequence with `RetryStrategy` |
+| Connection pool | `syncTimeout`, response pool | Multiplexer - single multiplexed connection per node |
+| Events | `OnConnectionFailed`, `OnConnectionRestored`, etc. | No EventEmitter-style events - errors surface per-Task; track state via `client.GetStatistics()` |
+| Transactions | `ITransaction tx = db.CreateTransaction(); tx.AddCondition(...)` | `Batch(isAtomic: true)` + `client.ExecAsync(batch, raiseOnError)` |
+| Pipelines | `db.Batch()` + chained awaits | `Batch(isAtomic: false)` - same class, flag-selected |
+| `RedisSubscriber` | `var sub = mux.GetSubscriber(); sub.Subscribe(ch, (ch, msg) => ...)` | Static config on builder OR dynamic `client.SubscribeAsync(ch, timeout)` (2.3+); callback OR polling |
+| `sub.Publish(channel, message)` | Channel first | `client.PublishAsync(channel, message)` - **SAME ORDER** (Python/Node GLIDE reverse it; C# matches SE.Redis) |
+| Error types | `RedisException`, `RedisConnectionException`, `RedisTimeoutException`, etc. | Nested in static `Errors` class: `Errors.GlideException` (abstract base), `Errors.RequestException`, `Errors.ValkeyServerException`, `Errors.ExecAbortException`, `Errors.TimeoutException`, `Errors.ConnectionException`, `Errors.ConfigurationError` (note inconsistent "Error" suffix on the last one) |
+| `RedisResult` | Dynamic typed result | Methods return typed `Task<ValkeyValue>`, `Task<bool>`, `Task<long>`, etc. |
+| `CommandMap` (command renaming) | Supported | Not supported |
 
-- String, hash, list, set, sorted set, delete, exists, cluster -> API Mapping
-- Transaction, Batch API, fire-and-forget -> Advanced Patterns
-- PubSub, subscribe, publish -> Advanced Patterns
-- Key types, API compatibility, ecosystem -> Advanced Patterns
+## Config translation
 
-## Key Differences
-
-| Area | StackExchange.Redis | GLIDE |
-|------|---------------------|-------|
-| Connection | `ConnectionMultiplexer.Connect()` | `GlideClient.CreateClient(config)` |
-| Operations | `IDatabase` methods | Direct client methods |
-| Async model | `async/await` with `Task<T>` | `async/await` with `Task<T>` (similar) |
-| Configuration | Connection string or `ConfigurationOptions` | `StandaloneClientConfigurationBuilder` |
-| Fire-and-forget | `CommandFlags.FireAndForget` | Not supported - all commands return results |
-| Keys/values | `RedisKey` / `RedisValue` types | Strings |
-| Transactions | `ITransaction` with conditions | `Batch` API |
-| Connection model | Multiplexed | Multiplexed (single connection per node) |
-
-Both libraries use multiplexed connections and async/await.
-
-## Quick Start - Connection Setup
-
-**StackExchange.Redis:**
 ```csharp
-var muxer = ConnectionMultiplexer.Connect("localhost:6379");
-IDatabase db = muxer.GetDatabase();
-```
+// SE.Redis:
+var mux = ConnectionMultiplexer.Connect(
+    "localhost:6379,password=pw,ssl=true,connectTimeout=5000,syncTimeout=5000");
+IDatabase db = mux.GetDatabase();
 
-**GLIDE:**
-```csharp
+// GLIDE - facade path (minimal change):
+var mux = await ConnectionMultiplexer.ConnectAsync(
+    "localhost:6379,password=pw,ssl=true");
+IDatabase db = mux.Database;
+
+// GLIDE - native builder path (more control):
 var config = new StandaloneClientConfigurationBuilder()
-    .WithAddress("localhost", 6379).Build();
+    .WithAddress("localhost", 6379)
+    .WithAuthentication("default", "pw")
+    .WithTls()
+    .WithRequestTimeout(TimeSpan.FromSeconds(5))
+    .Build();
 await using var client = await GlideClient.CreateClient(config);
 ```
 
-No `IDatabase` layer - commands are called directly on the client instance.
+## Method names - mostly the same, with a twist
 
-## Configuration Mapping
+GLIDE C# mirrors SE.Redis naming for most commands. Where it differs, the difference usually is dropping a redundant `<Type>` prefix:
 
-| StackExchange.Redis | GLIDE equivalent |
-|---------------------|------------------|
-| `EndPoints.Add(host, port)` | `.WithAddress(host, port)` |
-| `Password` | `.WithCredentials(username, password)` |
-| `DefaultDatabase` | `.WithDatabaseId(id)` |
-| `Ssl = true` | `.WithTls(true)` |
-| `ConnectTimeout` | `.WithRequestTimeout(ms)` |
-| `SyncTimeout` | Part of `WithRequestTimeout` |
-| `AllowAdmin` | Not applicable |
-| `AbortOnConnectFail` | GLIDE always retries - configure via backoff strategy |
+| SE.Redis | GLIDE C# |
+|----------|---------|
+| `db.StringSetAsync(k, v)` / `StringGetAsync(k)` | `client.SetAsync(k, v)` / `GetAsync(k)` - `String*` prefix dropped |
+| `db.StringSetBitAsync` / `StringGetBitAsync` / `StringBitCountAsync` | SAME names - `String*` prefix kept for bitmap ops |
+| `db.HashSetAsync` / `HashGetAsync` / `HashGetAllAsync` | SAME names |
+| `db.ListLeftPushAsync` / `ListRightPushAsync` / `ListLeftPopAsync` / `ListRightPopAsync` | SAME names |
+| `db.SetAddAsync` / `SetMembersAsync` / `SetIsMemberAsync` | SAME names |
+| `db.SortedSetAddAsync` / `SortedSetRangeAsync` | SAME names |
+| `db.StreamAddAsync` / `StreamReadAsync` | SAME names |
+| `db.KeyDeleteAsync` / `KeyExistsAsync` / `KeyExpireAsync` | SAME names |
+| `sub.Publish` / `Subscribe` | `PublishAsync` / `SubscribeAsync` (suffix `Async`) |
 
-## Incremental Migration Strategy
+When in doubt, the SE.Redis method name is likely correct; grep `sources/Valkey.Glide/Client/BaseClient.*Commands.cs` for exact signatures.
 
-No drop-in compatibility layer exists for C#. The GLIDE C# client intentionally mirrors StackExchange.Redis naming to reduce effort. Migration approach:
+## Migration strategy
 
-1. Add `Valkey.Glide` NuGet package alongside `StackExchange.Redis`
-2. Create a service interface abstracting your Redis operations
-3. Implement the interface with GLIDE, replacing `IDatabase` calls with direct client calls
-4. Replace `RedisKey`/`RedisValue` types with plain strings
-5. Remove `CommandFlags.FireAndForget` usage - use batching for throughput
-6. Migrate one service at a time and run integration tests
-7. Remove `StackExchange.Redis` NuGet package once all services are migrated
+Two routes:
+
+1. **Fast swap (facade path)**: replace `ConnectionMultiplexer.Connect` with `ConnectionMultiplexer.ConnectAsync`, rename `RedisKey` -> `ValkeyKey` and `RedisValue` -> `ValkeyValue` wholesale. Most call sites work unchanged. Fire-and-forget calls need rewriting to batches.
+2. **Progressive rewrite (native path)**: add a service interface; implement both SE.Redis and GLIDE-native sides; swap per service behind a flag. Most useful when you want explicit standalone-vs-cluster typing or the full GLIDE-specific builder options (IAM, AZ affinity, compression).
 
 ## Reference
 
 | Topic | File |
 |-------|------|
-| Command-by-command API mapping (strings, hashes, lists, sets, sorted sets, delete, exists, cluster) | [api-mapping](reference/api-mapping.md) |
-| Transactions, Pub/Sub, key types, fire-and-forget, API compatibility | [advanced-patterns](reference/advanced-patterns.md) |
+| Method-name mapping with the SE.Redis naming compatibility table, key types, cluster | [api-mapping](reference/api-mapping.md) |
+| Batch API (replaces `ITransaction`), Pub/Sub migration, no-fire-and-forget, ecosystem notes | [advanced-patterns](reference/advanced-patterns.md) |
 
-## Gotchas
+## Gotchas (the short list)
 
-1. **Preview status.** Not production-ready. Check [GLIDE C# releases](https://www.nuget.org/packages/Valkey.Glide) for the latest API surface.
-2. **Separate client types.** StackExchange.Redis auto-detects cluster mode. GLIDE requires `GlideClient` or `GlideClusterClient` explicitly.
-3. **No `IDatabase` layer.** Commands are on the client directly. No `GetDatabase(n)` - set database in configuration.
-4. **No `RedisKey`/`RedisValue` wrappers.** GLIDE uses plain strings.
-5. **No fire-and-forget.** All commands are awaitable. Use batching for throughput.
-6. **.NET 8.0+ required.** Earlier .NET versions are not supported.
-7. **Platform support.** Pre-built native libraries for Linux (x86_64, arm64), macOS, and Windows.
-8. **API stability.** Method signatures may change between releases. Pin the dependency version.
+1. **GA at v1.0.0** - not preview. Older docs claiming preview status are outdated.
+2. **`ConnectionMultiplexer.Connect` is async-only** - `ConnectAsync`. No synchronous version.
+3. **`ValkeyKey` / `ValkeyValue`** (not `RedisKey`/`RedisValue`). Rename, then most code still compiles.
+4. **No `CommandFlags.FireAndForget`** - all commands return `Task<T>`. Use batching for throughput.
+5. **`IDatabase` is ONLY available via the `ConnectionMultiplexer` facade.** GLIDE-native clients expose commands directly on the client.
+6. **`PublishAsync(channel, message)` - SAME ORDER** as SE.Redis. Python/Node GLIDE reverse it; C# does NOT.
+7. **Error types nested in `Errors` static class.** Use `Errors.ConnectionException`, `Errors.TimeoutException`, `Errors.ValkeyServerException` (NOT `ValkeyException`), `Errors.GlideException` (abstract base). `Errors.ConfigurationError` uses "Error" suffix.
+8. **No `IDatabase.GetDatabase(n)` multiple databases** on GLIDE-native path. Set `WithDatabaseId(n)` in config; one client = one database.
+9. **Reconnection is infinite** - no `AbortOnConnectFail` equivalent.
+10. **.NET 8.0+ required**. No .NET Framework, no .NET Standard.
+11. **No Alpine / MUSL support**. glibc 2.17+ required.
+12. **No `CommandMap` command renaming**.
+
+## Cross-references
+
+- `valkey-glide-csharp` - full C# skill for GLIDE features beyond the migration scope
+- `glide-dev` - GLIDE core internals (Rust) and P/Invoke binding mechanics

--- a/skills/migrate-stackexchange/skills/migrate-stackexchange/reference/advanced-patterns.md
+++ b/skills/migrate-stackexchange/skills/migrate-stackexchange/reference/advanced-patterns.md
@@ -1,105 +1,127 @@
-# StackExchange.Redis to GLIDE Advanced Patterns
+# StackExchange.Redis to GLIDE: migration patterns (C#)
 
-Use when migrating StackExchange.Redis transactions, Pub/Sub, fire-and-forget patterns, or understanding GLIDE C# API compatibility and key type differences.
+Use when translating SE.Redis transactions, Pub/Sub, and fire-and-forget patterns, or choosing between the ConnectionMultiplexer facade and the GLIDE-native builder.
 
-## Transactions
+## Transactions and batches
 
-**StackExchange.Redis:**
+SE.Redis `ITransaction` with conditions maps to GLIDE's `Batch(isAtomic: true)` + `client.ExecAsync(batch, raiseOnError)`:
+
 ```csharp
-var tran = db.CreateTransaction();
-tran.AddCondition(Condition.KeyNotExists("key"));
-_ = tran.StringSetAsync("key", "value");
-_ = tran.StringGetAsync("key");
-bool committed = await tran.ExecuteAsync();
+// SE.Redis:
+var tx = db.CreateTransaction();
+tx.AddCondition(Condition.KeyNotExists("key"));
+_ = tx.StringSetAsync("key", "value");
+_ = tx.StringGetAsync("key");
+bool committed = await tx.ExecuteAsync();
+
+// GLIDE:
+using Valkey.Glide.Pipeline;
+
+var batch = new Batch(isAtomic: true)
+    .Set("key", "value")
+    .Get("key");
+
+// WATCH via client.WatchAsync before the batch (replaces the AddCondition pattern)
+await client.WatchAsync(new ValkeyKey[] { "key" });
+object[]? results = await client.ExecAsync(batch, raiseOnError: true);
+// results is null when a watched key was modified (WATCH conflict)
 ```
 
-**GLIDE:**
+Differences from `ITransaction`:
+
+- No `Condition` objects - use `WATCH` + `ExecAsync` pattern. Returns `null` on conflict.
+- Atomic batches in cluster mode require all keys to hash to one slot; use hash tags.
+- Non-atomic pipelines (`new Batch(isAtomic: false)`) split per-slot automatically in cluster mode.
+
+Cluster-only retry strategy:
+
 ```csharp
-// Batch API (when available in C# client)
-// Atomic batch = transaction, non-atomic batch = pipeline
+var options = new ClusterBatchOptions { Timeout = TimeSpan.FromSeconds(5) }
+    .WithRetryStrategy(new BatchRetryStrategy(retryServerError: true, retryConnectionError: false));
+await clusterClient.ExecAsync(batch, raiseOnError: false, options);
 ```
 
-The C# Batch API is in development. Check the latest GLIDE C# release notes for current transaction support.
-
----
+Same hazards as in other languages - `retryServerError` can reorder within a slot; `retryConnectionError` can cause duplicates.
 
 ## Pub/Sub
 
-**StackExchange.Redis:**
 ```csharp
-var sub = muxer.GetSubscriber();
-await sub.SubscribeAsync("channel", (channel, message) => {
-    Console.WriteLine($"{channel}: {message}");
-});
+// SE.Redis:
+var sub = mux.GetSubscriber();
+await sub.SubscribeAsync("channel", (ch, msg) => Console.WriteLine($"{ch}: {msg}"));
 await sub.PublishAsync("channel", "hello");
-```
 
-**GLIDE (static subscriptions - at client creation):**
-```csharp
+// GLIDE - static subscriptions via builder:
 var config = new StandaloneClientConfigurationBuilder()
     .WithAddress("localhost", 6379)
     .WithPubSubSubscriptionConfig(new StandalonePubSubSubscriptionConfig()
         .WithChannel("channel")
         .WithPattern("events:*")
-        .WithCallback((msg, ctx) => {
-            Console.WriteLine($"[{msg.Channel}] {msg.Message}");
-        }))
+        .WithCallback((msg, ctx) =>
+            Console.WriteLine($"[{msg.Channel}] {msg.Message}")))
     .Build();
-
 await using var subscriber = await GlideClient.CreateClient(config);
-```
 
-**GLIDE (dynamic subscriptions - GLIDE 2.3+):**
-```csharp
-// Blocking subscribe - waits for confirmation
+// GLIDE - dynamic subscribe (2.3+):
 await subscriber.SubscribeAsync("channel", TimeSpan.FromSeconds(5));
 await subscriber.PSubscribeAsync("events:*", TimeSpan.FromSeconds(5));
-
-// Lazy subscribe - returns immediately
-await subscriber.SubscribeLazyAsync("updates");
-await subscriber.PSubscribeLazyAsync("logs:*");
-
-// Unsubscribe
+await subscriber.SubscribeLazyAsync("updates");          // non-blocking
 await subscriber.UnsubscribeAsync("channel", TimeSpan.FromSeconds(5));
-await subscriber.UnsubscribeLazyAsync(); // all channels
+await subscriber.UnsubscribeLazyAsync();                 // all channels
 
-// Publish (use a separate client)
+// Publish - argument order SAME as SE.Redis (channel, message)
 await publisher.PublishAsync("channel", "hello");
 ```
 
-Use a dedicated client for subscriptions - a subscribing client enters a special mode where most regular commands are unavailable. GLIDE automatically resubscribes on reconnection.
+GLIDE multiplexes subscriptions alongside commands - the subscribing client CAN still run regular commands. A dedicated subscriber client is recommended for high-volume subscriptions but not required. Auto-resubscribe on reconnect + topology change is handled by the synchronizer. `TimeSpan.Zero` for the timeout blocks indefinitely.
 
----
+Static subscriptions require RESP3 (default). RESP2 raises `Errors.ConfigurationError`.
 
-## Key Type Differences
+## Key and value types: rename, not reinvent
 
-**StackExchange.Redis** uses `RedisKey` and `RedisValue` as wrapper types with implicit conversions from strings. These support both string and binary data with operator overloads.
+SE.Redis uses `RedisKey` / `RedisValue` wrappers with implicit conversions from `string` / `byte[]` / etc. GLIDE keeps the exact same model, just renamed:
 
-**GLIDE** uses plain strings for keys and values. Binary data is handled through `GlideString` where needed.
+| SE.Redis | GLIDE C# |
+|----------|---------|
+| `RedisKey` | `ValkeyKey` |
+| `RedisValue` | `ValkeyValue` |
+| `HashEntry` | (no direct equivalent; `HashSetAsync` takes `KeyValuePair<ValkeyValue, ValkeyValue>[]`) |
+| `SortedSetEntry` | (no direct equivalent; typed methods take member + score args) |
 
-Migration simplifies code - fewer explicit conversions and wrapper types.
+For binary-safe bytes where even `ValkeyValue` is awkward, GLIDE uses `GlideString` at the interop boundary.
 
----
+Migration is a mechanical global rename (`RedisKey` -> `ValkeyKey`, `RedisValue` -> `ValkeyValue`). The implicit `string` conversions make most call sites keep working.
 
-## Fire-and-Forget
+## Fire-and-forget removed
 
-**StackExchange.Redis:**
+SE.Redis's `CommandFlags.FireAndForget` has NO equivalent in GLIDE. Every command returns `Task<T>` that must be awaited. Use non-atomic batches for bulk-send throughput:
+
 ```csharp
-db.StringSet("key", "value", flags: CommandFlags.FireAndForget);
+// SE.Redis:
+for (int i = 0; i < 1000; i++)
+    db.StringSet($"k:{i}", $"v:{i}", flags: CommandFlags.FireAndForget);
+
+// GLIDE:
+var batch = new Batch(isAtomic: false);
+for (int i = 0; i < 1000; i++) batch.Set($"k:{i}", $"v:{i}");
+await client.ExecAsync(batch, raiseOnError: false);
 ```
 
-**GLIDE** does not support fire-and-forget. Every command returns a result that must be awaited. For equivalent throughput, use non-atomic batches.
+One round trip, one multiplexer slot. Faster than 1000 fire-and-forget sends.
 
----
+## ConnectionMultiplexer facade vs GLIDE-native
 
-## API Compatibility Approach
+| Situation | Use |
+|-----------|-----|
+| Fast migration, minimal code changes | `ConnectionMultiplexer.ConnectAsync(connString)` facade - same `IDatabase`, same `IBatch`, `ValkeyKey`/`ValkeyValue` replace `Redis*` types, everything else familiar |
+| Need explicit standalone/cluster typing | `GlideClient.CreateClient` / `GlideClusterClient.CreateClient` with builder |
+| Want GLIDE-only features (IAM, AZ affinity, compression config, OTel init before client creation) | Native path - the `ConfigurationBuilder` exposes these; the facade's connection string parser does not cover all of them |
+| Existing SE.Redis DI setup via `IConnectionMultiplexer` | Facade - GLIDE's `ConnectionMultiplexer` implements `IConnectionMultiplexer` for drop-in DI replacement |
 
-The C# GLIDE client intentionally mirrors StackExchange.Redis naming conventions (`ConnectionMultiplexer`, `StringSetAsync`, `StringGetAsync`) to ease migration. The README states: "API Compatibility: Compatible with StackExchange.Redis APIs to ease migration."
+## Platform and packaging
 
-Key positions from the community discussion on API compatibility:
-
-- **Pro-compatibility** (from AWS/GCP stakeholders): Reducing migration effort drives adoption.
-- **Anti-compatibility** (from core architect): GLIDE's thin-binding architecture means foreign interfaces would break the design. Dedicated **Adapters** that translate foreign interfaces are preferred over modifying GLIDE core.
-- **Tooling approach**: A .NET Roslyn-based migration tool could automate code transformation.
-
-The client has been moved to a separate repository: https://github.com/valkey-io/valkey-glide-csharp
+- **NuGet**: `dotnet add package Valkey.Glide`. v1.0.0 is GA.
+- **.NET 8.0+** required. No .NET Framework / .NET Standard support.
+- **Platforms**: Linux (glibc 2.17+, x86_64/arm64), macOS (x86_64/Apple Silicon), Windows (x86_64). Alpine / MUSL not supported.
+- **Native binary**: ships platform-specific `Valkey.Glide.<os>-<arch>` runtime package. Lockfile on one OS/arch won't pull the right native for another - keep `dotnet restore` platform-aligned with deploy target.
+- **Proxies**: GLIDE sends `CLIENT SETNAME`, `CLIENT SETINFO`, `INFO REPLICATION` at setup. Transparent proxies that strip these break topology detection.

--- a/skills/migrate-stackexchange/skills/migrate-stackexchange/reference/advanced-patterns.md
+++ b/skills/migrate-stackexchange/skills/migrate-stackexchange/reference/advanced-patterns.md
@@ -62,7 +62,7 @@ var config = new StandaloneClientConfigurationBuilder()
     .Build();
 await using var subscriber = await GlideClient.CreateClient(config);
 
-// GLIDE - dynamic subscribe (2.3+):
+// GLIDE - dynamic subscribe:
 await subscriber.SubscribeAsync("channel", TimeSpan.FromSeconds(5));
 await subscriber.PSubscribeAsync("events:*", TimeSpan.FromSeconds(5));
 await subscriber.SubscribeLazyAsync("updates");          // non-blocking

--- a/skills/migrate-stackexchange/skills/migrate-stackexchange/reference/api-mapping.md
+++ b/skills/migrate-stackexchange/skills/migrate-stackexchange/reference/api-mapping.md
@@ -1,149 +1,86 @@
-# StackExchange.Redis to GLIDE API Mapping
+# StackExchange.Redis to GLIDE: where signatures diverge
 
-Use when migrating specific StackExchange.Redis commands to their GLIDE equivalents, looking up type differences, or converting data type operations.
+Use when translating SE.Redis calls. GLIDE C# intentionally mirrors SE.Redis method names, so for most commands the only change is the type rename (`RedisKey`/`RedisValue` -> `ValkeyKey`/`ValkeyValue`) and `async` method call-sites.
 
-## String Operations
+## Most commands: name-identical, just rename types
 
-**StackExchange.Redis:**
+The big one: `RedisKey` -> `ValkeyKey`, `RedisValue` -> `ValkeyValue`. Both sets implicit-convert from `string` / `byte[]` so most call-sites keep working unchanged.
+
+| SE.Redis | GLIDE C# | Comment |
+|----------|---------|---------|
+| `await db.HashSetAsync(k, f, v)` | `await client.HashSetAsync(k, f, v)` | Identical |
+| `await db.HashGetAsync(k, f)` returning `RedisValue` | `await client.HashGetAsync(k, f)` returning `ValkeyValue` | Type rename only |
+| `await db.ListLeftPushAsync(k, v)` / `ListRightPushAsync` / `ListLeftPopAsync` / `ListRightPopAsync` | Identical names | |
+| `await db.SetAddAsync(k, v)` / `SetMembersAsync` / `SetRemoveAsync` / `SetContainsAsync` | Identical names | |
+| `await db.SortedSetAddAsync(k, m, score)` / `SortedSetRangeAsync` / `SortedSetScoreAsync` | Identical names | |
+| `await db.StreamAddAsync(key, field, value)` / `StreamReadAsync` / `StreamReadGroupAsync` | Identical names | |
+| `await db.KeyDeleteAsync(k)` / `KeyExistsAsync` / `KeyExpireAsync` / `KeyTimeToLiveAsync` | Identical names | |
+| `await db.StringBitCountAsync(k)` / `StringSetBitAsync` / `StringGetBitAsync` | Identical names | |
+| `await db.HyperLogLogAddAsync` / `HyperLogLogLengthAsync` | Identical names | |
+| `await db.GeoAddAsync` / `GeoDistanceAsync` / `GeoSearchAsync` | Identical names | |
+| `await db.ScriptEvaluateAsync(lua, keys, values)` | Identical | |
+
+## Handful of renames (`String*` prefix dropped for GET / SET)
+
+| SE.Redis | GLIDE C# |
+|----------|---------|
+| `await db.StringSetAsync(k, v)` | `await client.SetAsync(k, v)` |
+| `await db.StringSetAsync(k, v, TimeSpan.FromSeconds(60))` | `await client.SetAsync(k, v, SetExpiryOptions.From(TimeSpan.FromSeconds(60)))` - typed expiry option |
+| `await db.StringSetAsync(k, v, when: When.NotExists)` | `await client.SetAsync(k, v, SetCondition.NotExists)` |
+| `await db.StringGetAsync(k)` | `await client.GetAsync(k)` |
+| `await db.StringGetSetAsync(k, v)` | `await client.GetSetAsync(k, v)` |
+| `await db.StringLengthAsync(k)` | `await client.LengthAsync(k)` (in the string-commands group) |
+
+`StringSetBitAsync` / `StringGetBitAsync` / `StringBitCountAsync` keep the `String*` prefix.
+
+## Different set operations take arrays
+
+SE.Redis has both single-value and array-valued overloads. GLIDE is consistent:
+
 ```csharp
-await db.StringSetAsync("key", "value");
-await db.StringSetAsync("key", "value", TimeSpan.FromSeconds(60));
-await db.StringSetAsync("key", "value", when: When.NotExists);
-RedisValue val = await db.StringGetAsync("key");
-string str = val.ToString();
+// Single-value
+await client.SetAddAsync("set", (ValkeyValue)"a");
+await client.SetRemoveAsync("set", (ValkeyValue)"a");
+
+// Multi-value (bulk)
+await client.SetAddAsync("set", new ValkeyValue[] { "a", "b", "c" });
+await client.SetRemoveAsync("set", new ValkeyValue[] { "a", "b" });
 ```
 
-**GLIDE:**
+## Publish: argument order UNCHANGED
+
 ```csharp
-await client.Set("key", "value");
-// Expiry and conditional set use options (API may vary in preview)
-var val = await client.GetAsync("key");
+// SE.Redis:
+await sub.PublishAsync("channel", "message");
+
+// GLIDE: same order (unlike Python/Node GLIDE which reverse it)
+await client.PublishAsync("channel", "message");
 ```
 
----
+## Cluster client type
 
-## Hash Operations
+SE.Redis auto-detects cluster via `ConnectionMultiplexer.Connect`. GLIDE has two paths:
 
-**StackExchange.Redis:**
 ```csharp
-await db.HashSetAsync("hash", new HashEntry[] {
-    new HashEntry("f1", "v1"),
-    new HashEntry("f2", "v2"),
-});
-RedisValue val = await db.HashGetAsync("hash", "f1");
-HashEntry[] all = await db.HashGetAllAsync("hash");
-```
+// Facade path - auto-detects like SE.Redis:
+var mux = await ConnectionMultiplexer.ConnectAsync("n1:6379,n2:6379");
 
-**GLIDE:**
-```csharp
-// Hash commands use field-value pairs
-await client.HSet("hash", new Dictionary<string, string> {
-    { "f1", "v1" },
-    { "f2", "v2" },
-});
-var val = await client.HGet("hash", "f1");
-```
-
----
-
-## List Operations
-
-**StackExchange.Redis:**
-```csharp
-await db.ListLeftPushAsync("list", new RedisValue[] { "a", "b", "c" });
-await db.ListRightPushAsync("list", "x");
-RedisValue val = await db.ListLeftPopAsync("list");
-RedisValue[] range = await db.ListRangeAsync("list", 0, -1);
-```
-
-**GLIDE:**
-```csharp
-await client.LPush("list", new string[] { "a", "b", "c" });
-await client.RPush("list", new string[] { "x" });
-var val = await client.LPop("list");
-```
-
----
-
-## Set Operations
-
-**StackExchange.Redis:**
-```csharp
-await db.SetAddAsync("set", new RedisValue[] { "a", "b", "c" });
-await db.SetRemoveAsync("set", "a");
-RedisValue[] members = await db.SetMembersAsync("set");
-bool isMember = await db.SetContainsAsync("set", "b");
-```
-
-**GLIDE:**
-```csharp
-await client.SAdd("set", new string[] { "a", "b", "c" });
-await client.SRem("set", new string[] { "a" });
-```
-
----
-
-## Sorted Set Operations
-
-**StackExchange.Redis:**
-```csharp
-await db.SortedSetAddAsync("zset", new SortedSetEntry[] {
-    new SortedSetEntry("alice", 1.0),
-    new SortedSetEntry("bob", 2.0),
-});
-double? score = await db.SortedSetScoreAsync("zset", "alice");
-```
-
-**GLIDE:**
-```csharp
-// Sorted set commands accept member-score mappings
-await client.ZAdd("zset", new Dictionary<string, double> {
-    { "alice", 1.0 },
-    { "bob", 2.0 },
-});
-```
-
----
-
-## Delete and Exists
-
-**StackExchange.Redis:**
-```csharp
-await db.KeyDeleteAsync(new RedisKey[] { "k1", "k2", "k3" });
-bool exists = await db.KeyExistsAsync("k1");
-```
-
-**GLIDE:**
-```csharp
-await client.Del(new string[] { "k1", "k2", "k3" });
-var exists = await client.Exists(new string[] { "k1" });
-```
-
----
-
-## Cluster Mode
-
-**StackExchange.Redis:**
-```csharp
-// StackExchange.Redis auto-detects cluster mode
-var options = new ConfigurationOptions
-{
-    EndPoints = {
-        { "node1.example.com", 6379 },
-        { "node2.example.com", 6380 },
-    },
-};
-var muxer = ConnectionMultiplexer.Connect(options);
-```
-
-**GLIDE:**
-```csharp
+// Native path - explicit cluster client:
 var config = new ClusterClientConfigurationBuilder()
-    .WithAddress("node1.example.com", 6379)
-    .WithAddress("node2.example.com", 6380)
+    .WithAddress("n1", 6379)
+    .WithAddress("n2", 6379)
     .Build();
-
 await using var client = await GlideClusterClient.CreateClient(config);
 ```
 
-StackExchange.Redis auto-detects standalone vs cluster mode. GLIDE uses separate client types: `GlideClient` for standalone and `GlideClusterClient` for cluster.
+## Everything else is translation-free
+
+For 80%+ of command call-sites, the SE.Redis code compiles after:
+
+1. `using StackExchange.Redis;` -> `using Valkey.Glide;`
+2. `RedisKey` -> `ValkeyKey`, `RedisValue` -> `ValkeyValue` (global find/replace works)
+3. `ConnectionMultiplexer.Connect(...)` -> `await ConnectionMultiplexer.ConnectAsync(...)`
+4. Remove any `CommandFlags.FireAndForget` (no equivalent - use a Batch)
+5. Rewrite catch blocks: `RedisConnectionException` -> `Errors.ConnectionException`, etc.
+
+The method names just work.

--- a/skills/valkey-glide-csharp/.claude-plugin/plugin.json
+++ b/skills/valkey-glide-csharp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "valkey-glide-csharp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Use when building C#/.NET apps with Valkey GLIDE - async/await API, .NET 8.0+ (preview), GlideClient, configuration builders, TLS, PubSub. Not for StackExchange.Redis migration - use migrate-stackexchange skill.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/valkey-glide-csharp/skills/valkey-glide-csharp/SKILL.md
+++ b/skills/valkey-glide-csharp/skills/valkey-glide-csharp/SKILL.md
@@ -18,7 +18,7 @@ Package: `dotnet add package Valkey.Glide`.
 | Question | Reference |
 |----------|-----------|
 | `GlideClient` vs `GlideClusterClient`, TLS, auth, IAM, lazy connect, AZ affinity, `ConnectionMultiplexer` facade | [connection](reference/features-connection.md) |
-| PubSub: static config vs dynamic `SubscribeAsync` (2.3+), `PublishAsync` arg order (NOT reversed), sharded | [pubsub](reference/features-pubsub.md) |
+| PubSub: static config vs dynamic `SubscribeAsync`, `PublishAsync` arg order (NOT reversed), sharded | [pubsub](reference/features-pubsub.md) |
 | Command groups, platform support, `ValkeyKey`/`ValkeyValue`, error hierarchy, GA status | [overview](reference/features-overview.md) |
 
 ## Multiplexer rule (the #1 agent mistake)

--- a/skills/valkey-glide-csharp/skills/valkey-glide-csharp/SKILL.md
+++ b/skills/valkey-glide-csharp/skills/valkey-glide-csharp/SKILL.md
@@ -1,25 +1,51 @@
 ---
 name: valkey-glide-csharp
-description: "Use when building C#/.NET apps with Valkey GLIDE - async/await API, .NET 8.0+ (preview), GlideClient, configuration builders, TLS, PubSub. Not for StackExchange.Redis migration - use migrate-stackexchange skill."
-version: 2.0.0
+description: "Use when building C# / .NET 8+ apps with Valkey GLIDE - async/await API, GlideClient, GlideClusterClient, ConnectionMultiplexer facade, SE.Redis-compatible method names, ValkeyKey/ValkeyValue primitives, multiplexer behavior. Covers the divergence from StackExchange.Redis; basic command shapes are assumed knowable from training. Not for SE.Redis migration - use migrate-stackexchange."
+version: 2.1.0
 argument-hint: "[API or config question]"
 ---
 
 # Valkey GLIDE C# Client
 
-Async/await C# client for Valkey built on the GLIDE Rust core via native interop. Currently in preview.
+Agent-facing skill for GLIDE C#. Assumes the reader can already write basic StackExchange.Redis from training (`db.StringSetAsync`, `ConnectionMultiplexer.Connect`, `IDatabase`, `RedisKey`/`RedisValue`). Covers only what diverges and what GLIDE adds on top.
 
-**Separate repository:** [valkey-io/valkey-glide-csharp](https://github.com/valkey-io/valkey-glide-csharp)
+**Separate repository:** [valkey-io/valkey-glide-csharp](https://github.com/valkey-io/valkey-glide-csharp). GA at `v1.0.0` (not preview).
+
+Package: `dotnet add package Valkey.Glide`.
 
 ## Routing
 
 | Question | Reference |
 |----------|-----------|
-| Setup, client creation, TLS, auth, config builders, read strategy | [connection](reference/features-connection.md) |
-| PubSub, subscribe, publish, sharded channels | [pubsub](reference/features-pubsub.md) |
-| Install, API status, platform support, command groups, limitations | [overview](reference/features-overview.md) |
+| `GlideClient` vs `GlideClusterClient`, TLS, auth, IAM, lazy connect, AZ affinity, `ConnectionMultiplexer` facade | [connection](reference/features-connection.md) |
+| PubSub: static config vs dynamic `SubscribeAsync` (2.3+), `PublishAsync` arg order (NOT reversed), sharded | [pubsub](reference/features-pubsub.md) |
+| Command groups, platform support, `ValkeyKey`/`ValkeyValue`, error hierarchy, GA status | [overview](reference/features-overview.md) |
 
-## Cross-References
+## Multiplexer rule (the #1 agent mistake)
 
-- `valkey-glide` skill - shared architecture, cluster topology, connection model
-- `valkey` skill - Valkey server commands, data types, patterns
+One `GlideClient` / `GlideClusterClient` per process (or one `ConnectionMultiplexer` if using the SE.Redis facade). Shared across every task. Do not create per-request clients. Do not pool them.
+
+**Exceptions that need a dedicated client:**
+
+- Blocking commands: `ListLeftPopAsync` / `ListRightPopAsync` with `timeout`, `SortedSetPopAsync` with `timeout`, plus `StreamReadAsync` / `StreamReadGroupAsync` with block.
+- WATCH / MULTI / EXEC transactions (connection-state commands).
+- Long-running PubSub polling.
+
+## Grep hazards
+
+1. **`PublishAsync(channel, message)` - NOT reversed** like Python/Node GLIDE. C# matches the Redis / StackExchange.Redis convention. `await client.PublishAsync(channel, message)`.
+2. **`ValkeyKey` / `ValkeyValue` types, NOT `RedisKey`/`RedisValue`.** Otherwise SE.Redis-compatible primitives with implicit conversions from `string` / `byte[]`.
+3. **Method names are SE.Redis-style, NOT GLIDE-invented.** The API uses `SetAsync` / `GetAsync` (not `StringSetAsync`/`StringGetAsync`), `ListLeftPushAsync` / `ListRightPushAsync` / `ListLeftPopAsync` / `ListRightPopAsync` (not `ListPushAsync`/`ListPopAsync`), `HashSetAsync` / `HashGetAsync`, `SortedSetAddAsync` / `SortedSetRangeAsync`, `StreamAddAsync` / `StreamReadAsync`, `ScriptEvaluateAsync`.
+4. **Error classes nested in `Errors` static class.** `Valkey.Glide.Errors.GlideException` (abstract base), `Errors.RequestException`, `Errors.ValkeyServerException` (NOT `ValkeyException`), `Errors.ExecAbortException`, `Errors.TimeoutException`, `Errors.ConnectionException`, `Errors.ConfigurationError` (note "Error" suffix, not "Exception").
+5. **`ConnectionMultiplexer` facade exists** for SE.Redis compatibility. Two entry points: GLIDE-native `GlideClient.CreateClient(config)` OR SE.Redis-compatible `ConnectionMultiplexer.ConnectAsync("localhost:6379")`. Same underlying multiplexer.
+6. **Builder pattern for GLIDE-native path**: `StandaloneClientConfigurationBuilder` / `ClusterClientConfigurationBuilder` with fluent `WithAddress()`, `WithTls()`, `WithAuthentication()`, `WithReadFrom()`, `WithLazyConnect()`, `.Build()`.
+7. **No Alpine / MUSL support** - glibc 2.17+ required.
+8. **Reconnection is infinite.** `RetryStrategy` caps backoff sequence length only.
+9. **`await using var client = ...`** pattern: client implements `IAsyncDisposable`. Always prefer over manual dispose.
+10. **Static subscriptions require RESP3.** Using RESP2 raises `ConfigurationError`.
+
+## Cross-references
+
+- `migrate-stackexchange` - migrating from StackExchange.Redis
+- `glide-dev` - GLIDE core internals (Rust) and P/Invoke binding mechanics
+- `valkey` - Valkey commands and app patterns

--- a/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-connection.md
+++ b/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-connection.md
@@ -15,10 +15,10 @@ Both sit on the same underlying multiplexer. All clients implement `IAsyncDispos
 
 | SE.Redis | GLIDE C# |
 |----------|---------|
-| `ConnectionMultiplexer.Connect(connString)` - sync | `GlideClient.CreateClient(config)` async static OR `ConnectionMultiplexer.ConnectAsync(connString)` |
+| `ConnectionMultiplexer.Connect(connString)` - sync or `ConnectAsync(...)` | Facade has both `Connect` and `ConnectAsync`; GLIDE-native `GlideClient.CreateClient(config)` is async-only |
 | Connection pool with `syncTimeout` / `responseTimeout` | Multiplexer - single multiplexed connection per node; no pool knobs |
 | `RedisKey` / `RedisValue` primitive wrappers | `ValkeyKey` / `ValkeyValue` - same idea, rebranded |
-| `IDatabase db = mux.GetDatabase()` | Call commands directly on `client` (or `mux.Database` through the facade) |
+| `IDatabase db = mux.GetDatabase()` | Call commands directly on `client` (or `mux.GetDatabase()` through the facade) |
 | `db.StringSetAsync(key, value)` | `client.SetAsync(key, value)` - SE.Redis-compatible method names but `String*` prefix dropped where redundant |
 | `db.ListLeftPushAsync` / `ListRightPushAsync` | Same names (SE.Redis-compatible) |
 | `ConnectionMultiplexer.GetServer()` / `GetServers()` | Not exposed; server commands on the client |
@@ -85,7 +85,7 @@ Only seed addresses are needed - GLIDE discovers full topology automatically.
 using Valkey.Glide;
 
 var mux = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
-var db = mux.Database;
+var db = mux.GetDatabase();
 await db.StringSetAsync("key", "value");
 ```
 

--- a/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-connection.md
+++ b/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-connection.md
@@ -1,18 +1,32 @@
-# Connection and Configuration (C#)
+# Connection and configuration (C#)
 
-Use when creating a GLIDE client in C#, choosing between standalone and cluster mode, configuring authentication, TLS, timeouts, reconnection backoff, read strategy, or the StackExchange.Redis-compatible ConnectionMultiplexer.
+Use when creating clients, configuring auth, TLS, timeouts, reconnection, read strategy, or using the StackExchange.Redis-compatible ConnectionMultiplexer. Covers what differs from StackExchange.Redis's `ConnectionMultiplexer.Connect(connString)` + `IDatabase`.
 
-## Client Classes
+## Two entry points - pick one
 
-| Class | Mode | Description |
-|-------|------|-------------|
-| `GlideClient` | Standalone | Single-node or primary+replicas via builder config |
-| `GlideClusterClient` | Cluster | Valkey Cluster with auto-topology discovery |
-| `ConnectionMultiplexer` | Auto-detect | StackExchange.Redis-compatible facade, detects cluster automatically |
+| API | When to use |
+|-----|-------------|
+| `GlideClient.CreateClient(config)` / `GlideClusterClient.CreateClient(config)` | GLIDE-native builder pattern; explicit standalone vs cluster |
+| `ConnectionMultiplexer.ConnectAsync(connString)` | SE.Redis facade; auto-detects standalone vs cluster from connection string |
 
-All clients implement `IAsyncDisposable` - use `await using` for automatic cleanup.
+Both sit on the same underlying multiplexer. All clients implement `IAsyncDisposable` - use `await using` for cleanup.
 
-## Standalone Client (Builder Pattern)
+## Divergence from StackExchange.Redis
+
+| SE.Redis | GLIDE C# |
+|----------|---------|
+| `ConnectionMultiplexer.Connect(connString)` - sync | `GlideClient.CreateClient(config)` async static OR `ConnectionMultiplexer.ConnectAsync(connString)` |
+| Connection pool with `syncTimeout` / `responseTimeout` | Multiplexer - single multiplexed connection per node; no pool knobs |
+| `RedisKey` / `RedisValue` primitive wrappers | `ValkeyKey` / `ValkeyValue` - same idea, rebranded |
+| `IDatabase db = mux.GetDatabase()` | Call commands directly on `client` (or `mux.Database` through the facade) |
+| `db.StringSetAsync(key, value)` | `client.SetAsync(key, value)` - SE.Redis-compatible method names but `String*` prefix dropped where redundant |
+| `db.ListLeftPushAsync` / `ListRightPushAsync` | Same names (SE.Redis-compatible) |
+| `ConnectionMultiplexer.GetServer()` / `GetServers()` | Not exposed; server commands on the client |
+| `ConfigurationOptions` parser | `StandaloneClientConfigurationBuilder` / `ClusterClientConfigurationBuilder` fluent builder; connection strings also parsed by `ConnectionMultiplexer` facade |
+| `OnConnectionFailed` / `OnConnectionRestored` events | No events - errors surface per-Task via `await`; track via `client.GetStatistics()` |
+| `MaxRetries`, `MaxInflightOperations` | `RetryStrategy(n, factor, exponentBase, jitter)` caps BACKOFF sequence length only - reconnection is INFINITE |
+
+## GLIDE-native builder pattern
 
 ```csharp
 using Valkey.Glide;
@@ -24,8 +38,8 @@ var config = new StandaloneClientConfigurationBuilder()
 
 await using var client = await GlideClient.CreateClient(config);
 
-await client.StringSetAsync("key", "value");
-var result = await client.StringGetAsync("key");
+await client.SetAsync("key", "value");         // NOT StringSetAsync
+ValkeyValue val = await client.GetAsync("key"); // NOT StringGetAsync
 ```
 
 With full configuration:

--- a/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-overview.md
+++ b/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-overview.md
@@ -1,111 +1,95 @@
 # C# Client Overview
 
-Use when checking GLIDE C# capabilities, available commands, and limitations.
+Use when checking GLIDE C# status, platform support, method naming convention, error model, or features beyond the connection / pubsub basics.
 
 ## Status
 
-**Preview** - the C# wrapper is functional but API may change before GA. PascalCase method names (`StringSetAsync`, `StringGetAsync`), `Task<T>`/async-await, optional `ConnectionMultiplexer` facade for StackExchange.Redis compatibility.
+**GA at v1.0.0** (previously preview). Published as `Valkey.Glide` on NuGet. Repo: [valkey-io/valkey-glide-csharp](https://github.com/valkey-io/valkey-glide-csharp).
 
-## Requirements
+## Requirements and platform support
 
 - .NET 8.0+
 - Valkey 7.2+ or Redis 6.2+
 
-## Platform Support
-
-| Platform | Architecture | Supported |
-|----------|-------------|-----------|
-| Linux | x86_64 | Yes |
-| Linux | arm64 | Yes |
-| macOS | Apple Silicon | Yes |
-| macOS | x86_64 | Yes |
+| Platform | Arch | Supported |
+|----------|------|-----------|
+| Linux (glibc) | x86_64, arm64 | Yes |
+| macOS | Apple Silicon, x86_64 | Yes |
 | Windows | x86_64 | Yes |
-| Alpine/MUSL | any | No |
+| Alpine / MUSL | any | No (glibc 2.17+ required) |
 
-## Two Connection Styles
+## Method naming
 
-**Builder pattern** (GLIDE-native):
-```csharp
-var config = new StandaloneClientConfigurationBuilder()
-    .WithAddress("localhost", 6379)
-    .Build();
-await using var client = await GlideClient.CreateClient(config);
+C# GLIDE uses **StackExchange.Redis-compatible** method names, NOT GLIDE-invented `<Type>Command`-style prefixes. Agents migrating from SE.Redis can use the same method names for most commands. Examples:
+
+| What you want | Actual method |
+|---------------|---------------|
+| SET | `SetAsync(key, value)` - NOT `StringSetAsync` |
+| GET | `GetAsync(key)` - NOT `StringGetAsync` |
+| HSET | `HashSetAsync(key, field, value)` - ✓ matches SE.Redis |
+| HGET | `HashGetAsync(key, field)` |
+| LPUSH / RPUSH | `ListLeftPushAsync` / `ListRightPushAsync` - NOT `ListPushAsync` |
+| LPOP / RPOP | `ListLeftPopAsync` / `ListRightPopAsync` - NOT `ListPopAsync` |
+| SADD / SMEMBERS | `SetAddAsync` / `SetMembersAsync` |
+| ZADD / ZRANGE | `SortedSetAddAsync` / `SortedSetRangeAsync` |
+| XADD / XREAD | `StreamAddAsync` / `StreamReadAsync` |
+| SUBSCRIBE / PUBLISH | `SubscribeAsync` / `PublishAsync` |
+| SETBIT / GETBIT / BITCOUNT | `StringSetBitAsync` / `StringGetBitAsync` / `StringBitCountAsync` (here `String*` prefix IS used - inherits from SE.Redis convention for these) |
+| PFADD / PFCOUNT | `HyperLogLogAddAsync` / `HyperLogLogLengthAsync` |
+| GEOADD / GEOSEARCH | `GeoAddAsync` / `GeoSearchAsync` |
+| EVAL / EVALSHA | `ScriptEvaluateAsync` |
+| DEL / EXISTS / EXPIRE | `KeyDeleteAsync` / `KeyExistsAsync` / `KeyExpireAsync` |
+| INFO / DBSIZE / FLUSHALL | `InfoAsync` / `DatabaseSizeAsync` / `FlushAllAsync` (server-management group) |
+
+When in doubt, the SE.Redis naming convention is the default; grep the `BaseClient.*Commands.cs` files under `sources/Valkey.Glide/Client/` for exact signatures.
+
+## Types
+
+- `ValkeyKey` - SE.Redis-compatible key wrapper (equivalent to `RedisKey`). Implicit conversions from `string` and `byte[]`.
+- `ValkeyValue` - SE.Redis-compatible value wrapper (equivalent to `RedisValue`).
+- `GlideString` - binary-safe string used in some low-level APIs.
+- `ClusterValue<T>` - cluster response wrapper when a command fans out to multiple nodes.
+
+## Error hierarchy
+
+All errors nested in the static `Errors` class. `Valkey.Glide.Errors.GlideException` (abstract base) with sealed subclasses:
+
+```
+Errors.GlideException (abstract)              # catches everything
+├── Errors.RequestException                    # general request failure
+├── Errors.ValkeyServerException               # server-side error (WRONGTYPE, OOM, NOAUTH)
+├── Errors.ExecAbortException                  # atomic batch aborted (WATCH conflict)
+├── Errors.TimeoutException                    # request timeout
+├── Errors.ConnectionException                 # network / connection problem
+└── Errors.ConfigurationError                  # invalid config (note "Error" suffix, not "Exception")
 ```
 
-**ConnectionMultiplexer** (StackExchange.Redis-compatible):
-```csharp
-var mux = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
-var db = mux.Database;
-```
-
-ConnectionMultiplexer auto-detects cluster mode and provides a familiar API for StackExchange.Redis users.
-
-## Available Command Groups
-
-| Group | Examples | Status |
-|-------|----------|--------|
-| String | `StringSetAsync`, `StringGetAsync`, `IncrAsync` | Available |
-| Hash | `HashSetAsync`, `HashGetAsync`, `HashGetAllAsync` | Available |
-| List | `ListPushAsync`, `ListPopAsync`, `ListRangeAsync` | Available |
-| Set | `SetAddAsync`, `SetMembersAsync`, `SetIsMemberAsync` | Available |
-| Sorted Set | `SortedSetAddAsync`, `SortedSetRangeAsync` | Available |
-| Stream | `StreamAddAsync`, `StreamReadAsync`, `StreamReadGroupAsync` | Available |
-| PubSub | `SubscribeAsync`, `PublishAsync`, `PSubscribeAsync` | Available |
-| Bitmap | `StringSetBitAsync`, `StringGetBitAsync`, `BitCountAsync` | Available |
-| HyperLogLog | `HyperLogLogAddAsync`, `HyperLogLogLengthAsync` | Available |
-| Geo | `GeoAddAsync`, `GeoSearchAsync`, `GeoDistAsync` | Available |
-| Scripting | `ScriptEvaluateAsync`, `ScriptEvaluateShaAsync` | Available |
-| Generic | `KeyDeleteAsync`, `KeyExistsAsync`, `KeyExpireAsync` | Available |
-| Server | `InfoAsync`, `DBSizeAsync`, `FlushAllAsync` | Available |
-| Batching | `ClusterBatch` / `StandaloneBatch` | Available |
-
-## Features
-
-| Feature | Available | Notes |
-|---------|-----------|-------|
-| Standalone mode | Yes | Via `GlideClient` or `ConnectionMultiplexer` |
-| Cluster mode | Yes | Via `GlideClusterClient` or `ConnectionMultiplexer` |
-| TLS/mTLS | Yes | Builder `.WithTls()` or connection string `ssl=true` |
-| Authentication | Yes | Password, ACL username+password, IAM (AWS) |
-| PubSub | Yes | Static + dynamic subscriptions, sharded PubSub |
-| Batching | Yes | Atomic (MULTI/EXEC) and non-atomic (pipeline) |
-| OpenTelemetry | Yes | Traces + metrics via `OpenTelemetry.Init()` |
-| AZ Affinity | Yes | `ReadFromStrategy.AzAffinity` (Valkey 8.0+) |
-| Compression | In progress | Zstd/LZ4 support being added |
-| Server modules | In progress | JSON, Search support being added |
-| Lazy connect | Yes | Defer connection until first command |
-| RESP2/RESP3 | Yes | RESP3 default, RESP2 for compatibility |
-
-## Error Handling
+**Gotcha**: `ConfigurationError` uses the `Error` suffix while every other leaf uses `Exception`. That's an upstream inconsistency in `sources/Valkey.Glide/Errors.cs`. Use the exact name when catching.
 
 ```csharp
+using static Valkey.Glide.Errors;
+
 try
 {
-    await client.StringSetAsync("key", "value");
+    await client.SetAsync("key", "value");
 }
-catch (ConnectionException ex)
-{
-    // Connection lost - client auto-reconnects
-}
-catch (TimeoutException ex)
-{
-    // Request exceeded configured timeout
-}
-catch (ValkeyException ex)
-{
-    // Server-side error (WRONGTYPE, OOM, etc.)
-}
+catch (ConnectionException ex) { /* network issue - auto-reconnecting */ }
+catch (TimeoutException    ex) { /* check requestTimeout or server load */ }
+catch (ValkeyServerException ex) { /* server-side WRONGTYPE, OOM, etc. */ }
+catch (GlideException ex)        { /* catch-all */ }
 ```
 
-## Limitations (Preview)
+## Feature availability
 
-- API may change before GA
-- Some advanced features (compression, server modules) may lag behind GA clients
-- Not all StackExchange.Redis APIs are supported in the ConnectionMultiplexer facade
-- Performance tuning and benchmarking are ongoing
-
-## Repository
-
-Separate repo: [valkey-io/valkey-glide-csharp](https://github.com/valkey-io/valkey-glide-csharp)
-
-Package: `dotnet add package Valkey.Glide`
+| Feature | Notes |
+|---------|-------|
+| Standalone + Cluster | Both via `GlideClient` / `GlideClusterClient` or `ConnectionMultiplexer` facade |
+| TLS / mTLS | Builder `.WithTls()` + optional `.WithRootCertificate(bytes)`; or `ssl=true` in connection string |
+| Password / ACL / IAM auth | All supported. IAM config requires TLS. |
+| PubSub | Static (in config) + dynamic (2.3+); sharded cluster-only |
+| Batching | `Batch` / `ClusterBatch` with atomic (MULTI/EXEC) and non-atomic (pipeline) modes |
+| OpenTelemetry | Traces + metrics via `OpenTelemetry.Init(...)` before creating clients |
+| AZ Affinity | `ReadFromStrategy.AzAffinity` + `WithReadFrom(new ReadFrom(strategy, "us-east-1a"))` |
+| Compression | Zstd / LZ4 via `CompressionConfig` on builder |
+| Lazy connect | `.WithLazyConnect(true)` |
+| RESP2 / RESP3 | RESP3 default; PubSub static subscriptions require RESP3 |

--- a/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-overview.md
+++ b/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-overview.md
@@ -86,7 +86,7 @@ catch (GlideException ex)        { /* catch-all */ }
 | Standalone + Cluster | Both via `GlideClient` / `GlideClusterClient` or `ConnectionMultiplexer` facade |
 | TLS / mTLS | Builder `.WithTls()` + optional `.WithRootCertificate(bytes)`; or `ssl=true` in connection string |
 | Password / ACL / IAM auth | All supported. IAM config requires TLS. |
-| PubSub | Static (in config) + dynamic (2.3+); sharded cluster-only |
+| PubSub | Static (in config) + dynamic; sharded cluster-only |
 | Batching | `Batch` / `ClusterBatch` with atomic (MULTI/EXEC) and non-atomic (pipeline) modes |
 | OpenTelemetry | Traces + metrics via `OpenTelemetry.Init(...)` before creating clients |
 | AZ Affinity | `ReadFromStrategy.AzAffinity` + `WithReadFrom(new ReadFrom(strategy, "us-east-1a"))` |

--- a/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-pubsub.md
+++ b/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-pubsub.md
@@ -6,7 +6,7 @@ Use when working with publish/subscribe. Covers what differs from StackExchange.
 
 | StackExchange.Redis | GLIDE C# |
 |---------------------|---------|
-| `var sub = mux.GetSubscriber(); sub.Subscribe(ch, (ch, msg) => ...)` | Either static config in builder (`WithPubSubSubscriptionConfig`) OR dynamic `await client.SubscribeAsync(ch, timeout)` (GLIDE 2.3+) |
+| `var sub = mux.GetSubscriber(); sub.Subscribe(ch, (ch, msg) => ...)` | Either static config in builder (`WithPubSubSubscriptionConfig`) OR dynamic `await client.SubscribeAsync(ch, timeout)`  |
 | `sub.Publish(channel, message)` | `await client.PublishAsync(channel, message)` - **SAME ORDER** (Python/Node GLIDE reverse it; C# does NOT) |
 | `RedisChannel.Literal("ch")`, `RedisChannel.Pattern("p:*")` | Channel passed as `ValkeyKey` / string; pattern via separate `PSubscribeAsync` method |
 | `ChannelMessageQueue` async iteration | Callback on config OR poll via `GetPubSubMessageAsync` / `TryGetPubSubMessage` |

--- a/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-pubsub.md
+++ b/skills/valkey-glide-csharp/skills/valkey-glide-csharp/reference/features-pubsub.md
@@ -1,10 +1,22 @@
 # Pub/Sub (C#)
 
-Use when implementing real-time message broadcasting in C# - chat, notifications, event distribution, or live data feeds. For durable message processing with consumer groups, use Streams instead.
+Use when working with publish/subscribe. Covers what differs from StackExchange.Redis's `mux.GetSubscriber().Subscribe(channel, handler)` pattern.
 
-GLIDE C# supports all three PubSub subscription modes with full async/await, dynamic subscribe/unsubscribe, callback-based message delivery, and automatic reconnection with resubscription.
+## Divergence from StackExchange.Redis
 
-## Subscription Modes
+| StackExchange.Redis | GLIDE C# |
+|---------------------|---------|
+| `var sub = mux.GetSubscriber(); sub.Subscribe(ch, (ch, msg) => ...)` | Either static config in builder (`WithPubSubSubscriptionConfig`) OR dynamic `await client.SubscribeAsync(ch, timeout)` (GLIDE 2.3+) |
+| `sub.Publish(channel, message)` | `await client.PublishAsync(channel, message)` - **SAME ORDER** (Python/Node GLIDE reverse it; C# does NOT) |
+| `RedisChannel.Literal("ch")`, `RedisChannel.Pattern("p:*")` | Channel passed as `ValkeyKey` / string; pattern via separate `PSubscribeAsync` method |
+| `ChannelMessageQueue` async iteration | Callback on config OR poll via `GetPubSubMessageAsync` / `TryGetPubSubMessage` |
+| `ISubscriber.SubscribedEndpoint()` | `client.GetSubscriptionsAsync()` returning `PubSubState` with `Desired` / `Actual` maps |
+| Manual resubscribe on reconnect | Automatic via synchronizer |
+| Sharded pub/sub | `SSubscribeAsync` / `SPublishAsync` on `GlideClusterClient` only (Valkey 7.0+) |
+
+The subscribing client multiplexes subscriptions alongside regular commands - it does NOT enter a "special mode" (unlike raw Redis protocol clients). A dedicated client for high-volume subscribers is still recommended to avoid head-of-line effects.
+
+## Subscription modes
 
 | Mode | Methods | Description | Cluster Only |
 |------|---------|-------------|--------------|
@@ -102,7 +114,7 @@ long receivers = await client.PublishAsync("events", "Hello subscribers!");
 long receivers = await clusterClient.SPublishAsync("shard-topic", "Hello shard!");
 ```
 
-Always use a separate client for publishing - a subscribing client enters a special mode.
+A dedicated subscriber client is recommended for high-volume subscriptions but not required - GLIDE multiplexes subscriptions alongside commands on the core side.
 
 ## Subscription Introspection
 
@@ -129,7 +141,7 @@ Cluster clients also have `PubSubShardChannelsAsync()` and `PubSubShardNumSubAsy
 
 ## Important Notes
 
-1. **Separate clients for pub and sub.** A subscribing client cannot execute regular commands.
+1. **Dedicated subscriber client recommended** but not required - the subscribing client CAN still run regular commands (GLIDE multiplexes).
 2. **RESP3 required.** PubSub push notifications need RESP3 (the default protocol).
 3. **Automatic reconnection.** On disconnect, GLIDE resubscribes to all desired channels automatically.
 4. **Message loss during reconnect.** PubSub is at-most-once delivery. Use Streams for durability.


### PR DESCRIPTION
## Summary

Two-pass validation of `valkey-glide-csharp` and `migrate-stackexchange` against Valkey GLIDE C# at **v1.0.0** (separate repo [valkey-io/valkey-glide-csharp](https://github.com/valkey-io/valkey-glide-csharp)). Applied the divergence-only skill-writing rule.

## Size

- `valkey-glide-csharp`: 411 -> 447 lines (slight growth for method-name correctness section), plugin 2.0.0 -> 2.1.0
- `migrate-stackexchange`: 348 -> 320 lines (8% cut), plugin 1.0.0 -> 1.1.0

The skill grew slightly because the old content was mostly fabricated method names (e.g. `StringSetAsync`, `ListPushAsync`) and had to be replaced with the actual API surface. Total content accuracy went way up.

## Pass-2 correctness fixes - MAJOR (multiple fabrications found)

### 1. C# IS GA AT v1.0.0 - not preview

The skill said "preview" throughout. The repo has tag `v1.0.0`. Corrected everywhere.

### 2. PUBLISH ARGUMENT ORDER IS NOT REVERSED IN C#

Like Go, C# matches the Redis / StackExchange.Redis convention: `PublishAsync(channel, message)`. Python and Node GLIDE reverse it; C# does NOT. Source: `Client/BaseClient.PubSubCommands.cs`:

```csharp
public async Task<long> PublishAsync(ValkeyKey channel, ValkeyValue message)
```

Updated SKILL.md, migrate-stackexchange, and memory accordingly. Reversed-publish is Python + Node specific only.

### 3. METHOD NAMES WERE MOSTLY FABRICATED

Old skill claimed `StringSetAsync`, `StringGetAsync`, `ListPushAsync`, `ListPopAsync`, `HyperLogLogLengthAsync`. ACTUAL API is SE.Redis-compatible by design:

- **`SetAsync` / `GetAsync`** (NOT `StringSetAsync`/`StringGetAsync` - `String*` prefix dropped here)
- **`ListLeftPushAsync` / `ListRightPushAsync`** (NOT `ListPushAsync`)
- **`ListLeftPopAsync` / `ListRightPopAsync`** (NOT `ListPopAsync`)
- `HashSetAsync` / `HashGetAsync` - unchanged (SE.Redis parity)
- `SortedSetAddAsync` / `SetAddAsync` / `StreamAddAsync` - unchanged
- `StringSetBitAsync` / `StringGetBitAsync` / `StringBitCountAsync` - these KEEP the `String*` prefix (matching SE.Redis's bitmap-command convention)

Source: `sources/Valkey.Glide/Client/BaseClient.*Commands.cs`.

### 4. ERROR CLASSES NESTED IN `Errors` STATIC CLASS

Old skill used `ConnectionException`, `TimeoutException`, `ValkeyException`. Actual hierarchy from `Errors.cs`:

```csharp
public static class Errors
{
    public abstract class GlideException : Exception { }      // base
    public sealed class RequestException : GlideException { }
    public sealed class ValkeyServerException : GlideException { }  // NOT ValkeyException
    public sealed class ExecAbortException : GlideException { }
    public sealed class TimeoutException : GlideException { }
    public sealed class ConnectionException : GlideException { }
    public sealed class ConfigurationError : GlideException { }  // "Error" suffix (inconsistent)
}
```

Added the "Error" vs "Exception" suffix inconsistency as an explicit gotcha.

### 5. ValkeyKey / ValkeyValue primitive wrapper types

Old migration skill claimed "GLIDE uses plain strings for keys and values". Actual: `ValkeyKey` and `ValkeyValue` - direct `RedisKey` / `RedisValue` analogues with the same implicit conversions from `string` / `byte[]`. Migration is a mechanical find/replace. Corrected.

### 6. `ConnectionMultiplexer` facade + `IDatabase` ARE supported

Old migration skill said "No `IDatabase` layer". The repo has `sources/Valkey.Glide/Abstract/` with `ConnectionMultiplexer.cs`, `IConnectionMultiplexer.cs`, `Database.cs`, `IBatch.cs` - a full SE.Redis-compatible facade. Rewrote around "two entry points: facade OR GLIDE-native builder".

### 7. Subscribing client does NOT enter a "special mode"

Multiple files claimed subscribers can't run regular commands. GLIDE multiplexes subscriptions alongside commands on the core side - same as every other language. Corrected.

### 8. Batch API confirmed at v1.0.0

Old migration skill said "C# Batch API is in development". `sources/Valkey.Glide/Pipeline/` is present with `Batch`, `ClusterBatch`, `IBatch`, `BatchRetryStrategy`, `ClusterBatchOptions`. Added proper transaction migration pattern.

## Pass-1 editorial

- SKILL.md rewritten with multiplexer-first framing and 10-point C#-specific grep hazards
- features-connection.md rewritten around the facade-vs-native split
- features-overview.md rewritten with accurate method-naming table and full error hierarchy diagram
- features-pubsub.md rewritten with divergence-from-SE.Redis table
- migrate-stackexchange SKILL.md rewritten with comprehensive divergence table including the "SAME ORDER" positive call-out for `publish`
- api-mapping.md rewritten around SE.Redis-compat naming: 80%+ of method names are literally identical, only GET/SET drop the `String*` prefix
- advanced-patterns.md rewritten around Batch API with WATCH, Pub/Sub switch, fire-and-forget removal, and a facade-vs-native decision table

## Verified against v1.0.0 source via GitHub API

- `Errors.cs` class hierarchy: nested in static `Errors`, with abstract `GlideException` base and sealed `RequestException`, `ValkeyServerException`, `ExecAbortException`, `TimeoutException`, `ConnectionException`, `ConfigurationError`
- `BaseClient.PubSubCommands.cs`: `PublishAsync(ValkeyKey channel, ValkeyValue message)`, plus full dynamic pubsub API (`SubscribeAsync`/`SubscribeLazyAsync`, `PSubscribeAsync`/`PSubscribeLazyAsync`, `UnsubscribeAsync`/`UnsubscribeLazyAsync`, `PUnsubscribeAsync`/`PUnsubscribeLazyAsync`, with `SSubscribe*` on `GlideClusterClient` only)
- `BaseClient.StringCommands.cs`: `SetAsync` / `GetAsync` / `GetSetAsync` / `SetRangeAsync` / `GetRangeAsync` etc.
- `BaseClient.ListCommands.cs`: `ListLeftPushAsync` / `ListRightPushAsync` / `ListLeftPopAsync` / `ListRightPopAsync`
- `BaseClient.HashCommands.cs`: `HashGetAsync` / `HashSetAsync` / `HashSetIfNotExistsAsync` / `HashDeleteAsync` with matching SE.Redis signatures
- `GlideClient.cs`: `public static async Task<GlideClient> CreateClient(StandaloneClientConfiguration config)`
- `ConnectionConfiguration.cs`: `RetryStrategy(numberOfRetries, factor, exponentBase, jitterPercent)`, `ReadFrom(ReadFromStrategy, string? az)`, `StandaloneClientConfigurationBuilder`, `ClusterClientConfigurationBuilder`, `CompressionConfig` on base, `LazyConnect` flag, `RefreshTopologyFromInitialNodes`, `PubSubReconciliationInterval`
- `Abstract/ConnectionMultiplexer.cs`, `Abstract/IConnectionMultiplexer.cs`, `Abstract/Database.cs`, `Abstract/IBatch.cs` confirm the SE.Redis facade
- `Pipeline/` directory confirms `Batch`, `ClusterBatch`, `IBatch`, batch options types

## Test plan

- [x] All 3 C# reference files read end-to-end
- [x] Both migration files read end-to-end
- [x] Pass 1: general source verification via GitHub API
- [x] Pass 2: caught 8 real fabrications pass 1 missed (preview vs GA, method names, error classes, key types, facade, special-mode claim, batch status)
- [x] Cross-file consistency: method names, error types, publish-same-order claim
- [ ] Ecosystem reviewers (Gemini, Cursor Bugbot)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to skill/documentation content, but incorrect guidance could still mislead migrations if any remaining API details are wrong.
> 
> **Overview**
> Rewrites the `migrate-stackexchange` and `valkey-glide-csharp` skills to be *divergence-only* and accurate against Valkey.Glide **v1.0.0 (GA)**, correcting prior “preview” claims and multiple API-shape inaccuracies.
> 
> Documentation now consistently describes the two C# entry points (SE.Redis-compatible `ConnectionMultiplexer.ConnectAsync` facade vs GLIDE-native builders), the `RedisKey`/`RedisValue` -> `ValkeyKey`/`ValkeyValue` mechanical rename, real method-name differences (notably `SetAsync`/`GetAsync` vs `String*`), `PublishAsync(channel, message)` argument order, the `Errors.*` exception hierarchy, Batch/WATCH transaction migration, and updated Pub/Sub behavior (no special subscriber mode; RESP3 requirement for static subs). Plugin versions bump to `migrate-stackexchange@1.1.0` and `valkey-glide-csharp@2.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d61725f959c3c72696cd0356f0252513d7a3556. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->