### PR TITLE
java bundle: validate against v2.3.1, apply divergence-only lens

### DIFF
--- a/skills/migrate-jedis/.claude-plugin/plugin.json
+++ b/skills/migrate-jedis/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-jedis",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use when migrating Java from Jedis to Valkey GLIDE. Covers zero-code-change compatibility layer, native CompletableFuture rewrite, PubSub, Batch API, cluster mode. Not for greenfield Java apps - use valkey-glide-java instead.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/migrate-jedis/skills/migrate-jedis/SKILL.md
+++ b/skills/migrate-jedis/skills/migrate-jedis/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: migrate-jedis
-description: "Use when migrating Java from Jedis to Valkey GLIDE. Covers zero-code-change compatibility layer, native CompletableFuture rewrite, PubSub, Batch API, cluster mode. Not for greenfield Java apps - use valkey-glide-java instead."
-version: 1.0.0
+description: "Use when migrating Java from Jedis to Valkey GLIDE. Covers zero-code-change compat layer (2.1+), native CompletableFuture rewrite, REVERSED publish() args, Batch API replaces Transaction/Pipeline, no Sentinel, FLAT error hierarchy. Not for greenfield Java - use valkey-glide-java."
+version: 1.1.0
 argument-hint: "[API or pattern to migrate]"
 ---
 
@@ -94,13 +94,18 @@ For the zero-code-change path using the Jedis compatibility layer, see the Migra
 | Command-by-command API mapping (strings, hashes, lists, sets, sorted sets, delete, exists, cluster, errors) | [api-mapping](reference/api-mapping.md) |
 | Transactions, pipelines, Pub/Sub, Spring Data Valkey alternative | [advanced-patterns](reference/advanced-patterns.md) |
 
-## Gotchas
+## Gotchas (the short list)
 
-1. **Every command returns CompletableFuture.** Call .get() for synchronous behavior.
-2. **Array args, not varargs.** Multi-key commands take String[] arrays, not varargs.
-3. **No connection pool management.** Drop JedisPool and JedisPoolConfig entirely.
-4. **Builder pattern everywhere.** Configuration, set options, and batch options all use the builder pattern.
-5. **Batch replaces Transaction and Pipeline.** Use new Batch(true) for atomic and new Batch(false) for non-atomic.
-6. **Classifier required in Maven/Gradle.** Use os-maven-plugin or osdetector-gradle-plugin. An uber JAR (GLIDE 2.3+) bundles all native libraries.
-7. **Compatibility layer gotchas.** After calling `multi()`, use the returned `Transaction` object. `HashSet<byte[]>` operations degrade to O(n) because `byte[].hashCode()` returns identity hash.
-8. **No Sentinel support.** GLIDE does not support Redis Sentinel - use cluster mode or direct connection.
+1. **`publish()` argument order is REVERSED.** Jedis is `jedis.publish(channel, message)`; GLIDE Java is `client.publish(message, channel).get()`. **Silent bug factory during migration** - code compiles and runs but publishes to the wrong channel. Verified in `java/client/.../commands/PubSubBaseCommands.java:54`.
+2. **Every command returns `CompletableFuture<T>`.** Call `.get(timeout, TimeUnit)` for synchronous behavior - never bare `.get()` (can block indefinitely on a bad connection).
+3. **Array args, not varargs.** Multi-key commands take `String[]` arrays. `jedis.del("k1", "k2")` -> `client.del(new String[]{"k1", "k2"}).get()`.
+4. **No connection pool management.** Drop `JedisPool` and `JedisPoolConfig` entirely. Multiplexer is the pool. Blocking commands (`blpop`, `brpop`, `blmove`, `bzpopmax`/`min`, `brpoplpush`, `blmpop`, `bzmpop`, `xread`/`xreadgroup` with block) and WATCH/MULTI/EXEC need a dedicated client.
+5. **Builder pattern everywhere.** Lombok `@Builder` on config, set options, batch options. `GlideClientConfiguration.builder()...build()`.
+6. **Batch replaces both Transaction and Pipeline.** `new Batch(true)` for atomic (replaces `jedis.multi()`), `new Batch(false)` for pipeline. Same class, `isAtomic` flag.
+7. **Classifier required in Maven / Gradle.** Use `os-maven-plugin` (Maven) or `osdetector-gradle-plugin` (Gradle) to pick the right native library. **Uber JAR (GLIDE 2.3+)** bundles all platform natives - preferred for projects that ship cross-platform.
+8. **Jedis compatibility layer has edge cases.** After calling `.multi()` on the compat-wrapped client, use the returned `Transaction` object (not the underlying client). `HashSet<byte[]>` operations degrade to O(n) because `byte[].hashCode()` uses identity hash - prefer `GlideString` or the native Batch API for byte-key workloads.
+9. **No Sentinel support** in GLIDE. Migrate Sentinel users to cluster mode or direct primary/replica connection.
+10. **Error hierarchy is FLAT under `GlideException`.** Jedis's `JedisException` tree maps to GLIDE's 6 siblings: `ClosingException`, `ConnectionException`, `ConfigurationError` (Error suffix, inconsistent), `ExecAbortException`, `RequestException`, `TimeoutException`. All inside `ExecutionException` when unwrapping `.get()`.
+11. **GLIDE `TimeoutException` vs `java.util.concurrent.TimeoutException`** - two different classes with the same simple name. Fully-qualify or alias on import.
+12. **Reconnection is infinite.** No `MaxRetries` equivalent; `BackoffStrategy.numOfRetries` caps backoff sequence length only. Commands fail with `ConnectionException` while reconnecting.
+13. **No Alpine / MUSL support** - glibc 2.17+ required. Use Debian-based images.

--- a/skills/migrate-jedis/skills/migrate-jedis/SKILL.md
+++ b/skills/migrate-jedis/skills/migrate-jedis/SKILL.md
@@ -96,10 +96,10 @@ For the zero-code-change path using the Jedis compatibility layer, see the Migra
 
 ## Gotchas (the short list)
 
-1. **`publish()` argument order is REVERSED.** Jedis is `jedis.publish(channel, message)`; GLIDE Java is `client.publish(message, channel).get()`. **Silent bug factory during migration** - code compiles and runs but publishes to the wrong channel. Verified in `java/client/.../commands/PubSubBaseCommands.java:54`.
+1. **`publish()` argument order is REVERSED.** Jedis is `jedis.publish(channel, message)`; GLIDE Java is `client.publish(message, channel).get()`. **Silent bug factory during migration** - code compiles and runs but publishes to the wrong channel. Verified in `java/client/.../commands/PubSubBaseCommands.java`.
 2. **Every command returns `CompletableFuture<T>`.** Call `.get(timeout, TimeUnit)` for synchronous behavior - never bare `.get()` (can block indefinitely on a bad connection).
 3. **Array args, not varargs.** Multi-key commands take `String[]` arrays. `jedis.del("k1", "k2")` -> `client.del(new String[]{"k1", "k2"}).get()`.
-4. **No connection pool management.** Drop `JedisPool` and `JedisPoolConfig` entirely. Multiplexer is the pool. Blocking commands (`blpop`, `brpop`, `blmove`, `bzpopmax`/`min`, `brpoplpush`, `blmpop`, `bzmpop`, `xread`/`xreadgroup` with block) and WATCH/MULTI/EXEC need a dedicated client.
+4. **No connection pool management.** Drop `JedisPool` and `JedisPoolConfig` entirely. Multiplexer is the pool. Blocking commands (`blpop`, `brpop`, `blmove`, `bzpopmax`, `bzpopmin`, `brpoplpush`, `blmpop`, `bzmpop`, `xread`/`xreadgroup` with block, `wait`/`waitaof`) need a dedicated client due to **occupancy**. WATCH/MULTI/EXEC need a dedicated client due to **connection-state leakage**.
 5. **Builder pattern everywhere.** Lombok `@Builder` on config, set options, batch options. `GlideClientConfiguration.builder()...build()`.
 6. **Batch replaces both Transaction and Pipeline.** `new Batch(true)` for atomic (replaces `jedis.multi()`), `new Batch(false)` for pipeline. Same class, `isAtomic` flag.
 7. **Classifier required in Maven / Gradle.** Use `os-maven-plugin` (Maven) or `osdetector-gradle-plugin` (Gradle) to pick the right native library. **Uber JAR (GLIDE 2.3+)** bundles all platform natives - preferred for projects that ship cross-platform.

--- a/skills/migrate-lettuce/.claude-plugin/plugin.json
+++ b/skills/migrate-lettuce/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-lettuce",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use when migrating Java from Lettuce to Valkey GLIDE. Covers Spring Data Valkey path, native rewrite from RedisFuture to CompletableFuture, PubSub, no reactive API or codec equivalent. Not for Jedis migration - use migrate-jedis instead.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/migrate-lettuce/skills/migrate-lettuce/SKILL.md
+++ b/skills/migrate-lettuce/skills/migrate-lettuce/SKILL.md
@@ -89,11 +89,11 @@ For native migration, the key steps:
 
 ## Gotchas (the short list)
 
-1. **`publish()` argument order is REVERSED.** Lettuce is `redis.async().publish(channel, message)`; GLIDE Java is `client.publish(message, channel).get()`. **Silent bug factory during migration.** Verified in `java/client/.../commands/PubSubBaseCommands.java:54`.
+1. **`publish()` argument order is REVERSED.** Lettuce is `redis.async().publish(channel, message)`; GLIDE Java is `client.publish(message, channel).get()`. **Silent bug factory during migration.** Verified in `java/client/.../commands/PubSubBaseCommands.java`.
 2. **No reactive API.** Lettuce offers Project Reactor (`Flux` / `Mono`). GLIDE only provides `CompletableFuture`. Adapt with `Mono.fromFuture(client.get(key))`. Significant for Spring WebFlux - the reactive `ReactiveRedisTemplate` / `ReactiveValueOperations` is only available via Lettuce in Spring Data Valkey today.
 3. **No codec system.** Lettuce `RedisCodec<K, V>` has no equivalent. Handle serialization manually or use `GlideString` for binary-safe bytes.
 4. **`hset("hash", "field", "value")` variadic form** in Lettuce takes 3 strings; GLIDE takes a `Map<String, String>` or an array of `String[]` pairs via overloads. Always check signature.
-5. **Array args for multi-element commands** - `lpush`, `rpush`, `sadd`, `srem`, etc. take `String[]` arrays instead of varargs.
+5. **Array args for multi-element commands** - `lpush`, `rpush`, `sadd`, `srem`, `del`, `exists` take `String[]` arrays instead of varargs.
 6. **No `ClientResources` / thread-pool configuration.** GLIDE Rust core manages its own threading.
 7. **Simpler connection lifecycle** - no separate `StatefulConnection` + `Commands` layers. Call commands directly on the client.
 8. **Multi-arch native library distribution.** Use `osdetector-gradle-plugin` or `os-maven-plugin`. **Uber JAR (GLIDE 2.3+)** bundles all platform natives - preferred for cross-platform projects.

--- a/skills/migrate-lettuce/skills/migrate-lettuce/SKILL.md
+++ b/skills/migrate-lettuce/skills/migrate-lettuce/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: migrate-lettuce
-description: "Use when migrating Java from Lettuce to Valkey GLIDE. Covers Spring Data Valkey path, native rewrite from RedisFuture to CompletableFuture, PubSub, no reactive API or codec equivalent. Not for Jedis migration - use migrate-jedis instead."
-version: 1.0.0
+description: "Use when migrating Java from Lettuce to Valkey GLIDE. Covers Spring Data Valkey path, native rewrite from RedisFuture to CompletableFuture, REVERSED publish() args, no reactive API, no codec, no Sentinel. Not for Jedis migration - use migrate-jedis."
+version: 1.1.0
 argument-hint: "[API or pattern to migrate]"
 ---
 
@@ -87,13 +87,18 @@ For native migration, the key steps:
 | Command-by-command API mapping (strings, hashes, lists, sets, sorted sets, delete, exists, cluster) | [api-mapping](reference/api-mapping.md) |
 | Transactions, pipelines, Pub/Sub, Spring Data Valkey alternative, compatibility layer status | [advanced-patterns](reference/advanced-patterns.md) |
 
-## Gotchas
+## Gotchas (the short list)
 
-1. **No reactive API.** Lettuce offers Project Reactor support (Flux/Mono). GLIDE only provides CompletableFuture. Adapt with `Mono.fromFuture()`. Significant for Spring WebFlux - the reactive `ReactiveRedisTemplate` is only available with Lettuce in Spring Data Valkey.
-2. **No codec system.** Lettuce RedisCodec has no equivalent. Handle serialization manually.
-3. **Single-field hset.** Lettuce hset("hash", "field", "value") takes three string args. GLIDE always takes a Map.
-4. **Array args for lists.** Multi-element commands like lpush, rpush, sadd take String[] arrays instead of varargs.
-5. **No ClientResources.** Lettuce ClientResources for thread pool configuration has no equivalent. GLIDE Rust core manages its own threading.
-6. **Simpler connection lifecycle.** No separate StatefulConnection and Commands objects.
-7. **Multi-arch native library distribution.** Use `osdetector-gradle-plugin` or `os-maven-plugin`. Uber JAR available from GLIDE 2.3.
-8. **No Sentinel support.** Use cluster mode or direct connection instead.
+1. **`publish()` argument order is REVERSED.** Lettuce is `redis.async().publish(channel, message)`; GLIDE Java is `client.publish(message, channel).get()`. **Silent bug factory during migration.** Verified in `java/client/.../commands/PubSubBaseCommands.java:54`.
+2. **No reactive API.** Lettuce offers Project Reactor (`Flux` / `Mono`). GLIDE only provides `CompletableFuture`. Adapt with `Mono.fromFuture(client.get(key))`. Significant for Spring WebFlux - the reactive `ReactiveRedisTemplate` / `ReactiveValueOperations` is only available via Lettuce in Spring Data Valkey today.
+3. **No codec system.** Lettuce `RedisCodec<K, V>` has no equivalent. Handle serialization manually or use `GlideString` for binary-safe bytes.
+4. **`hset("hash", "field", "value")` variadic form** in Lettuce takes 3 strings; GLIDE takes a `Map<String, String>` or an array of `String[]` pairs via overloads. Always check signature.
+5. **Array args for multi-element commands** - `lpush`, `rpush`, `sadd`, `srem`, etc. take `String[]` arrays instead of varargs.
+6. **No `ClientResources` / thread-pool configuration.** GLIDE Rust core manages its own threading.
+7. **Simpler connection lifecycle** - no separate `StatefulConnection` + `Commands` layers. Call commands directly on the client.
+8. **Multi-arch native library distribution.** Use `osdetector-gradle-plugin` or `os-maven-plugin`. **Uber JAR (GLIDE 2.3+)** bundles all platform natives - preferred for cross-platform projects.
+9. **Error hierarchy is FLAT under `GlideException`.** Lettuce's `RedisException` -> `RedisCommandExecutionException` / `RedisCommandTimeoutException` / `RedisConnectionException` subclass tree maps to GLIDE's 6 siblings: `ClosingException`, `ConnectionException`, `ConfigurationError` (note "Error" suffix), `ExecAbortException`, `RequestException`, `TimeoutException`. All come inside `ExecutionException` when unwrapping `.get()`.
+10. **GLIDE `TimeoutException` vs `java.util.concurrent.TimeoutException`** - two different classes with the same simple name; the former is the internal request timeout, the latter is what `.get(n, TimeUnit)` throws when the future doesn't resolve in time. Fully-qualify or alias.
+11. **No Sentinel support** in GLIDE. Migrate Sentinel users to cluster mode or direct primary/replica connection.
+12. **Reconnection is infinite.** No `maxRedirects` / reconnect-cap equivalent - `BackoffStrategy.numOfRetries` caps backoff sequence length only.
+13. **No Alpine / MUSL support** - glibc 2.17+ required.

--- a/skills/valkey-glide-java/.claude-plugin/plugin.json
+++ b/skills/valkey-glide-java/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "valkey-glide-java",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Use when building Java apps with Valkey GLIDE - CompletableFuture API, GlideClient, GlideClusterClient, Batch, TLS, OpenTelemetry, streams, Lua scripting. Not for Jedis/Lettuce migration - use migrate-jedis or migrate-lettuce skill.",
   "author": {
     "name": "Avi Fenesh",

--- a/skills/valkey-glide-java/skills/valkey-glide-java/SKILL.md
+++ b/skills/valkey-glide-java/skills/valkey-glide-java/SKILL.md
@@ -28,15 +28,15 @@ One `GlideClient` / `GlideClusterClient` per JVM. Shared across every thread / C
 
 **Exceptions that need a dedicated client:**
 
-- Blocking commands: `blpop`, `brpop`, `blmove`, `bzpopmax`, `bzpopmin`, `brpoplpush`, `blmpop`, `bzmpop`, plus `xread` / `xreadgroup` with block, and `wait` / `waitaof`.
-- `watch` / `multi` / `exec` (atomic batch after WATCH) - connection-state commands.
-- Long polling `getPubSubMessage()` - holds the future indefinitely.
+- Blocking commands (dedicated client due to **occupancy** - they hold the multiplexed connection for the block duration): `blpop`, `brpop`, `blmove`, `bzpopmax`, `bzpopmin`, `brpoplpush`, `blmpop`, `bzmpop`, plus `xread` / `xreadgroup` with block, and `wait` / `waitaof`.
+- Transactional commands (dedicated client due to **connection-state leakage** across callers on the shared multiplexer): `watch` / `multi` / `exec` (atomic batch after WATCH).
+- Long polling `getPubSubMessage()` - holds the future indefinitely (occupancy).
 
 Large values are NOT an exception - they pipeline through the multiplexer fine.
 
 ## Grep hazards
 
-1. **`publish(message, channel)` - REVERSED from Jedis / Lettuce.** Java matches the Python/Node reversed pattern. `client.publish("message", "channel").get()` - message first, channel second. Jedis is `publish(channel, message)`; Lettuce is `publish(channel, message)`. **Silent bug factory during migration.** Go and C# GLIDE match the legacy convention; Python, Node, and Java GLIDE reverse it. Source: `java/client/.../commands/PubSubBaseCommands.java:54` `CompletableFuture<String> publish(String message, String channel);`.
+1. **`publish(message, channel)` - REVERSED from Jedis / Lettuce.** Java matches the Python/Node reversed pattern. `client.publish("message", "channel").get()` - message first, channel second. Jedis is `publish(channel, message)`; Lettuce is `publish(channel, message)`. **Silent bug factory during migration.** Go and C# GLIDE match the legacy convention; Python, Node, and Java GLIDE reverse it. Source: `java/client/.../commands/PubSubBaseCommands.java` `CompletableFuture<String> publish(String message, String channel);`.
 2. **Java uses direct JNI, NOT UDS.** Migrated from UDS to direct JNI in GLIDE 2.2 for Windows support. UDS is Python-async and Node.js ONLY; Java, Go, Python-sync, C#, PHP, Ruby are all direct-FFI. Do not describe Java as UDS-backed.
 3. **Every command returns `CompletableFuture<T>`.** Unwrap with `.get(timeout, TimeUnit)` - never bare `.get()` (blocks indefinitely if the connection has issues).
 4. **Errors come via `ExecutionException` from `.get()`.** Unwrap via `.getCause()` and `instanceof` check against specific `GlideException` subclasses.

--- a/skills/valkey-glide-java/skills/valkey-glide-java/SKILL.md
+++ b/skills/valkey-glide-java/skills/valkey-glide-java/SKILL.md
@@ -1,26 +1,58 @@
 ---
 name: valkey-glide-java
-description: "Use when building Java apps with Valkey GLIDE - CompletableFuture API, GlideClient, GlideClusterClient, Batch, TLS, OpenTelemetry, streams, Lua scripting. Not for Jedis/Lettuce migration - use migrate-jedis or migrate-lettuce skill."
-version: 2.0.0
+description: "Use when building Java apps with Valkey GLIDE - CompletableFuture API, Lombok builder pattern, GlideClient, GlideClusterClient, multiplexer behavior, direct-JNI binding (NOT UDS), Batch, PubSub, streams, OpenTelemetry. Covers the divergence from Jedis / Lettuce; basic command shapes are assumed knowable from training. Not for Jedis/Lettuce migration - use migrate-jedis or migrate-lettuce."
+version: 2.1.0
 argument-hint: "[API or config question]"
 ---
 
 # Valkey GLIDE Java Client
 
+Agent-facing skill for GLIDE Java. Assumes the reader can already write basic Jedis or Lettuce from training (Jedis synchronous commands, Lettuce's `RedisAsyncCommands`, `RedisFuture`, or reactive `RedisReactiveCommands`). Covers only what diverges and what GLIDE adds on top.
+
 ## Routing
 
 | Question | Reference |
 |----------|-----------|
-| Install, setup, client creation, TLS, auth, reconnect | [connection](reference/features-connection.md) |
-| PubSub, subscribe, publish, sharded channels | [pubsub](reference/features-pubsub.md) |
-| Batching, transactions, pipelines | [batching](reference/features-batching.md) |
-| Streams, consumer groups, XADD, XREAD | [streams](reference/features-streams.md) |
-| TLS details, auth (password/IAM), Lua scripting, Valkey functions, error types, CompletableFuture, custom commands, OTel | [advanced](reference/features-advanced.md) |
-| Error types, retry, reconnection patterns | [error-handling](reference/best-practices-error-handling.md) |
-| Benchmarks, throughput, batching perf | [performance](reference/best-practices-performance.md) |
-| Timeouts, connection management, AZ affinity, OTel setup, cloud defaults | [production](reference/best-practices-production.md) |
+| `GlideClient` vs `GlideClusterClient`, Lombok builders, TLS, auth, IAM, lazy connect, AZ affinity, `AutoCloseable` | [connection](reference/features-connection.md) |
+| PubSub: static subscription config vs runtime `subscribe`, callback vs polling, `publish(message, channel)` REVERSED args, sharded | [pubsub](reference/features-pubsub.md) |
+| `Batch` / `ClusterBatch` with `isAtomic` constructor, `BatchOptions`, retry strategy, WATCH | [batching](reference/features-batching.md) |
+| Stream typed options, `StreamRange` bounds, split `xclaim` / `xclaimJustId`, cluster multi-stream slot constraint | [streams](reference/features-streams.md) |
+| TLS advanced config, IAM, `Script` + `invokeScript`, Valkey Functions, custom commands, OTel | [advanced](reference/features-advanced.md) |
+| Error types: `GlideException` base + 6 siblings (FLAT hierarchy), `ExecutionException` unwrap rule, `ConfigurationError` "Error" suffix | [error-handling](reference/best-practices-error-handling.md) |
+| Multiplexer discipline, batching as top optimization, inflight cap, CompletableFuture composition | [performance](reference/best-practices-performance.md) |
+| Production defaults, timeout tuning, AZ affinity, OTel setup, JVM and glibc constraints | [production](reference/best-practices-production.md) |
 
-## Cross-References
+## Multiplexer rule (the #1 agent mistake)
 
-- `valkey-glide` skill - shared architecture, cluster topology, connection model
-- `valkey` skill - Valkey server commands, data types, patterns
+One `GlideClient` / `GlideClusterClient` per JVM. Shared across every thread / CompletableFuture chain. Do not create per-request clients. Do not pool them.
+
+**Exceptions that need a dedicated client:**
+
+- Blocking commands: `blpop`, `brpop`, `blmove`, `bzpopmax`, `bzpopmin`, `brpoplpush`, `blmpop`, `bzmpop`, plus `xread` / `xreadgroup` with block, and `wait` / `waitaof`.
+- `watch` / `multi` / `exec` (atomic batch after WATCH) - connection-state commands.
+- Long polling `getPubSubMessage()` - holds the future indefinitely.
+
+Large values are NOT an exception - they pipeline through the multiplexer fine.
+
+## Grep hazards
+
+1. **`publish(message, channel)` - REVERSED from Jedis / Lettuce.** Java matches the Python/Node reversed pattern. `client.publish("message", "channel").get()` - message first, channel second. Jedis is `publish(channel, message)`; Lettuce is `publish(channel, message)`. **Silent bug factory during migration.** Go and C# GLIDE match the legacy convention; Python, Node, and Java GLIDE reverse it. Source: `java/client/.../commands/PubSubBaseCommands.java:54` `CompletableFuture<String> publish(String message, String channel);`.
+2. **Java uses direct JNI, NOT UDS.** Migrated from UDS to direct JNI in GLIDE 2.2 for Windows support. UDS is Python-async and Node.js ONLY; Java, Go, Python-sync, C#, PHP, Ruby are all direct-FFI. Do not describe Java as UDS-backed.
+3. **Every command returns `CompletableFuture<T>`.** Unwrap with `.get(timeout, TimeUnit)` - never bare `.get()` (blocks indefinitely if the connection has issues).
+4. **Errors come via `ExecutionException` from `.get()`.** Unwrap via `.getCause()` and `instanceof` check against specific `GlideException` subclasses.
+5. **Error hierarchy is FLAT under `GlideException`.** No nested subclass tree like Python/Node. `GlideException extends RuntimeException` (not abstract). Direct children: `ClosingException`, `ConnectionException`, `ConfigurationError` (note "Error" suffix - inconsistency), `ExecAbortException`, `RequestException`, `TimeoutException`. No `LoggerError`.
+6. **`java.util.concurrent.TimeoutException` vs GLIDE's `TimeoutException`** - two different classes with the same simple name. `.get(n, TimeUnit.MILLISECONDS)` can throw the former if the future doesn't complete in `n` ms; GLIDE's internal request timeout surfaces as the latter wrapped in `ExecutionException`. Import both with explicit packages or fully-qualified names.
+7. **`GlideString` binary type** - methods often have `String` and `GlideString` overloads. Use `GlideString` for binary-safe bytes; `gs("...")` is the factory helper.
+8. **Lombok `@Builder` pattern** - `GlideClientConfiguration.builder().address(...).useTLS(true).build()`. Nested builders for `NodeAddress`, `ServerCredentials`, `BackoffStrategy`, `AdvancedGlideClientConfiguration`.
+9. **`AutoCloseable`** - clients implement it; use try-with-resources or call `close()` explicitly.
+10. **Jedis compatibility layer** available at `java/jedis-compatibility/` - zero-code-change drop-in for Jedis users. See `migrate-jedis` skill.
+11. **Reconnection is infinite.** `BackoffStrategy.numOfRetries` caps the backoff sequence length only.
+12. **Static PubSub subscriptions require RESP3.** Using RESP2 raises `ConfigurationError`.
+
+## Cross-references
+
+- `migrate-jedis` - migrating from Jedis (with zero-code-change compat layer option)
+- `migrate-lettuce` - migrating from Lettuce (CompletableFuture-to-CompletableFuture conversion)
+- `spring-data-valkey` - Spring Boot integration via Spring Data Valkey
+- `glide-dev` - GLIDE core internals (Rust) and JNI binding mechanics
+- `valkey` - Valkey commands and app patterns

--- a/skills/valkey-glide-java/skills/valkey-glide-java/reference/best-practices-error-handling.md
+++ b/skills/valkey-glide-java/skills/valkey-glide-java/reference/best-practices-error-handling.md
@@ -4,7 +4,7 @@ Use for retry logic and batch error semantics. Covers GLIDE-specific divergence 
 
 ## Hierarchy - FLAT under GlideException
 
-All errors extend `GlideException extends RuntimeException` directly. No multi-level subclass tree (unlike Python's `ValkeyError -> RequestError -> TimeoutError/etc.`).
+All errors extend `GlideException extends RuntimeException` directly. No multi-level subclass tree (unlike Python's `ValkeyError -> RequestError -> TimeoutError` / `ExecAbortError` / `ConnectionError` / `ConfigurationError`).
 
 ```
 GlideException extends RuntimeException         # concrete base; catch-all
@@ -12,7 +12,7 @@ GlideException extends RuntimeException         # concrete base; catch-all
 ├── ConnectionException          # network / connection issue (temporary - auto-reconnecting)
 ├── ConfigurationError           # invalid config (note "Error" suffix - inconsistent with others)
 ├── ExecAbortException           # atomic batch aborted (WATCH conflict)
-├── RequestException             # server-side / protocol error (WRONGTYPE, OOM, etc.)
+├── RequestException             # server-side / protocol error (WRONGTYPE, OOM, NOAUTH, MOVED, ASK)
 └── TimeoutException             # GLIDE request timeout
 ```
 
@@ -26,7 +26,7 @@ Every command returns `CompletableFuture<T>`. Errors from the server come back i
 
 | Error kind | When it occurs |
 |-----------|----------------|
-| `RequestException` | Server / protocol errors - WRONGTYPE, OOM, NOAUTH, etc. |
+| `RequestException` | Server / protocol errors - WRONGTYPE, OOM, NOAUTH, MOVED, ASK |
 | `TimeoutException` (GLIDE) | Request exceeded `requestTimeout` (default 250 ms) |
 | `ConnectionException` | Connection lost. Auto-reconnect in progress. |
 | `ExecAbortException` | Atomic batch aborted (WATCH key changed) |

--- a/skills/valkey-glide-java/skills/valkey-glide-java/reference/best-practices-error-handling.md
+++ b/skills/valkey-glide-java/skills/valkey-glide-java/reference/best-practices-error-handling.md
@@ -1,18 +1,37 @@
-# Error Handling
+# Error Handling (Java)
 
-Use when implementing error handling, retry logic, or batch error semantics in the GLIDE Java client.
+Use for retry logic and batch error semantics. Covers GLIDE-specific divergence from Jedis (`JedisException` hierarchy) and Lettuce (`RedisException` / `RedisCommandExecutionException`).
 
-## Error Types
+## Hierarchy - FLAT under GlideException
 
-Java GLIDE operations return `CompletableFuture`. Errors are wrapped in `ExecutionException` - always unwrap with `getCause()`.
+All errors extend `GlideException extends RuntimeException` directly. No multi-level subclass tree (unlike Python's `ValkeyError -> RequestError -> TimeoutError/etc.`).
 
-| Error | When It Occurs | Recovery |
-|-------|---------------|----------|
-| `RequestException` | Server/protocol errors | Check message for details |
-| `TimeoutException` | Request exceeded `requestTimeout` (default 250ms) | Increase timeout or check server load |
-| `ConnectionException` | Connection lost | GLIDE auto-reconnects; retry the operation |
-| `ExecAbortException` | Atomic batch aborted (WATCH key changed) | Retry the transaction |
-| `ClosingException` | Client was closed while requests pending | Create a new client |
+```
+GlideException extends RuntimeException         # concrete base; catch-all
+├── ClosingException             # client closed while requests pending
+├── ConnectionException          # network / connection issue (temporary - auto-reconnecting)
+├── ConfigurationError           # invalid config (note "Error" suffix - inconsistent with others)
+├── ExecAbortException           # atomic batch aborted (WATCH conflict)
+├── RequestException             # server-side / protocol error (WRONGTYPE, OOM, etc.)
+└── TimeoutException             # GLIDE request timeout
+```
+
+All 6 direct children are siblings at the same level. `catch (GlideException e)` catches all of them. Subclass checks are independent `instanceof` tests.
+
+**Gotcha**: `java.util.concurrent.TimeoutException` vs GLIDE's `TimeoutException` - two different classes with the same simple name. `.get(n, TimeUnit.MILLISECONDS)` throws the former if the future doesn't complete within `n` ms; GLIDE's internal request timeout surfaces as the latter wrapped in `ExecutionException`. Always fully-qualify or import with aliases.
+
+## Unwrap pattern
+
+Every command returns `CompletableFuture<T>`. Errors from the server come back inside `ExecutionException` when you call `.get()`:
+
+| Error kind | When it occurs |
+|-----------|----------------|
+| `RequestException` | Server / protocol errors - WRONGTYPE, OOM, NOAUTH, etc. |
+| `TimeoutException` (GLIDE) | Request exceeded `requestTimeout` (default 250 ms) |
+| `ConnectionException` | Connection lost. Auto-reconnect in progress. |
+| `ExecAbortException` | Atomic batch aborted (WATCH key changed) |
+| `ClosingException` | Client was closed while requests pending - create a new client |
+| `ConfigurationError` | Invalid config (TLS mismatch, RESP2+PubSub) |
 
 ## Basic Error Handling
 

--- a/skills/valkey-glide-java/skills/valkey-glide-java/reference/features-pubsub.md
+++ b/skills/valkey-glide-java/skills/valkey-glide-java/reference/features-pubsub.md
@@ -150,7 +150,7 @@ Optional<GlideString> pattern = msg.getPattern(); // pattern that matched (if pa
 
 **GOTCHA: argument order is REVERSED from Jedis / Lettuce.** Jedis is `publish(channel, message)`; Lettuce is `publish(channel, message)`; GLIDE Java is `publish(message, channel)` - message first, channel second. **Silent mis-routing during migration if you don't notice.**
 
-Source: `java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java:54` -
+Source: `java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java` -
 `CompletableFuture<String> publish(String message, String channel);`
 
 ```java

--- a/skills/valkey-glide-java/skills/valkey-glide-java/reference/features-pubsub.md
+++ b/skills/valkey-glide-java/skills/valkey-glide-java/reference/features-pubsub.md
@@ -1,24 +1,21 @@
 # Pub/Sub (Java)
 
-Use when implementing Pub/Sub messaging with GLIDE Java - subscribing to channels, receiving messages, publishing, or using sharded pub/sub in cluster mode.
+Use when working with publish/subscribe in GLIDE Java. Covers the divergence from Jedis's `jedis.subscribe(listener, channels)` blocking-thread pattern and Lettuce's `RedisPubSubCommands` / `RedisPubSubAsyncCommands`.
 
-## Contents
+## Divergence from Jedis / Lettuce
 
-- Two Subscription Models (line 19)
-- Creation-Time Subscriptions (Standalone) (line 23)
-- Creation-Time Subscriptions (Cluster) (line 53)
-- Runtime Subscribe/Unsubscribe (line 74)
-- Runtime Sharded Subscribe/Unsubscribe (Cluster Only) (line 100)
-- Receiving Messages - Callback vs Polling (line 113)
-- PubSubMessage Fields (line 143)
-- Publishing (line 152)
-- Introspection (line 162)
-- Subscription State (line 179)
-- Reconciliation (line 193)
+| Jedis / Lettuce | GLIDE Java |
+|-----------------|-----------|
+| Jedis: `jedis.subscribe(new JedisPubSub() {...}, "channel")` blocks the calling thread | Either static config on the builder OR runtime `client.subscribe(Set.of("channel"))` / `subscribe(Set.of(...), timeoutMs)` - neither blocks the calling thread |
+| Lettuce: `RedisPubSubCommands pubsub = redis.connectPubSub().sync(); pubsub.subscribe("ch")` | `client.subscribe(Set.of("ch")).get()` on the same client |
+| Jedis: `jedis.publish(channel, message)` | `client.publish(message, channel).get()` - **arguments REVERSED** compared to Jedis/Lettuce/everything else |
+| Lettuce: `redis.async().publish(channel, message)` | Same reversed order on GLIDE: message first, channel second |
+| Callback-only (Jedis) or async iterable (Lettuce reactive) | Callback configured up front on the subscription config, OR pull-model via `getPubSubMessage()` / `tryGetPubSubMessage()` |
+| Manual resubscribe on reconnect | Automatic via synchronizer; `client.getSubscriptions()` returns `PubSubState` with `getDesiredSubscriptions()` / `getActualSubscriptions()` |
+| Cluster sharded pub/sub not in Jedis base; Lettuce via `RedisClusterPubSubCommands` | `ssubscribe` / `sunsubscribe` / cluster `publish(msg, ch, true)` on `GlideClusterClient` (Valkey 7.0+) |
+| Subscribing client enters a "special mode" unable to send regular commands (Jedis/Lettuce) | GLIDE multiplexes subscriptions alongside commands - subscribing client CAN still run regular commands (dedicated client still recommended for high-throughput subscribers) |
 
-## Two Subscription Models
-
-GLIDE Java supports both creation-time subscriptions (configured in the builder) and runtime subscriptions (subscribe/unsubscribe after client creation).
+Static PubSub subscriptions require RESP3 (default). Using RESP2 raises `ConfigurationError`.
 
 ## Creation-Time Subscriptions (Standalone)
 
@@ -151,13 +148,20 @@ Optional<GlideString> pattern = msg.getPattern(); // pattern that matched (if pa
 
 ## Publishing
 
+**GOTCHA: argument order is REVERSED from Jedis / Lettuce.** Jedis is `publish(channel, message)`; Lettuce is `publish(channel, message)`; GLIDE Java is `publish(message, channel)` - message first, channel second. **Silent mis-routing during migration if you don't notice.**
+
+Source: `java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java:54` -
+`CompletableFuture<String> publish(String message, String channel);`
+
 ```java
-// Standalone and cluster
+// GLIDE: message FIRST, channel SECOND
 client.publish("Hello!", "announcements").get();
 
-// Cluster sharded publish (Valkey 7.0+)
+// Cluster sharded publish (Valkey 7.0+) - message FIRST, channel SECOND, sharded flag THIRD
 clusterClient.publish("Hello!", "shard-channel", true).get();
 ```
+
+Call out the same reversed-order gotcha in any migration from Jedis, Lettuce, or Spring Data Redis.
 
 ## Introspection
 


### PR DESCRIPTION
## Summary

Validation of the Java bundle (4 skills) against Valkey GLIDE `v2.3.1` (commit `9601a7695`), applying the divergence-only lens.

## Skills in this PR

| Skill | Version | Notes |
|-------|---------|-------|
| `valkey-glide-java` | 2.0.0 -> 2.1.0 | SKILL.md + pubsub + error-handling rewritten |
| `migrate-jedis` | 1.0.0 -> 1.1.0 | Gotchas rewritten with reversed-publish as #1 |
| `migrate-lettuce` | 1.0.0 -> 1.1.0 | Gotchas rewritten with reversed-publish as #1 |
| `spring-data-valkey` | 1.1.0 (unchanged) | Already divergence-focused |

## Pass-2 correctness fixes

### 1. `publish()` argument order IS REVERSED in Java (same as Python/Node)

Source `java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java:54`:

```java
CompletableFuture<String> publish(String message, String channel);
```

Jedis is `publish(channel, message)`. Lettuce is `publish(channel, message)`. GLIDE Java reverses it to `publish(message, channel)`. **This is a silent bug factory during migration** - code compiles and runs but publishes to the wrong channel.

Added explicit GOTCHA callouts to:
- `valkey-glide-java` SKILL.md grep hazard #1
- `features-pubsub.md` GOTCHA banner on Publishing section + full divergence-from-Jedis/Lettuce table
- `migrate-jedis` SKILL.md gotcha #1
- `migrate-lettuce` SKILL.md gotcha #1

Memory updated: reversed-publish is **Python + Node + Java**, NOT Go/C#. Not a GLIDE-wide convention.

### 2. Java uses direct JNI, NOT UDS

Explicit grep hazard. Java migrated from UDS to direct JNI in GLIDE 2.2 for Windows support. UDS is Python-async and Node.js ONLY. Java, Go, Python-sync, C#, PHP, Ruby are all direct-FFI bindings. The "UDS is in-process IPC" framing does NOT apply to Java.

### 3. Error hierarchy is FLAT under `GlideException` (not abstract, not multi-level)

Verified via direct class reads:

```
GlideException extends RuntimeException      # concrete base, catches all
├── ClosingException
├── ConnectionException
├── ConfigurationError                       # "Error" suffix - inconsistent
├── ExecAbortException
├── RequestException
└── TimeoutException
```

All 6 siblings extend `GlideException` directly. No `LoggerError` (Python has one). Unlike Python (`ValkeyError -> RequestError -> TimeoutError/etc.`) and Node (`ValkeyError -> RequestError -> ...`), there's no nested subclass tree.

Rewrote `best-practices-error-handling.md` with the flat diagram.

### 4. `java.util.concurrent.TimeoutException` vs GLIDE `TimeoutException`

Two different classes with the same simple name:
- `.get(n, TimeUnit.MILLISECONDS)` throws `java.util.concurrent.TimeoutException` if the future doesn't resolve in `n` ms
- GLIDE's internal request timeout surfaces as `glide.api.models.exceptions.TimeoutException` wrapped in `ExecutionException`

Fully-qualify imports or use aliases. Called out as grep hazard.

## Pass-1 editorial

- `valkey-glide-java` SKILL.md rewritten with multiplexer rule + 12 grep hazards (publish reversed, NOT UDS, CompletableFuture unwrap, flat error model, TimeoutException collision, GlideString, Lombok builders, AutoCloseable, jedis-compat layer, infinite reconnect, RESP3 for static subs)
- `features-pubsub.md` top divergence table covering Jedis and Lettuce both
- `migrate-jedis` SKILL.md gotcha list from 8 -> 13 items, refined with v2.3 specifics (uber JAR, FLAT errors, TimeoutException collision)
- `migrate-lettuce` SKILL.md gotcha list from 8 -> 13 items, refined with reactive-API escape hatch (`Mono.fromFuture`), codec/ClientResources gaps, FLAT error hierarchy vs Lettuce's `RedisException` tree

## Verified against v2.3.1 source

- `java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java` - `publish(String message, String channel)` REVERSED signature, full dynamic subscribe/unsubscribe API (subscribe, psubscribe, ssubscribe, unsubscribe, punsubscribe, sunsubscribe, with overloads taking `Set<String>` and optional `long timeoutMs`)
- `java/client/src/main/java/glide/api/models/exceptions/` - all 7 class files (GlideException + 6 leaves), verified `extends` relations
- `java/client/src/main/java/glide/api/BaseClient.java` - `getPubSubMessage()` / `tryGetPubSubMessage()`, `CompletableFuture<T>` throughout
- `java/jedis-compatibility/` directory exists for the compat layer migration path
- `valkey-io/spring-data-valkey` repo tag `v1.0.0` - GA; spring-data-valkey skill's Maven coordinate (`1.0.0`) matches

## Test plan

- [x] Java source files read + verified for publish signature, error classes, pubsub API
- [x] Pass 1: general structure + content verification
- [x] Pass 2: reversed-publish across 4 files, FLAT error hierarchy, TimeoutException name collision, NOT-UDS classification
- [x] Cross-file consistency: reversed-publish flagged in SKILL.md + pubsub.md + migrate-jedis + migrate-lettuce
- [ ] Ecosystem reviewers (Gemini, Cursor Bugbot)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to skill content and versions; low risk aside from potentially changing guidance that agents/users rely on (not runtime code).
> 
> **Overview**
> Updates the Java-oriented skill docs to align with GLIDE `v2.3.1` and focus on *divergence-only* guidance.
> 
> Highlights and standardizes several migration hazards across `migrate-jedis`, `migrate-lettuce`, and `valkey-glide-java`, especially the **reversed** `publish(message, channel)` argument order, plus clarified multiplexer usage, flat `GlideException` hierarchy/unwrap pattern, and the `TimeoutException` name collision.
> 
> Reworks `valkey-glide-java` Pub/Sub and error-handling reference pages to reflect these gotchas and updates skill/plugin versions (`migrate-*` `1.0.0→1.1.0`, `valkey-glide-java` `2.0.0→2.1.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbdd9b147c2882d248cbafe8f8d2d6a668a2f198. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->