### PR TITLE
php + ruby: validate against v1.0.0, apply divergence-only lens

### DIFF
--- a/skills/valkey-glide-php/.claude-plugin/plugin.json
+++ b/skills/valkey-glide-php/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "valkey-glide-php",
-  "version": "2.0.0",
-  "description": "Use when building PHP apps with Valkey GLIDE - synchronous C extension API (PHP 8.1+), PIE/Composer/PECL install, GlideClient, batching, phpredis compat, PubSub, TLS. Not for other languages - see valkey-glide router.",
+  "version": "2.1.0",
+  "description": "Use when building PHP apps with Valkey GLIDE - native C extension (PHP 8.2/8.3), synchronous blocking API, ValkeyGlide + ValkeyGlideCluster, callback-based subscribe/psubscribe, PHPRedis compatibility aliases, PIE/Composer/PECL install. Assumes PHPRedis knowledge; only GLIDE divergence is documented.",
   "author": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"

--- a/skills/valkey-glide-php/skills/valkey-glide-php/SKILL.md
+++ b/skills/valkey-glide-php/skills/valkey-glide-php/SKILL.md
@@ -1,25 +1,46 @@
 ---
 name: valkey-glide-php
-description: "Use when building PHP apps with Valkey GLIDE - synchronous C extension API (PHP 8.1+), PIE/Composer/PECL install, GlideClient, batching, phpredis compat, PubSub, TLS. Not for other languages - see valkey-glide router."
-version: 2.0.0
+description: "Use when building PHP apps with Valkey GLIDE - native C extension (PHP 8.2/8.3), synchronous blocking API, ValkeyGlide + ValkeyGlideCluster, callback-based subscribe/psubscribe, PHPRedis compatibility aliases, PIE/Composer/PECL install. Assumes PHPRedis knowledge; only GLIDE divergence is documented."
+version: 2.1.0
 argument-hint: "[API or config question]"
 ---
 
 # Valkey GLIDE PHP Client
 
-Synchronous PHP client for Valkey built on the GLIDE Rust core via native C extension. GA release (1.0).
+Agent-facing skill for GLIDE PHP. Assumes the reader can already write PHPRedis from training (`new Redis()`, `$r->connect($host, $port)`, positional command args). Covers only what GLIDE diverges on and what GLIDE adds on top.
 
-**Separate repository:** [valkey-io/valkey-glide-php](https://github.com/valkey-io/valkey-glide-php)
+**Separate repository:** `valkey-io/valkey-glide-php` (v1.0.0 GA).
 
 ## Routing
 
 | Question | Reference |
 |----------|-----------|
-| Setup, client creation, TLS, auth, config, read strategy, PHPRedis aliases | [connection](reference/features-connection.md) |
-| PubSub, subscribe, publish, pattern subscriptions | [pubsub](reference/features-pubsub.md) |
-| Install, API status, platform support, command groups, batching, phpredis compat, limitations | [overview](reference/features-overview.md) |
+| `ValkeyGlide` vs `ValkeyGlideCluster` construction divergence (standalone needs explicit `connect()`; cluster config goes in `__construct`), TLS, auth, IAM, read_from, reconnect strategy, `registerPHPRedisAliases()` | [connection](reference/features-connection.md) |
+| Array-and-callback `subscribe(array, callable)` / `psubscribe(array, callable)` - REVERSED shape from PHPRedis varargs; `ssubscribe` NOT implemented in v1.0.0; `unsubscribe(?array)`; introspection via `pubsub()` | [pubsub](reference/features-pubsub.md) |
+| Install via PIE/PECL/Composer, PHP 8.2/8.3 only, supported platforms, command groups, batching (MULTI/EXEC + pipeline), error model (`ValkeyGlideException`), password rotation | [overview](reference/features-overview.md) |
 
-## Cross-References
+## The #1 agent mistake: subscribe signature
 
-- `valkey-glide` skill - shared architecture, cluster topology, connection model
-- `valkey` skill - Valkey server commands, data types, patterns
+PHPRedis accepts `$r->subscribe(['ch1','ch2'], $callback)` but also legacy forms. GLIDE PHP is strict: **`subscribe(array $channels, callable $cb): bool`** - the array of channels is REQUIRED, the callback is REQUIRED, and there are NO varargs-style overloads. Same for `psubscribe`. See the features-pubsub reference for callback signature.
+
+## Grep hazards
+
+1. **`publish(string $channel, string $message): int` - STANDARD ORDER.** PHP GLIDE does NOT reverse the args (unlike Python, Node.js, Java GLIDE which DO reverse to `publish(message, channel)`). PHP follows PHPRedis convention. No action needed on migration.
+2. **`subscribe(array $channels, callable $cb): bool`** - channels MUST be an array even for a single channel. Callback signature: `function ($client, $channel, $message) { }`. Inside the callback you can call `$client->unsubscribe([$channel])` to break out of the subscribe loop.
+3. **`psubscribe(array $patterns, callable $cb): bool`** - same shape. Callback signature the same: `function ($client, $channel, $message) { }`. Note PHPRedis pattern callback uses 4 args `($redis, $pattern, $channel, $message)` - GLIDE uses 3 even for pattern subscribes. Silent-bug risk.
+4. **`ssubscribe` / `sunsubscribe` / `spublish` NOT IMPLEMENTED in v1.0.0.** The stub has a TODO-commented `ssubscribe` signature. Do not document sharded PubSub as available.
+5. **Standalone construction is two-step: `new ValkeyGlide()` then `->connect(addresses: [...])`.** The constructor takes zero arguments. Passing config to `new ValkeyGlide(addresses: [...])` is a type error.
+6. **Cluster construction is one-step: `new ValkeyGlideCluster(addresses: [...], use_tls: true, ...)`.** Cluster has a parameterized constructor with 19 positions (7 PHPRedis-style + 12 GLIDE-style). Mixing PHPRedis-style and GLIDE-style positional args throws.
+7. **PHP support is 8.2 and 8.3 ONLY.** Not 8.1, not 8.4. The v1.0.0 binaries are built for these two minor versions.
+8. **No Windows, no Alpine/MUSL.** Pre-built binaries cover Ubuntu 20+ (x86_64/arm64) and macOS 14.7+ (Apple Silicon).
+9. **All errors throw `ValkeyGlideException`.** Single exception class, no hierarchy. Inspect `$e->getMessage()` for text classification (WRONGTYPE, timeout, connection, etc.). Aliased as `RedisException` after `ValkeyGlide::registerPHPRedisAliases()`.
+10. **`registerPHPRedisAliases()` is static, returns `bool`.** Creates `Redis -> ValkeyGlide`, `RedisCluster -> ValkeyGlideCluster`, `RedisException -> ValkeyGlideException` aliases. Call once at bootstrap; returns `false` if already registered.
+11. **`$client->close()` is mandatory** for deterministic shutdown. The destructor closes automatically but releasing early is preferred for long-running CLI/daemons.
+12. **`reconnect_strategy` keys:** `num_of_retries`, `factor`, `exponent_base`, `jitter_percent`. Not `numOfRetries` / `retries` / `backoff`.
+13. **Read strategy constants on `ValkeyGlide::`:** `READ_FROM_PRIMARY` (0), `READ_FROM_PREFER_REPLICA` (1), `READ_FROM_AZ_AFFINITY` (2), `READ_FROM_AZ_AFFINITY_REPLICAS_AND_PRIMARY` (3). Passed as `read_from: 2` to `connect()` or cluster constructor.
+14. **Password rotation: `updateConnectionPassword()` and `clearConnectionPassword()`** - both take `$immediateAuth = false` flag. Use during secret rotation without client restart.
+
+## Cross-references
+
+- `valkey` skill - Valkey server commands and app patterns
+- `glide-dev` skill - GLIDE core internals and FFI binding mechanics

--- a/skills/valkey-glide-php/skills/valkey-glide-php/SKILL.md
+++ b/skills/valkey-glide-php/skills/valkey-glide-php/SKILL.md
@@ -19,6 +19,18 @@ Agent-facing skill for GLIDE PHP. Assumes the reader can already write PHPRedis 
 | Array-and-callback `subscribe(array, callable)` / `psubscribe(array, callable)` - REVERSED shape from PHPRedis varargs; `ssubscribe` NOT implemented in v1.0.0; `unsubscribe(?array)`; introspection via `pubsub()` | [pubsub](reference/features-pubsub.md) |
 | Install via PIE/PECL/Composer, PHP 8.2/8.3 only, supported platforms, command groups, batching (MULTI/EXEC + pipeline), error model (`ValkeyGlideException`), password rotation | [overview](reference/features-overview.md) |
 
+## Multiplexer rule
+
+One `ValkeyGlide` / `ValkeyGlideCluster` instance is the shared multiplexer for a PHP process (long-running CLI, daemon, or FPM worker). Do not create per-request clients inside the same process. Do not pool multiple instances against the same node. The Rust core pipelines concurrent calls across the multiplexed connection.
+
+**Exceptions that need a dedicated client instance:**
+
+- PubSub subscribers (`subscribe` / `psubscribe` hold the connection in subscriber mode - occupancy).
+- Blocking commands (`blPop`, `brPop`, `bzPopMin`, `bzPopMax`, `blmpop`, `bzmpop`, `wait`) - occupancy, they hold the multiplexed connection for the block duration.
+- Transactional `watch` / `multi` / `exec` flows - connection-state leakage on a shared multiplexer, not occupancy.
+
+Large values are NOT an exception - they pipeline through the multiplexer fine.
+
 ## The #1 agent mistake: subscribe signature
 
 PHPRedis accepts `$r->subscribe(['ch1','ch2'], $callback)` but also legacy forms. GLIDE PHP is strict: **`subscribe(array $channels, callable $cb): bool`** - the array of channels is REQUIRED, the callback is REQUIRED, and there are NO varargs-style overloads. Same for `psubscribe`. See the features-pubsub reference for callback signature.
@@ -33,7 +45,7 @@ PHPRedis accepts `$r->subscribe(['ch1','ch2'], $callback)` but also legacy forms
 6. **Cluster construction is one-step: `new ValkeyGlideCluster(addresses: [...], use_tls: true, ...)`.** Cluster has a parameterized constructor with 19 positions (7 PHPRedis-style + 12 GLIDE-style). Mixing PHPRedis-style and GLIDE-style positional args throws.
 7. **PHP support is 8.2 and 8.3 ONLY.** Not 8.1, not 8.4. The v1.0.0 binaries are built for these two minor versions.
 8. **No Windows, no Alpine/MUSL.** Pre-built binaries cover Ubuntu 20+ (x86_64/arm64) and macOS 14.7+ (Apple Silicon).
-9. **All errors throw `ValkeyGlideException`.** Single exception class, no hierarchy. Inspect `$e->getMessage()` for text classification (WRONGTYPE, timeout, connection, etc.). Aliased as `RedisException` after `ValkeyGlide::registerPHPRedisAliases()`.
+9. **All errors throw `ValkeyGlideException`.** Single exception class, no hierarchy. Inspect `$e->getMessage()` for text classification (WRONGTYPE, OOM, NOAUTH, WRONGPASS, MOVED, ASK, CROSSSLOT, NOSCRIPT, READONLY, timeout, connection closed). Aliased as `RedisException` after `ValkeyGlide::registerPHPRedisAliases()`.
 10. **`registerPHPRedisAliases()` is static, returns `bool`.** Creates `Redis -> ValkeyGlide`, `RedisCluster -> ValkeyGlideCluster`, `RedisException -> ValkeyGlideException` aliases. Call once at bootstrap; returns `false` if already registered.
 11. **`$client->close()` is mandatory** for deterministic shutdown. The destructor closes automatically but releasing early is preferred for long-running CLI/daemons.
 12. **`reconnect_strategy` keys:** `num_of_retries`, `factor`, `exponent_base`, `jitter_percent`. Not `numOfRetries` / `retries` / `backoff`.

--- a/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-connection.md
+++ b/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-connection.md
@@ -1,40 +1,48 @@
 # Connection and Configuration (PHP)
 
-Use when creating a GLIDE client in PHP, choosing between standalone and cluster mode, configuring authentication, TLS, timeouts, reconnection backoff, read strategy, or the PHPRedis-compatible aliases.
+Use when constructing a GLIDE PHP client, switching between standalone and cluster mode, or mapping PHPRedis config to GLIDE config. Assumes PHPRedis knowledge - only divergence is documented.
 
-## Client Classes
+## Divergence from PHPRedis - construction asymmetry
 
-| Class | Mode | Description |
-|-------|------|-------------|
-| `ValkeyGlide` | Standalone | Single-node or primary+replicas |
-| `ValkeyGlideCluster` | Cluster | Valkey Cluster with auto-topology discovery |
-
-The PHP client provides a synchronous (blocking) API - all commands block until a response is received.
-
-## Standalone Connection
+| | Standalone (`ValkeyGlide`) | Cluster (`ValkeyGlideCluster`) |
+|---|---|---|
+| Constructor args | **none** | **up to 19** (PHPRedis-style 7 + GLIDE-style 12) |
+| How to configure | call `->connect(...)` after `new` | pass all config to `new ValkeyGlideCluster(...)` |
+| Can pass `addresses:` to `new`? | **No** (constructor takes zero args) | Yes |
 
 ```php
-<?php
+// Standalone - TWO STEPS
 $client = new ValkeyGlide();
-$client->connect(
-    addresses: [['host' => 'localhost', 'port' => 6379]]
+$client->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
+
+// Cluster - ONE STEP
+$cluster = new ValkeyGlideCluster(
+    addresses: [
+        ['host' => 'node1.example.com', 'port' => 6379],
+        ['host' => 'node2.example.com', 'port' => 6380],
+    ],
+    use_tls: true,
 );
-
-$client->set('key', 'value');
-$value = $client->get('key');
-
-$client->close();
 ```
 
-### PHPRedis-Style Connection
+Only seed addresses are needed for cluster - topology is discovered automatically.
+
+## PHPRedis-style connect (standalone)
+
+The standalone `->connect()` method accepts BOTH PHPRedis-style positional args AND GLIDE-style named args, but you cannot mix them:
 
 ```php
-$client = new ValkeyGlide();
-$client->connect('localhost', 6379);        // host, port
-$client->connect('localhost', 6379, 2.5);   // with timeout
+// PHPRedis-style positional
+$client->connect('localhost', 6379);
+$client->connect('localhost', 6379, 2.5);  // + timeout in seconds
+
+// GLIDE-style named (preferred for new code)
+$client->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
 ```
 
-### Full Standalone Configuration
+PHPRedis-style args (`persistent_id`, `retry_interval`, `read_timeout`) exist in the signature but are marked "not implemented" - pass them only for signature compatibility.
+
+## Full GLIDE-style standalone config
 
 ```php
 $client = new ValkeyGlide();
@@ -42,45 +50,57 @@ $client->connect(
     addresses: [['host' => 'localhost', 'port' => 6379]],
     use_tls: false,
     credentials: ['username' => 'myuser', 'password' => 'mypass'],
-    read_from: 0,               // 0=PRIMARY
-    request_timeout: 5000,      // milliseconds
+    read_from: ValkeyGlide::READ_FROM_PRIMARY,
+    request_timeout: 5000,            // milliseconds
     reconnect_strategy: [
         'num_of_retries' => 5,
-        'factor' => 2.0,
+        'factor' => 2,
         'exponent_base' => 2,
+        'jitter_percent' => 15,
     ],
     database_id: 0,
     client_name: 'my-app',
-    client_az: null,            // for AZ_AFFINITY reads
+    client_az: null,                   // set to AZ string for AZ_AFFINITY
     advanced_config: [
         'connection_timeout' => 5000,
-        'socket_timeout' => 3000,
+        'tls_config' => ['use_insecure_tls' => false],
     ],
     lazy_connect: false,
 );
 ```
 
-## Cluster Connection
+## Cluster config
+
+Cluster accepts the same GLIDE-style args plus `periodic_checks` (periodic topology refresh) and `refresh_topology_from_initial_nodes` (advanced_config key):
 
 ```php
-$client = new ValkeyGlideCluster(
-    addresses: [
-        ['host' => 'node1.example.com', 'port' => 6379],
-        ['host' => 'node2.example.com', 'port' => 6380],
-    ]
+$cluster = new ValkeyGlideCluster(
+    addresses: [['host' => 'node1', 'port' => 7001]],
+    use_tls: true,
+    credentials: ['password' => 'secret'],
+    read_from: ValkeyGlide::READ_FROM_AZ_AFFINITY,
+    client_az: 'us-east-1a',
+    periodic_checks: ValkeyGlideCluster::PERIODIC_CHECK_ENABLED_DEFAULT_CONFIGS,
+    request_timeout: 5000,
+    reconnect_strategy: [
+        'num_of_retries' => 3,
+        'factor' => 2,
+        'exponent_base' => 10,
+        'jitter_percent' => 15,
+    ],
+    advanced_config: [
+        'connection_timeout' => 5000,
+        'refresh_topology_from_initial_nodes' => false,
+    ],
+    lazy_connect: false,
 );
-
-$client->set('key', 'value');
-$client->close();
 ```
 
-Only seed addresses are needed - GLIDE discovers full topology automatically.
-
-PHPRedis-style: `new ValkeyGlideCluster(seeds: [['host' => 'localhost', 'port' => 7001]])`.
-
-Cluster-specific options: `periodic_checks` (topology refresh interval in seconds), `client_az` (for AZ affinity). All other options (`use_tls`, `credentials`, `read_from`, `request_timeout`, `reconnect_strategy`, `advanced_config`, `lazy_connect`) match standalone.
+`database_id` on cluster requires Valkey 9.0+ with `cluster-databases > 1`.
 
 ## Authentication
+
+Password / ACL:
 
 ```php
 // Username + password (ACL)
@@ -89,59 +109,73 @@ $client->connect(
     credentials: ['username' => 'myuser', 'password' => 'mypass'],
 );
 
-// Password only
+// Password only (legacy AUTH without username)
 $client->connect(
     addresses: [['host' => 'localhost', 'port' => 6379]],
     credentials: ['password' => 'mypass'],
 );
-
-// IAM authentication (AWS) - requires use_tls: true
-// credentials['iamConfig'] with keys: IAM_CONFIG_CLUSTER_NAME, IAM_CONFIG_REGION,
-// IAM_CONFIG_SERVICE (IAM_SERVICE_ELASTICACHE or IAM_SERVICE_MEMORYDB),
-// IAM_CONFIG_REFRESH_INTERVAL (default 300s). Tokens refresh automatically.
 ```
 
-## ReadFrom Strategy
-
-| Value | Strategy | Behavior |
-|-------|----------|----------|
-| `0` | PRIMARY | All reads to primary (default) |
-| `1` | PREFER_REPLICA | Round-robin replicas, fallback to primary |
-| `2` | AZ_AFFINITY | Same-AZ replicas, fallback to others |
-
-AZ affinity requires Valkey 8.0+ and `client_az` to be set.
-
-## Reconnect Strategy
-
-Delay follows `rand(0 ... factor * (exponent_base ^ N))`:
+IAM (AWS) - requires `use_tls: true` and `username` to be set:
 
 ```php
 $client->connect(
-    addresses: $addresses,
-    reconnect_strategy: [
-        'num_of_retries' => 5,    // retries before delay plateaus
-        'factor' => 2.0,          // base delay multiplier
-        'exponent_base' => 2,     // exponential growth factor
+    addresses: [['host' => 'my-cluster.cache.amazonaws.com', 'port' => 6379]],
+    use_tls: true,
+    credentials: [
+        'username' => 'iam-user',
+        'iamConfig' => [
+            ValkeyGlide::IAM_CONFIG_CLUSTER_NAME => 'my-cluster',
+            ValkeyGlide::IAM_CONFIG_REGION => 'us-east-1',
+            ValkeyGlide::IAM_CONFIG_SERVICE => ValkeyGlide::IAM_SERVICE_ELASTICACHE,
+            ValkeyGlide::IAM_CONFIG_REFRESH_INTERVAL => 300,
+        ],
     ],
 );
 ```
 
-## PHPRedis Compatibility Aliases
+Tokens refresh automatically in the Rust core.
 
-Register class aliases to use PHPRedis class names:
+## Read strategy
+
+Constants on the `ValkeyGlide` class:
+
+| Constant | Value | Behavior |
+|----------|-------|----------|
+| `READ_FROM_PRIMARY` | 0 | All reads to primary (default) |
+| `READ_FROM_PREFER_REPLICA` | 1 | Round-robin replicas, fall back to primary |
+| `READ_FROM_AZ_AFFINITY` | 2 | Same-AZ replicas first, requires `client_az` and Valkey 8.0+ |
+| `READ_FROM_AZ_AFFINITY_REPLICAS_AND_PRIMARY` | 3 | Same-AZ replicas + primary, then cross-AZ |
+
+## Reconnect strategy
+
+Delay formula: `rand(0 ... factor * (exponent_base ^ attempt))` milliseconds. After `num_of_retries` attempts the delay plateaus at the ceiling - reconnection is infinite.
+
+Keys use snake_case: `num_of_retries`, `factor`, `exponent_base`, `jitter_percent`. Not `numOfRetries` (that's Java).
+
+## PHPRedis compatibility aliases
 
 ```php
-ValkeyGlide::registerPHPRedisAliases();
+ValkeyGlide::registerPHPRedisAliases();  // returns bool
 
-// Now these work:
-$client = new Redis();          // -> ValkeyGlide
-$cluster = new RedisCluster();  // -> ValkeyGlideCluster
+// Now these resolve to GLIDE classes
+$client = new Redis();              // -> ValkeyGlide
+$cluster = new RedisCluster();      // -> ValkeyGlideCluster
 
 try {
     $client->connect('localhost', 6379);
-} catch (RedisException $e) {   // -> ValkeyGlideException
-    echo $e->getMessage();
+} catch (RedisException $e) {       // -> ValkeyGlideException
+    error_log($e->getMessage());
 }
 ```
 
-Requires PHP 8.3+ for internal class aliasing support.
+Call once at application bootstrap. Subsequent calls return `false` (aliases already registered).
+
+## Password rotation without reconnect
+
+```php
+$client->updateConnectionPassword('new-secret', immediateAuth: true);
+$client->clearConnectionPassword(immediateAuth: false);
+```
+
+`immediateAuth: true` re-authenticates now. `immediateAuth: false` defers re-auth until the next command. Works on both standalone and cluster.

--- a/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-overview.md
+++ b/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-overview.md
@@ -1,120 +1,137 @@
 # PHP Client Overview
 
-Use when checking GLIDE PHP capabilities, available commands, and limitations.
+Use when checking GLIDE PHP capabilities, limitations, and install options.
 
 ## Status
 
-**GA** - version 1.0.0 released. Production-ready. Synchronous (blocking) API, native C extension, PHPRedis-compatible class name aliases.
+**GA** - v1.0.0 (2026-01-28). Synchronous blocking native C extension. PHPRedis-compatible class aliases via opt-in `registerPHPRedisAliases()`.
 
 ## Requirements
 
-- PHP 8.2 or 8.3
-- Valkey 7.2+ or Redis 6.2+
-
-## Platform Support
-
-| Platform | Architecture | Supported |
-|----------|-------------|-----------|
-| Ubuntu 20+ | x86_64 | Yes |
-| Ubuntu 20+ | arm64 | Yes |
-| macOS 14.7+ | Apple Silicon | Yes |
-| Windows | any | No |
-| Alpine/MUSL | any | No |
+- PHP **8.2 or 8.3** (not 8.1, not 8.4)
+- Valkey 7.2+ / Redis 6.2+
+- Pre-built binaries for Ubuntu 20+ (x86_64, arm64) and macOS 14.7+ (Apple Silicon)
 
 ## Installation
 
 ```bash
-# Via PIE (recommended)
+# PIE (preferred)
 pie install valkey-io/valkey-glide-php:1.0.0
 
-# Via PECL
-curl -L https://github.com/valkey-io/valkey-glide-php/releases/download/v1.0.0/valkey_glide-1.0.0.tgz -o valkey_glide-1.0.0.tgz
-pecl install valkey_glide-1.0.0.tgz
+# PECL
+pecl install https://github.com/valkey-io/valkey-glide-php/releases/download/v1.0.0/valkey_glide-1.0.0.tgz
 
-# Via Composer
+# Composer
 composer require valkey-io/valkey-glide-php
 ```
 
-After PECL installation, add to `php.ini`:
+After PECL install, enable in `php.ini`:
 ```ini
 extension=valkey_glide
 ```
 
-## Available Command Groups
+## Command groups
 
-| Group | Examples | Status |
-|-------|----------|--------|
-| String | `set`, `get`, `incr`, `incrBy`, `mget`, `mset` | Available |
-| Hash | `hset`, `hget`, `hgetall`, `hdel`, `hmset` | Available |
-| List | `lpush`, `rpush`, `lpop`, `rpop`, `lrange` | Available |
-| Set | `sadd`, `smembers`, `sismember`, `scard` | Available |
-| Sorted Set | `zadd`, `zscore`, `zrank`, `zrange`, `zrangebyscore` | Available |
-| Stream | `xadd`, `xread`, `xreadgroup`, `xack`, `xgroup` | Available |
-| PubSub | `subscribe`, `publish`, `psubscribe` | Available |
-| Bitmap | `setbit`, `getbit`, `bitcount`, `bitop` | Available |
-| HyperLogLog | `pfadd`, `pfcount`, `pfmerge` | Available |
-| Geo | `geoadd`, `geosearch`, `geodist` | Available |
-| Scripting | `eval`, `evalsha` | Available |
-| Generic | `del`, `exists`, `expire`, `ttl`, `type`, `scan` | Available |
-| Server | `info`, `dbsize`, `flushdb`, `config` | Available |
-| Connection | `ping`, `echo`, `select`, `auth` | Available |
-| Cluster | `cluster info`, `cluster nodes` | Available (cluster client) |
-| Batching | Transaction (MULTI/EXEC) and pipeline | Available |
+Same groups as PHPRedis plus GLIDE additions. Method names follow PHPRedis camelCase (`hSet`, `zAdd`, `sAdd`) per the stub - not snake_case.
 
-## Features
+| Group | Examples |
+|-------|----------|
+| String | `set`, `get`, `incr`, `incrBy`, `mget`, `mset`, `getDel`, `getEx` |
+| Hash | `hSet`, `hGet`, `hGetAll`, `hDel`, `hMGet`, `hScan` |
+| List | `lPush`, `rPush`, `lPop`, `rPop`, `lRange`, `blPop` |
+| Set | `sAdd`, `sMembers`, `sIsMember`, `sInter`, `sUnion` |
+| Sorted Set | `zAdd`, `zScore`, `zRange`, `zRangeByScore`, `bzPopMin` |
+| Stream | `xAdd`, `xRead`, `xReadGroup`, `xAck`, `xClaim`, `xAutoClaim` |
+| PubSub | `subscribe`, `publish`, `psubscribe` (no `ssubscribe` yet) |
+| Bitmap | `setBit`, `getBit`, `bitCount`, `bitOp`, `bitPos` |
+| HyperLogLog | `pfAdd`, `pfCount`, `pfMerge` |
+| Geo | `geoAdd`, `geoSearch`, `geoDist` |
+| Scripting | `eval`, `evalSha`, `eval_ro`, `evalSha_ro` |
+| Functions | `function`, `fcall`, `fcall_ro` |
+| Generic | `del`, `exists`, `expire`, `ttl`, `type`, `scan` |
+| Server | `info`, `dbSize`, `flushDB`, `config` |
+| Connection | `ping`, `echo`, `select`, `auth`, `client` |
+| Transactions | `multi`, `discard`, `watch`, `unwatch`, `pipeline` |
+
+## Features matrix
 
 | Feature | Available | Notes |
 |---------|-----------|-------|
-| Standalone mode | Yes | Via `ValkeyGlide` |
-| Cluster mode | Yes | Via `ValkeyGlideCluster` |
-| TLS | Yes | `use_tls: true` parameter |
-| Authentication | Yes | Password, ACL, IAM (AWS) |
-| PubSub | Yes | Subscribe, psubscribe, publish |
-| Batching | Yes | Atomic (MULTI/EXEC) and non-atomic (pipeline) |
-| Cluster scan | Yes | Unified key iteration across shards |
+| Standalone mode | Yes | `ValkeyGlide` class; `new` + `connect()` |
+| Cluster mode | Yes | `ValkeyGlideCluster` class; config in constructor |
+| TLS | Yes | `use_tls: true` |
+| Auth - password / ACL | Yes | `credentials: ['username' => ..., 'password' => ...]` |
+| Auth - IAM (AWS) | Yes | `credentials: ['username' => ..., 'iamConfig' => [...]]`. Requires `use_tls: true`. |
+| PubSub (exact, pattern) | Yes | Array+callback form only |
+| Sharded PubSub | **No** | `ssubscribe` is a TODO stub in v1.0.0 |
+| Batching - atomic (MULTI) | Yes | See Batching section below |
+| Batching - pipeline | Yes | See Batching section below |
+| WATCH | Yes | `$client->watch(...)` |
+| Cluster scan | Yes | Unified iteration across shards |
 | Multi-slot commands | Yes | MGET/MSET/DEL across slots |
 | AZ Affinity | Yes | `read_from: 2` with `client_az` |
-| PHPRedis aliases | Yes | `ValkeyGlide::registerPHPRedisAliases()` |
-| Compression | Experimental | Being expanded |
-| OpenTelemetry | In progress | Traces + metrics support |
-| Lazy connect | Yes | Defer connection until first command |
+| PHPRedis aliases | Yes | Opt-in via `ValkeyGlide::registerPHPRedisAliases()` |
+| Lazy connect | Yes | `lazy_connect: true` |
+| Password rotation | Yes | `updateConnectionPassword()` / `clearConnectionPassword()` |
+| OpenTelemetry | Yes | `advanced_config: ['otel' => OpenTelemetryConfig::builder()...]` |
+| Compression | Experimental | Not production-ready |
+| Async API | **No** | PHP's execution model is synchronous |
 
-## Error Handling
+## Batching
+
+Three shapes, all ending in a call to `$client->` plus the `exec` method:
+
+```php
+// Atomic transaction
+$client->multi(ValkeyGlide::MULTI);
+$client->set('a', '1');
+$client->incr('a');
+$results = $client->exec();
+
+// Pipeline (non-atomic, higher throughput)
+$client->pipeline()
+    ->set('a', '1')
+    ->incr('a')
+    ->exec();
+
+// Optimistic locking - exec() returns null if the watched key changed
+$client->watch(['key']);
+$client->multi(ValkeyGlide::MULTI);
+$client->set('key', $newValue);
+$results = $client->exec();
+```
+
+## Error handling
 
 ```php
 try {
     $value = $client->get('key');
 } catch (ValkeyGlideException $e) {
-    $msg = $e->getMessage();
-    if (str_contains($msg, 'timeout')) {
-        echo "Request timed out\n";
-    } elseif (str_contains($msg, 'connection')) {
-        echo "Connection lost - client is reconnecting\n";
-    } else {
-        echo "Error: {$msg}\n";
-    }
+    // Single exception class - no subtype hierarchy.
+    // Inspect $e->getMessage() to classify (WRONGTYPE, timeout, connection, NOAUTH, etc.).
+    error_log($e->getMessage());
 }
 ```
 
-All errors throw `ValkeyGlideException` (aliased as `RedisException` when PHPRedis aliases are registered).
+Under `ValkeyGlide::registerPHPRedisAliases()` the same instances satisfy `catch (RedisException $e)`.
 
-## Architecture Notes
+## Password rotation without reconnect
 
-- Native C extension calling the GLIDE Rust core via `glide-ffi`
-- Synchronous blocking API - each command blocks until response
-- Single multiplexed connection per node
-- Pre-built binaries distributed via PIE, Composer, and PECL
+```php
+$client->updateConnectionPassword('new-secret', immediateAuth: false);
+$client->clearConnectionPassword(immediateAuth: false);
+```
+
+Set `immediateAuth: true` to re-authenticate immediately rather than lazily on the next command.
 
 ## Limitations
 
-- **No Windows support**
-- **No Alpine/MUSL support**
-- **No async API** - PHP's execution model is synchronous
-- **Compression is experimental** - not yet production-ready
-- **No official framework integrations** - PHPRedis aliases may enable use with Laravel's Redis driver but this is untested
+- **No Windows, no Alpine/MUSL.** Glibc-based Linux only.
+- **No async API.**
+- **No sharded PubSub** in v1.0.0.
+- **Compression is experimental.**
+- **No Laravel/Symfony framework integration** bundled. PHPRedis aliases may enable it but it is untested.
 
 ## Repository
 
-Separate repo: [valkey-io/valkey-glide-php](https://github.com/valkey-io/valkey-glide-php)
-
-Package: `pie install valkey-io/valkey-glide-php`
+`valkey-io/valkey-glide-php` (separate repo from the main GLIDE monorepo). Package: `valkey-io/valkey-glide-php` on Packagist.

--- a/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-overview.md
+++ b/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-overview.md
@@ -108,7 +108,7 @@ try {
     $value = $client->get('key');
 } catch (ValkeyGlideException $e) {
     // Single exception class - no subtype hierarchy.
-    // Inspect $e->getMessage() to classify (WRONGTYPE, timeout, connection, NOAUTH, etc.).
+    // Inspect $e->getMessage() to classify (WRONGTYPE, OOM, NOAUTH, WRONGPASS, MOVED, ASK, NOSCRIPT, READONLY, timeout, connection closed).
     error_log($e->getMessage());
 }
 ```

--- a/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-pubsub.md
+++ b/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-pubsub.md
@@ -115,7 +115,7 @@ $client->subscribe(['tasks'], function ($c, $channel, $message) {
 
 ## Important notes
 
-1. **Separate clients for pub and sub.** A subscribing client is in subscriber mode for the duration of the subscribe call; it cannot issue normal commands from the outer scope.
+1. **Separate clients for pub and sub (occupancy).** A subscribing client is in subscriber mode for the duration of the subscribe call; it cannot issue normal commands from the outer scope. This is occupancy - the same reason blocking commands need dedicated clients - not connection-state leakage like WATCH/MULTI/EXEC.
 2. **Automatic resubscribe on reconnect.** The Rust core restores subscriptions after a reconnect automatically.
 3. **At-most-once delivery.** Messages published during a reconnect gap are lost. Use Streams for durable delivery.
 4. **Callback exceptions** propagate out of `subscribe()` and leave the client in subscriber mode until you explicitly unsubscribe or close.

--- a/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-pubsub.md
+++ b/skills/valkey-glide-php/skills/valkey-glide-php/reference/features-pubsub.md
@@ -1,144 +1,121 @@
 # Pub/Sub (PHP)
 
-Use when implementing real-time message broadcasting in PHP - event distribution, notifications, or inter-process messaging. For durable message processing with consumer groups, use Streams instead.
+Use when wiring publish/subscribe in GLIDE PHP. Assumes familiarity with PHPRedis' `subscribe` / `psubscribe` callback-based model. This doc covers only what GLIDE PHP does differently.
 
-GLIDE PHP supports PubSub with blocking subscribe, callback-based message delivery, and automatic reconnection with resubscription. The API is synchronous, matching PHP's execution model.
+## Divergence from PHPRedis
 
-## Subscription Modes
+| | PHPRedis | GLIDE PHP |
+|---|---|---|
+| `subscribe` channels arg | varargs or array | **array required** |
+| `subscribe` callback | `function($r, $ch, $msg)` | same shape |
+| `psubscribe` callback | **4 args** `($r, $pat, $ch, $msg)` | **3 args** `($r, $ch, $msg)` - no pattern |
+| `unsubscribe()` with no args | all channels | all channels (same) |
+| Sharded PubSub (`ssubscribe`) | N/A | **NOT implemented in v1.0.0** |
+| Introspection | `pubsub` subcommand | same (`pubsub($cmd, $arg)`) |
 
-| Mode | Subscribe | Unsubscribe | Cluster Only |
-|------|-----------|-------------|--------------|
-| Exact | `subscribe()` | `unsubscribe()` | No |
-| Pattern | `psubscribe()` | `punsubscribe()` | No |
-
-Sharded PubSub (`ssubscribe`/`sunsubscribe`) availability depends on cluster client implementation status.
-
-## Subscribe and Receive
-
-PHP's PubSub operates as a blocking loop. When a client subscribes, it enters subscriber mode and can only execute subscribe/unsubscribe commands until it unsubscribes from all channels.
+## Subscribe and loop - canonical shape
 
 ```php
 <?php
-// Subscriber process
 $subscriber = new ValkeyGlide();
-$subscriber->connect(
-    addresses: [['host' => 'localhost', 'port' => 6379]]
-);
+$subscriber->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
 
-// Subscribe - enters subscriber mode
-$subscriber->subscribe('news', 'events');
+// Channels MUST be in an array. Callback is mandatory. Call blocks until unsubscribe.
+$subscriber->subscribe(['news', 'events'], function ($client, $channel, $message) {
+    echo "[$channel] $message\n";
 
-// In subscriber mode, messages arrive via the callback mechanism
-// The client processes messages until unsubscribed
-$subscriber->unsubscribe('news', 'events');
+    // Break the loop from inside the callback
+    if ($message === 'quit') {
+        $client->unsubscribe([$channel]);
+    }
+});
+
+// After unsubscribe from all channels, control returns here
 $subscriber->close();
 ```
 
-## Publishing
+The subscribe call is blocking. The callback fires for every message until all channels have been unsubscribed.
 
-Use a separate client for publishing:
+## Pattern subscriptions
+
+```php
+$subscriber = new ValkeyGlide();
+$subscriber->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
+
+// psubscribe callback gets 3 args - NOT 4 as in PHPRedis. Pattern is not passed.
+$subscriber->psubscribe(['news.*', 'events:*'], function ($client, $channel, $message) {
+    echo "[$channel] $message\n";
+});
+
+$subscriber->close();
+```
+
+**PHPRedis silent-bug**: PHPRedis pattern callback signature is `function($r, $pattern, $channel, $message)`. Copying that signature into GLIDE PHP means the third parameter gets `$message` instead of `$channel`, and the fourth is never invoked. Verify callback arity when migrating.
+
+## Publishing
 
 ```php
 $publisher = new ValkeyGlide();
-$publisher->connect(
-    addresses: [['host' => 'localhost', 'port' => 6379]]
-);
+$publisher->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
 
-// Returns number of subscribers that received the message
+// Standard (channel, message) order. Matches PHPRedis - NOT reversed like Python/Node/Java GLIDE.
 $count = $publisher->publish('events', 'Hello subscribers!');
-echo "Delivered to {$count} subscribers\n";
 
 $publisher->close();
 ```
 
-## Pattern Subscriptions
+Return value is the subscriber count that received the message.
+
+## Unsubscribe shapes
 
 ```php
-$subscriber = new ValkeyGlide();
-$subscriber->connect(
-    addresses: [['host' => 'localhost', 'port' => 6379]]
-);
-
-// Subscribe to patterns using glob syntax
-$subscriber->psubscribe('news.*', 'events:*');
-
-// Later, unsubscribe
-$subscriber->punsubscribe('news.*', 'events:*');
-$subscriber->close();
+$client->unsubscribe(['news']);      // specific channel
+$client->unsubscribe();              // null arg - all channels
+$client->punsubscribe(['news.*']);   // specific pattern
+$client->punsubscribe();             // null arg - all patterns
 ```
 
-## PubSub Introspection
+Signature: `unsubscribe(?array $channels = null): bool`. Inside a subscribe callback, calling `unsubscribe` from all channels returns control to the caller of `subscribe()`.
 
-Query active channels and subscriber counts without entering subscriber mode:
+## Introspection (no subscriber mode)
 
 ```php
 $client = new ValkeyGlide();
-$client->connect(
-    addresses: [['host' => 'localhost', 'port' => 6379]]
-);
+$client->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
 
-// List active channels
-$channels = $client->pubsub('channels');
-// => ["news", "events"]
+// PUBSUB CHANNELS
+$channels = $client->pubsub('channels');            // all
+$filtered = $client->pubsub('channels', 'news.*');  // by pattern
 
-// Filter by pattern
-$channels = $client->pubsub('channels', 'news.*');
+// PUBSUB NUMSUB
+$counts = $client->pubsub('numsub', ['news', 'events']);
 
-// Subscriber counts
-$counts = $client->pubsub('numsub', 'news', 'events');
-// => ["news", 5, "events", 3]
-
-// Pattern count
+// PUBSUB NUMPAT
 $patCount = $client->pubsub('numpat');
-// => 2
 ```
 
-## Message Callback Structure
+Signature: `pubsub(string $command, mixed $arg = null): mixed`.
 
-Messages arrive via a callback registered at the C extension level. Each message includes:
+## Sharded PubSub - not available
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `channel` | string | Channel the message was published to |
-| `message` | string | The published payload |
-| `pattern` | string/null | Matching pattern (pattern subscriptions only) |
-| `kind` | int | Message kind (exact, pattern, sharded) |
+The v1.0.0 stub has `ssubscribe` commented out with a TODO. `sunsubscribe` and `spublish` are also unavailable in this release. Do not design applications around sharded PubSub when using GLIDE PHP v1.0.0.
 
-## Multi-Process Pattern
+## Multi-process pattern
 
-PubSub subscribers run in a dedicated process due to PHP's synchronous execution model:
+PHP's synchronous model means a subscriber process is dedicated to PubSub for its lifetime. Run the subscriber as a long-lived worker (systemd, supervisord, or a PHP CLI loop); keep publishers in short-lived request handlers.
 
 ```php
-<?php
 // subscriber_worker.php - run as: php subscriber_worker.php
-
 $client = new ValkeyGlide();
-$client->connect(
-    addresses: [['host' => 'localhost', 'port' => 6379]]
-);
-
-$client->subscribe('tasks', 'notifications');
-
-// Process runs until killed or unsubscribed
-// Messages are delivered via the extension's callback mechanism
+$client->connect(addresses: [['host' => 'localhost', 'port' => 6379]]);
+$client->subscribe(['tasks'], function ($c, $channel, $message) {
+    // process $message
+});
 ```
 
-```php
-<?php
-// publisher.php - your web application or CLI
-$client = new ValkeyGlide();
-$client->connect(
-    addresses: [['host' => 'localhost', 'port' => 6379]]
-);
+## Important notes
 
-$client->publish('tasks', json_encode(['action' => 'process', 'id' => 42]));
-$client->close();
-```
-
-## Important Notes
-
-1. **Separate clients for pub and sub.** A subscribing client enters a special mode where regular commands are unavailable.
-2. **Blocking API.** PHP PubSub is synchronous - the subscriber process blocks while waiting for messages.
-3. **Automatic reconnection.** On disconnect, GLIDE resubscribes to all channels automatically via the Rust core.
-4. **Message loss during reconnect.** PubSub is at-most-once delivery. Use Streams for durability.
-5. **Dedicated process.** Subscribers typically run as long-lived worker processes, not within web request handlers.
+1. **Separate clients for pub and sub.** A subscribing client is in subscriber mode for the duration of the subscribe call; it cannot issue normal commands from the outer scope.
+2. **Automatic resubscribe on reconnect.** The Rust core restores subscriptions after a reconnect automatically.
+3. **At-most-once delivery.** Messages published during a reconnect gap are lost. Use Streams for durable delivery.
+4. **Callback exceptions** propagate out of `subscribe()` and leave the client in subscriber mode until you explicitly unsubscribe or close.

--- a/skills/valkey-glide-ruby/.claude-plugin/plugin.json
+++ b/skills/valkey-glide-ruby/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "valkey-glide-ruby",
-  "version": "2.0.0",
-  "description": "Use when building Ruby apps with Valkey GLIDE - valkey-rb gem (GA), redis-rb drop-in replacement, FFI bridge, PubSub, pipelining, OpenTelemetry, TLS. Not for other languages - see valkey-glide router.",
+  "version": "2.1.0",
+  "description": "Use when building Ruby apps with Valkey GLIDE - valkey-rb gem (GA), single Valkey class, drop-in for redis-rb, FFI bridge, varargs subscribe, pubsub_callback module method, pipelined/multi blocks, statistics method, Valkey::OpenTelemetry.init. Assumes redis-rb knowledge; only GLIDE divergence is documented.",
   "author": {
     "name": "Avi Fenesh",
     "url": "https://github.com/avifenesh"

--- a/skills/valkey-glide-ruby/skills/valkey-glide-ruby/SKILL.md
+++ b/skills/valkey-glide-ruby/skills/valkey-glide-ruby/SKILL.md
@@ -1,27 +1,57 @@
 ---
 name: valkey-glide-ruby
-description: "Use when building Ruby apps with Valkey GLIDE - valkey-rb gem (GA), redis-rb drop-in replacement, FFI bridge, PubSub, pipelining, OpenTelemetry, TLS. Not for other languages - see valkey-glide router."
-version: 2.0.0
+description: "Use when building Ruby apps with Valkey GLIDE - valkey-rb gem (GA), single Valkey class, drop-in for redis-rb, FFI bridge, varargs subscribe, pubsub_callback module method, pipelined/multi blocks, statistics method, Valkey::OpenTelemetry.init. Assumes redis-rb knowledge; only GLIDE divergence is documented."
+version: 2.1.0
 argument-hint: "[API or config question]"
 ---
 
 # Valkey GLIDE Ruby Client
 
-Synchronous Ruby client for Valkey built on the GLIDE Rust core via FFI. Drop-in replacement for redis-rb.
+Agent-facing skill for valkey-rb (GLIDE Ruby). Assumes the reader can already write redis-rb from training (`Redis.new`, `redis.set/get`, `pipelined { }`, `multi { }`). Covers only what GLIDE diverges on and what GLIDE adds on top.
 
-**Repository:** [valkey-io/valkey-glide-ruby](https://github.com/valkey-io/valkey-glide-ruby)
-
-**Status:** GA. valkey-rb 1.0.0 published on RubyGems.
+**Separate repository:** `valkey-io/valkey-glide-ruby`. Gem: `valkey-rb` on RubyGems (v1.0.0 GA).
 
 ## Routing
 
 | Question | Reference |
 |----------|-----------|
-| Setup, client creation, TLS, auth, config, redis-rb migration, reconnection | [connection](reference/features-connection.md) |
-| PubSub, subscribe, publish, sharded channels, introspection | [pubsub](reference/features-pubsub.md) |
-| Install, API status, platform support, command groups, pipelining, OpenTelemetry, limitations | [overview](reference/features-overview.md) |
+| `Valkey.new` single class for both modes (`cluster_mode: true` + `nodes:`), `url:`, TLS via `ssl:` + `ssl_params:` (`ca_file`, `cert`, `key`, `ca_path`, `root_certs`), reconnect, auth, `disconnect!` alias | [connection](reference/features-connection.md) |
+| Varargs `subscribe(*channels)` / `psubscribe(*patterns)` - NOT arrays; no `on.message` block form; override `pubsub_callback` module method; sharded `ssubscribe` / `spublish` implemented; introspection via `pubsub_*` helpers | [pubsub](reference/features-pubsub.md) |
+| `gem install valkey-rb`, Ruby 2.6+, nested error hierarchy, `pipelined { }` / `multi { }` blocks, **MULTI/EXEC batching falls back to sequential** (FFI stability), `statistics` (NOT `get_statistics`), `Valkey::OpenTelemetry.init` | [overview](reference/features-overview.md) |
 
-## Cross-References
+## The #1 agent mistake: statistics method
 
-- `valkey-glide` skill - shared architecture, cluster topology, connection model
-- `valkey` skill - Valkey server commands, data types, patterns
+Models often invent `client.get_statistics` with a nested `stats[:connection_stats][:active_connections]` shape. Neither exists. The real API is:
+
+```ruby
+stats = client.statistics   # NO `get_` prefix
+stats[:total_connections]   # flat keys only
+stats[:total_clients]
+stats[:total_values_compressed]
+# ... all top-level integer keys
+```
+
+See features-overview for the full key list.
+
+## Grep hazards
+
+1. **`publish(channel, message)` - STANDARD ORDER.** Ruby GLIDE matches redis-rb convention. Does NOT reverse args (unlike Python / Node / Java GLIDE which reverse).
+2. **`spublish(channel, message)` - STANDARD ORDER.** Same convention. Sharded publish is implemented.
+3. **`subscribe(*channels)` - VARARGS, not array.** `redis.subscribe("ch1", "ch2")`. Passing an array `subscribe(["ch1"])` treats the array as the first channel, not as a list.
+4. **No `on.message` block form.** redis-rb's `redis.subscribe("ch") { |on| on.message { } }` does NOT work. The subscribe call returns once the server ACKs the subscription; messages arrive through the FFI callback.
+5. **Message delivery: override `pubsub_callback` module method.** The default `Valkey::PubSubCallback#pubsub_callback(_client_ptr, kind, msg_ptr, msg_len, chan_ptr, chan_len, pat_ptr, pat_len)` prints messages. To handle messages, re-open `Valkey` and override it before creating the client.
+6. **`statistics` (NOT `get_statistics`).** Returns a flat hash of connection and compression counters. No `connection_stats` nested hash, no `command_stats`.
+7. **OpenTelemetry: `Valkey::OpenTelemetry.init(traces:, metrics:, flush_interval_ms:)`.** NOT `Valkey.new(tracing: true)` - that option is ignored. Configure OTel once per process; second init is a warning no-op.
+8. **MULTI/EXEC/DISCARD in a `pipelined` block falls back to sequential.** The gem code has a `WORKAROUND: The underlying Glide FFI backend has stability issues when batching transactional commands` - transactional ops are issued one-by-one inside a `pipelined` block. Plain `multi { }` (outside pipelined) works normally.
+9. **Single `Valkey` class, not `Valkey::Client` + `Valkey::Cluster`.** Cluster mode via `Valkey.new(nodes: [...], cluster_mode: true)` option.
+10. **Error hierarchy is NESTED under `Valkey::BaseError < StandardError`.** `CommandError`, `BaseConnectionError` are intermediate nodes with concrete leaves below them. Rescuing `Valkey::BaseError` catches everything; rescuing `StandardError` catches these plus unrelated Ruby errors.
+11. **`ssl:` scheme in `url:` is `rediss://`.** GLIDE uses that URL to determine TLS.
+12. **`reconnect_delay` / `reconnect_delay_max` interact to derive `exponent_base`** internally. They are not independent caps. The gem computes `exponent_base` from `(max_delay / base_delay) ** (1 / retries)`.
+13. **Ruby minimum is 2.6.0**, declared in the gemspec. Older 2.5 and below will not install.
+14. **Pre-built FFI shim bundled:** `libglide_ffi.so` (Linux) and `libglide_ffi.dylib` (macOS) in the gem. No Windows binary.
+15. **`disconnect!` is an alias for `close`.** Both work; redis-rb used `disconnect!` so keep the alias when migrating.
+
+## Cross-references
+
+- `valkey` skill - Valkey server commands and app patterns
+- `glide-dev` skill - GLIDE core internals and FFI binding mechanics

--- a/skills/valkey-glide-ruby/skills/valkey-glide-ruby/SKILL.md
+++ b/skills/valkey-glide-ruby/skills/valkey-glide-ruby/SKILL.md
@@ -19,6 +19,18 @@ Agent-facing skill for valkey-rb (GLIDE Ruby). Assumes the reader can already wr
 | Varargs `subscribe(*channels)` / `psubscribe(*patterns)` - NOT arrays; no `on.message` block form; override `pubsub_callback` module method; sharded `ssubscribe` / `spublish` implemented; introspection via `pubsub_*` helpers | [pubsub](reference/features-pubsub.md) |
 | `gem install valkey-rb`, Ruby 2.6+, nested error hierarchy, `pipelined { }` / `multi { }` blocks, **MULTI/EXEC batching falls back to sequential** (FFI stability), `statistics` (NOT `get_statistics`), `Valkey::OpenTelemetry.init` | [overview](reference/features-overview.md) |
 
+## Multiplexer rule
+
+One `Valkey` instance is the shared multiplexer for a Ruby process (Puma worker, Sidekiq worker, Rails app, long-running CLI). Do not create per-request clients. Do not pool multiple instances against the same node. The Rust core pipelines concurrent Ruby threads' commands across the multiplexed connection.
+
+**Exceptions that need a dedicated client instance:**
+
+- PubSub subscribers (`subscribe` / `psubscribe` / `ssubscribe` hold the connection in subscriber mode - occupancy).
+- Blocking commands (`blpop`, `brpop`, `blmove`, `bzpopmin`, `bzpopmax`, `blmpop`, `bzmpop`, `xread` / `xreadgroup` with `block`, `wait`) - occupancy, they hold the multiplexed connection for the block duration.
+- `watch` / `multi` / `exec` optimistic-locking flows - connection-state leakage on a shared multiplexer, not occupancy.
+
+Large values are NOT an exception - they pipeline through the multiplexer fine.
+
 ## The #1 agent mistake: statistics method
 
 Models often invent `client.get_statistics` with a nested `stats[:connection_stats][:active_connections]` shape. Neither exists. The real API is:

--- a/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-connection.md
+++ b/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-connection.md
@@ -1,10 +1,10 @@
 # Connection and Configuration (Ruby)
 
-Use when creating a GLIDE Ruby client, choosing between standalone and cluster mode, configuring authentication, TLS, timeouts, reconnection, read strategy, or migrating from redis-rb.
+Use when constructing a valkey-rb client, switching between standalone and cluster, configuring TLS, auth, reconnection, or mapping redis-rb config to GLIDE config.
 
-## Client Class
+## Single Valkey class
 
-The Ruby client uses a single `Valkey` class. Standalone and cluster modes are controlled by the `cluster_mode` option.
+Both standalone and cluster use the same `Valkey` class. Mode is selected by `cluster_mode: true` + `nodes:`.
 
 ```ruby
 require "valkey"
@@ -12,7 +12,7 @@ require "valkey"
 # Standalone (default)
 client = Valkey.new(host: "localhost", port: 6379)
 
-# Cluster mode
+# Cluster
 client = Valkey.new(
   nodes: [
     { host: "node1.example.com", port: 6379 },
@@ -22,109 +22,161 @@ client = Valkey.new(
 )
 ```
 
-## Standalone Connection
+Only seed addresses are needed - topology is discovered automatically.
 
-Minimal:
+## Constructor options
 
-```ruby
-client = Valkey.new
-# Defaults to localhost:6379
-```
+The `initialize` method builds an internal `redis[s]://` URI plus a JSON options hash. These kwargs are all recognized:
 
-With full configuration:
+| Option | Notes |
+|--------|-------|
+| `host:` | default `"127.0.0.1"` |
+| `port:` | default `6379` |
+| `nodes:` | array of `{host:, port:}` - required for cluster |
+| `cluster_mode:` | `true` for cluster |
+| `url:` | `redis://user:pass@host:port/db` or `rediss://...` - parsed first, explicit kwargs override |
+| `password:` | plain password (legacy AUTH) |
+| `username:` | ACL username - used with `password:` |
+| `db:` | integer DB index, must be non-negative |
+| `ssl:` | `true` to switch URI scheme to `rediss://` |
+| `ssl_params:` | Hash with `ca_file:`, `cert:`, `key:`, `ca_path:`, `root_certs:` |
+| `timeout:` | seconds, default `5.0`, maps to `request_timeout` in milliseconds |
+| `connect_timeout:` | seconds, maps to `connection_timeout` in milliseconds |
+| `protocol:` | `:resp2` (default) or `:resp3` |
+| `client_name:` | string |
+| `reconnect_attempts:` | integer, non-negative |
+| `reconnect_delay:` | seconds (positive number) |
+| `reconnect_delay_max:` | seconds; used to derive `exponent_base` internally |
+| `tracing:` | **NOT a real option.** OpenTelemetry is configured via `Valkey::OpenTelemetry.init`. |
 
-```ruby
-client = Valkey.new(
-  host: "localhost",
-  port: 6379,
-  password: "secret",
-  username: "myuser",
-  db: 0,
-  ssl: true,
-  timeout: 5.0,
-  connect_timeout: 3.0,
-  client_name: "my-app",
-  protocol: :resp2,
-)
-```
-
-## URL-Based Connection
+## URL-based connect
 
 ```ruby
 client = Valkey.new(url: "redis://user:pass@localhost:6379/0")
+client = Valkey.new(url: "rediss://secure.example.com:6380")   # TLS
 ```
 
-Supports `redis://` and `rediss://` (TLS) schemes, matching redis-rb conventions.
-
-## Cluster Connection
-
-```ruby
-client = Valkey.new(
-  nodes: [
-    { host: "node1.example.com", port: 6379 },
-    { host: "node2.example.com", port: 6380 },
-  ],
-  cluster_mode: true
-)
-```
-
-Only seed addresses are needed - GLIDE discovers full topology automatically.
+`redis://` and `rediss://` schemes only. Explicit kwargs passed alongside `url:` win over URL-parsed values.
 
 ## Authentication
 
 ```ruby
-# Password only
-client = Valkey.new(password: "secret")
+# Password only (legacy AUTH)
+Valkey.new(password: "secret")
 
-# Username + password (ACL)
-client = Valkey.new(username: "myuser", password: "secret")
+# ACL (username + password)
+Valkey.new(username: "myuser", password: "secret")
 
 # Via URL
-client = Valkey.new(url: "redis://myuser:secret@localhost:6379")
+Valkey.new(url: "redis://myuser:secret@localhost:6379")
 ```
 
-## TLS/SSL
+Passwords and usernames are URL-escaped when building the internal URI.
+
+## TLS / mTLS
 
 ```ruby
 # Basic TLS
-client = Valkey.new(
+Valkey.new(
   host: "valkey.example.com",
   port: 6380,
   ssl: true
 )
 
-# With custom certificates (mTLS)
-client = Valkey.new(
+# mTLS with client certs
+Valkey.new(
   host: "valkey.example.com",
   port: 6380,
   ssl: true,
   ssl_params: {
     ca_file: "/path/to/ca.crt",
-    cert: "/path/to/client.crt",
-    key: "/path/to/client.key",
+    cert: "/path/to/client.crt",     # or an OpenSSL::X509::Certificate
+    key: "/path/to/client.key",      # or an OpenSSL::PKey::PKey
+    ca_path: "/path/to/ca/dir",      # scans *.crt and *.pem
+    root_certs: ["<PEM string>"]     # explicit PEM blobs
   }
 )
 ```
 
+`cert:` and `key:` accept file paths (read as binary) OR objects responding to `to_pem` / `to_der`. File paths are validated at construction time - missing / unreadable files raise `ArgumentError`.
+
 ## Reconnection
 
+Three kwargs; the gem derives `exponent_base` internally:
+
 ```ruby
-client = Valkey.new(
-  reconnect_attempts: 5,
-  reconnect_delay: 0.5,        # initial delay in seconds
-  reconnect_delay_max: 5.0,    # max delay cap in seconds
+Valkey.new(
+  reconnect_attempts: 5,         # cap for the growing-delay phase
+  reconnect_delay: 0.5,          # base in seconds
+  reconnect_delay_max: 5.0       # used to compute exponent_base
 )
 ```
 
-The client retries with exponential backoff up to the configured maximum.
+Internally:
+- `base_delay * 1000` -> `factor` (milliseconds)
+- `exponent_base = max([calculated_base.round, 2])`, where `calculated_base = (max_delay / base_delay) ** (1.0 / retries)`
+- `jitter_percent = 0`
 
-## Other Options
+Setting only `reconnect_attempts:` (without `reconnect_delay:`) defaults base to 0.5 s; setting only `reconnect_delay_max:` is also accepted.
 
-- **Timeouts**: `timeout: 5.0` (general), `connect_timeout: 3.0` (connection). In seconds.
-- **Protocol**: `protocol: :resp2` or `:resp3`.
-- **Database**: `db: 2` at init, or `client.select(2)` at runtime.
-- **Closing**: `client.close` or `client.disconnect!` (redis-rb alias).
+## Timeouts
 
-## redis-rb Compatibility
+```ruby
+Valkey.new(
+  timeout: 5.0,          # request timeout in seconds (stored as ms)
+  connect_timeout: 3.0   # connection establishment timeout in seconds (stored as ms)
+)
+```
 
-Drop-in replacement: same option names, method names (`set`, `get`, `hset`, `lpush`), `pipelined { }` block syntax, `multi { }` transactions, `redis://` URL schemes, and `disconnect!` alias. Change `require "redis"` to `require "valkey"` and `Redis.new` to `Valkey.new`.
+Positive numeric required. Non-numeric or non-positive raises `ArgumentError`.
+
+## Protocol
+
+```ruby
+Valkey.new(protocol: :resp3)   # :resp2, :resp3, "resp3", or 3
+```
+
+Default is RESP2. The internal config normalizes the value to `"RESP2"` or `"RESP3"`.
+
+## Closing
+
+```ruby
+client.close
+client.disconnect!     # alias for close
+```
+
+Both idempotent. After close, the client's `@connection` pointer is nil-ed out.
+
+## Statistics (process-global)
+
+```ruby
+stats = client.statistics           # NOT `get_statistics`
+stats[:total_connections]           # flat keys
+stats[:total_clients]
+stats[:total_values_compressed]
+# see features-overview for the full key list
+```
+
+Global across all clients in the process. Not per-instance.
+
+## OpenTelemetry (separate init, NOT a constructor flag)
+
+```ruby
+Valkey::OpenTelemetry.init(
+  traces:  { endpoint: "http://otel:4318/v1/traces", sample_percentage: 10 },
+  metrics: { endpoint: "http://otel:4318/v1/metrics" },
+  flush_interval_ms: 5000
+)
+
+client = Valkey.new                  # traces/metrics flow automatically
+```
+
+Call once per process. `tracing:` / `otel:` on `Valkey.new` have no effect.
+
+## redis-rb migration notes
+
+`Redis.new` options that map 1:1: `host`, `port`, `password`, `username`, `db`, `url`, `ssl`, `ssl_params`, `timeout`, `connect_timeout`, `client_name`, `reconnect_attempts`.
+
+Options that **don't exist** in valkey-rb: `driver:`, `sentinels:`, `inherit_socket:`, `id:` (use `client_name:`), `logger:`.
+
+No Sentinel support. Applications using `Redis.new(sentinels: [...])` need to front valkey-rb with a different HA strategy (GLIDE cluster or a proxy).

--- a/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-overview.md
+++ b/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-overview.md
@@ -54,7 +54,7 @@ Namespace is `Valkey`, not `ValkeyGlide`. `require "valkey"` gives you everythin
 | HyperLogLogCommands | `pfadd`, `pfcount`, `pfmerge` |
 | JsonCommands | Valkey JSON module |
 | VectorSearchCommands | Valkey Search module (`FT.SEARCH`, `FT.AGGREGATE`) |
-| ClusterCommands | `cluster_info`, `cluster_nodes`, `cluster_slots`, `cluster_addslots`, etc. |
+| ClusterCommands | `cluster_info`, `cluster_nodes`, `cluster_slots`, `cluster_addslots`, `cluster_bumpepoch`, `cluster_countkeysinslot`, `cluster_forget`, `cluster_meet`, `cluster_reset`, `cluster_failover`, `asking` |
 | ConnectionCommands | `ping`, `echo`, `select`, `auth`, `hello`, `client_*`, `quit` |
 | ServerCommands | `info`, `dbsize`, `flushdb`, `config_*`, `acl_*`, `slowlog_*` |
 | FunctionCommands | `function_load`, `fcall`, `fcall_ro` |

--- a/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-overview.md
+++ b/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-overview.md
@@ -1,19 +1,17 @@
 # Ruby Client Overview
 
-Use when checking GLIDE Ruby capabilities, available commands, and limitations.
+Use when checking GLIDE Ruby capabilities, limitations, and install options.
 
 ## Status
 
-**GA** - valkey-rb 1.0.0 published on RubyGems. Production-ready. Synchronous (blocking) API via Ruby FFI gem, redis-rb drop-in replacement, single `Valkey` class for both standalone and cluster.
+**GA** - valkey-rb 1.0.0 on RubyGems. Synchronous blocking API via the Ruby FFI gem calling the bundled GLIDE Rust core. Single `Valkey` class for both standalone and cluster. Designed as a redis-rb drop-in.
 
 ## Requirements
 
-- Ruby 2.6+
-- FFI gem (~> 1.17.0)
-- google-protobuf gem (~> 3.23)
-- Valkey 7.2+ or Redis 6.2+
-
-The gem bundles pre-built `libglide_ffi.so` (Linux) or `libglide_ffi.dylib` (macOS).
+- Ruby **>= 2.6.0** (gemspec `required_ruby_version`)
+- `ffi` gem
+- Pre-built `libglide_ffi.so` (Linux) / `libglide_ffi.dylib` (macOS) bundled in the gem
+- **No Windows binary**
 
 ## Installation
 
@@ -21,17 +19,25 @@ The gem bundles pre-built `libglide_ffi.so` (Linux) or `libglide_ffi.dylib` (mac
 gem install valkey-rb
 ```
 
-Or in Gemfile:
-
+Gemfile:
 ```ruby
-gem 'valkey-rb'
+gem "valkey-rb"
 ```
 
-## Available Command Groups
+Usage:
+```ruby
+require "valkey"
+valkey = Valkey.new
+valkey.set("key", "value")
+```
 
-20 command modules covering the full Valkey command surface:
+Namespace is `Valkey`, not `ValkeyGlide`. `require "valkey"` gives you everything.
 
-| Module | Key Commands |
+## Command groups
+
+20 command modules included in the `Commands` module; all are mixed into `Valkey` instances.
+
+| Module | Key commands |
 |--------|-------------|
 | StringCommands | `set`, `get`, `incr`, `mget`, `mset`, `append`, `getdel`, `getex` |
 | HashCommands | `hset`, `hget`, `hgetall`, `hdel`, `hmset`, `hscan` |
@@ -40,92 +46,150 @@ gem 'valkey-rb'
 | SortedSetCommands | `zadd`, `zscore`, `zrank`, `zrange`, `zpopmin`, `zpopmax` |
 | StreamCommands | `xadd`, `xread`, `xreadgroup`, `xack`, `xclaim`, `xautoclaim` |
 | PubSubCommands | `subscribe`, `publish`, `psubscribe`, `ssubscribe`, `spublish` |
-| ScriptingCommands | `eval`, `evalsha`, `script` |
-| TransactionCommands | `multi`, `exec`, `discard`, `watch`, `unwatch` |
+| ScriptingCommands | `eval`, `evalsha`, `script_*` |
+| TransactionCommands | `multi`, `watch`, `unwatch`, `discard` |
 | GenericCommands | `del`, `exists`, `expire`, `ttl`, `type`, `scan`, `keys`, `sort` |
 | GeoCommands | `geoadd`, `geodist`, `geosearch`, `geosearchstore` |
 | BitmapCommands | `setbit`, `getbit`, `bitcount`, `bitop`, `bitfield` |
 | HyperLogLogCommands | `pfadd`, `pfcount`, `pfmerge` |
-| JsonCommands | JSON module commands |
-| VectorSearchCommands | FT.SEARCH, FT.AGGREGATE |
-| ClusterCommands | `cluster info`, `cluster nodes`, `cluster slots` |
-| ConnectionCommands | `ping`, `echo`, `select`, `auth`, `hello`, `client` |
-| ServerCommands | `info`, `dbsize`, `flushdb`, `config`, `acl`, `slowlog` |
-| FunctionCommands | `function load`, `fcall`, `fcall_ro` |
-| ModuleCommands | `module load`, `module list` |
+| JsonCommands | Valkey JSON module |
+| VectorSearchCommands | Valkey Search module (`FT.SEARCH`, `FT.AGGREGATE`) |
+| ClusterCommands | `cluster_info`, `cluster_nodes`, `cluster_slots`, `cluster_addslots`, etc. |
+| ConnectionCommands | `ping`, `echo`, `select`, `auth`, `hello`, `client_*`, `quit` |
+| ServerCommands | `info`, `dbsize`, `flushdb`, `config_*`, `acl_*`, `slowlog_*` |
+| FunctionCommands | `function_load`, `fcall`, `fcall_ro` |
+| ModuleCommands | `module_load`, `module_list`, `module_unload` |
 
-## Features
+## Batching
 
-| Feature | Available | Notes |
-|---------|-----------|-------|
-| Standalone mode | Yes | `Valkey.new(host: ...)` |
-| Cluster mode | Yes | `Valkey.new(nodes: [...], cluster_mode: true)` |
-| TLS/mTLS | Yes | `ssl: true`, `ssl_params: { ... }` |
-| Authentication | Yes | Password, ACL username+password |
-| PubSub | Yes | Subscribe, psubscribe, ssubscribe (sharded) |
-| Pipelining | Yes | `client.pipelined { \|pipe\| ... }` |
-| Transactions | Yes | `client.multi { \|tx\| ... }` |
-| OpenTelemetry | Yes | `tracing: true` in constructor |
-| Client statistics | Yes | `client.get_statistics` |
-| redis-rb compat | Yes | Drop-in replacement API |
-| URL-based connect | Yes | `redis://` and `rediss://` schemes |
-| Server modules | Yes | JSON and vector search commands |
-| Functions | Yes | Valkey Functions (FCALL) |
+Two block forms. Both match the redis-rb API shape, with one caveat.
+
+```ruby
+# Pipeline - non-atomic, higher throughput
+results = valkey.pipelined do |pipe|
+  pipe.set("a", 1)
+  pipe.incr("a")
+  pipe.get("a")
+end
+
+# MULTI - atomic transaction
+results = valkey.multi do |tx|
+  tx.set("a", 1)
+  tx.incr("a")
+end
+```
+
+**FFI stability caveat on `pipelined` containing MULTI/EXEC/DISCARD.** The gem detects transactional request types inside a `pipelined` block and falls back to sequential execution instead of native batching (from `lib/valkey.rb`: `WORKAROUND: The underlying Glide FFI backend has stability issues when batching transactional commands`). For atomic transactions use `multi do |tx|` directly - not nested inside `pipelined`.
+
+`watch` outside a `multi` block for optimistic locking:
+
+```ruby
+valkey.watch("key")
+if valkey.get("key") == "expected"
+  valkey.multi do |tx|
+    tx.set("key", "new")
+  end
+end
+```
+
+## Error hierarchy
+
+All under the `Valkey` namespace, nested under `BaseError`:
+
+```
+Valkey::BaseError < StandardError
+|-- ProtocolError                       # bad initial reply byte (forking issue)
+|-- CommandError                        # server command errors
+|   |-- PermissionError                 # ACL denied
+|   |-- WrongTypeError                  # WRONGTYPE
+|   |-- OutOfMemoryError                # OOM
+|   `-- NoScriptError                   # NOSCRIPT on EVALSHA
+|-- BaseConnectionError                 # connection issues
+|   |-- CannotConnectError              # initial connect failed
+|   |-- ConnectionError                 # lost mid-operation
+|   |-- TimeoutError                    # request timeout
+|   |-- InheritedError                  # forked socket inherited
+|   `-- ReadOnlyError                   # write to read-only replica
+|-- InvalidClientOptionError            # bad constructor args
+`-- SubscriptionError                   # PubSub state violation
+```
+
+Rescue `Valkey::BaseError` to catch everything from the client. `CommandError` errors inside an EXEC response come back as `CommandError` instances inside the result array (not raised) - check each result for that class before using it.
+
+## Client statistics
+
+**Method is `statistics` - NOT `get_statistics`.** Returns a FLAT hash of integer counters:
+
+```ruby
+stats = client.statistics
+
+stats[:total_connections]         # all connections opened to Valkey
+stats[:total_clients]             # total GLIDE clients
+stats[:total_values_compressed]
+stats[:total_values_decompressed]
+stats[:total_original_bytes]
+stats[:total_bytes_compressed]
+stats[:total_bytes_decompressed]
+stats[:compression_skipped_count]
+```
+
+These counters are **process-global**, tracked across all clients in the Ruby process. There is no `connection_stats` or `command_stats` nested hash - do not invent one.
 
 ## OpenTelemetry
 
-Built-in tracing - no separate instrumentation gem needed:
+**Configure via the module method, NOT a constructor flag.** Valid endpoints are `http://`, `grpc://`, or `file://`.
 
 ```ruby
 require "valkey"
-require "opentelemetry/sdk"
 
-OpenTelemetry::SDK.configure do |c|
-  c.service_name = "my-app"
-end
+Valkey::OpenTelemetry.init(
+  traces: {
+    endpoint: "http://localhost:4318/v1/traces",
+    sample_percentage: 10
+  },
+  metrics: {
+    endpoint: "http://localhost:4318/v1/metrics"
+  },
+  flush_interval_ms: 5000
+)
 
-client = Valkey.new(host: "localhost", port: 6379, tracing: true)
-# All commands are automatically traced
-```
-
-## Client Statistics
-
-```ruby
 client = Valkey.new
-client.set("key", "value")
-
-stats = client.get_statistics
-puts "Active connections: #{stats[:connection_stats][:active_connections]}"
-puts "Total commands: #{stats[:command_stats][:total_commands]}"
+# Subsequent commands emit spans / metrics automatically.
 ```
 
-## Error Types
+Call `init` once per process. The module warns and no-ops on a second init. `Valkey.new(tracing: true)` has no effect - that option does not exist in `initialize`.
 
-| Exception | Description |
-|-----------|-------------|
-| `Valkey::CommandError` | Command execution error |
-| `Valkey::PermissionError` | ACL permission denied |
-| `Valkey::WrongTypeError` | Wrong data type for command |
-| `Valkey::OutOfMemoryError` | Server out of memory |
-| `Valkey::NoScriptError` | EVALSHA script not found |
-| `Valkey::CannotConnectError` | Initial connection failed |
-| `Valkey::ConnectionError` | Connection lost during operation |
-| `Valkey::TimeoutError` | Request timed out |
-| `Valkey::ReadOnlyError` | Write to read-only replica |
-| `Valkey::SubscriptionError` | PubSub subscription error |
+## Features matrix
 
-## redis-rb Drop-In Replacement
+| Feature | Available | Notes |
+|---------|-----------|-------|
+| Standalone mode | Yes | `Valkey.new(host:, port:)` |
+| Cluster mode | Yes | `Valkey.new(nodes:, cluster_mode: true)` |
+| TLS / mTLS | Yes | `ssl: true` + `ssl_params:` |
+| Auth - password, ACL | Yes | `password:`, `username:` |
+| URL-based connect | Yes | `redis://` / `rediss://` |
+| PubSub exact / pattern | Yes | Varargs + `pubsub_callback` |
+| Sharded PubSub | Yes | `ssubscribe`, `spublish`, `sunsubscribe` |
+| Pipelining | Yes | `pipelined { \|pipe\| }` |
+| Transactions | Yes | `multi { \|tx\| }` (use outside `pipelined` due to FFI workaround) |
+| OpenTelemetry | Yes | `Valkey::OpenTelemetry.init` (not a constructor option) |
+| Statistics | Yes | `client.statistics` (not `get_statistics`) |
+| Valkey Functions | Yes | `fcall`, `fcall_ro`, `function_load` |
+| Valkey JSON | Yes | Via JsonCommands |
+| Valkey Search | Yes | Via VectorSearchCommands |
+| redis-rb drop-in | Mostly | Subscribe/unsubscribe block form NOT supported |
+| Async API | **No** | Ruby FFI binding is synchronous |
+| Windows | **No** | Pre-built binaries for Linux and macOS only |
 
-Change `require "redis"` to `require "valkey"` and `Redis.new` to `Valkey.new`. Same method names, return types, `pipelined` block syntax, `multi`/`exec` pattern, URL schemes, and `disconnect!` alias.
+## redis-rb drop-in notes
 
-## Limitations
+Replace `require "redis"` with `require "valkey"` and `Redis.new` with `Valkey.new`. Most method signatures and return types match. Known divergences:
 
-- No official framework integrations documented (Rails, Sidekiq)
-- No async API - Ruby FFI binding is synchronous
-- No Windows support (pre-built binaries for Linux and macOS only)
+- **No `redis.subscribe("ch") { |on| on.message { } }` block.** Override `pubsub_callback` instead (see features-pubsub).
+- **Statistics method name differs** (`statistics`, not something else).
+- **MULTI inside `pipelined`** runs sequentially due to FFI stability.
+- **`disconnect!` is an alias for `close`** - both work.
 
 ## Repository
 
-Separate repo: [valkey-io/valkey-glide-ruby](https://github.com/valkey-io/valkey-glide-ruby)
-
-Gem: `gem install valkey-rb`
+`valkey-io/valkey-glide-ruby` (separate repo from the main GLIDE monorepo). Gem name: `valkey-rb`.

--- a/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-pubsub.md
+++ b/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-pubsub.md
@@ -110,7 +110,7 @@ valkey.sunsubscribe("shard-news")
 
 ## Important notes
 
-1. **Separate clients for pub and sub.** A subscribing client is in subscriber mode and cannot issue non-pubsub commands from the outer thread.
+1. **Separate clients for pub and sub (occupancy).** A subscribing client is in subscriber mode and cannot issue non-pubsub commands from the outer thread. This is occupancy - the same reason blocking commands need dedicated clients - not connection-state leakage like WATCH/MULTI/EXEC.
 2. **Automatic resubscribe on reconnect.** Rust core restores subscriptions.
 3. **At-most-once delivery.** Messages during a reconnect gap are lost. Use Streams for durability.
 4. **`pubsub_callback` runs on an FFI-managed thread.** Treat it like a signal handler - minimal, non-blocking.

--- a/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-pubsub.md
+++ b/skills/valkey-glide-ruby/skills/valkey-glide-ruby/reference/features-pubsub.md
@@ -1,140 +1,117 @@
 # Pub/Sub (Ruby)
 
-Use when implementing real-time message broadcasting in Ruby - chat, notifications, event distribution, or inter-process messaging. For durable message processing with consumer groups, use Streams instead.
+Use when wiring publish/subscribe in valkey-rb. Assumes redis-rb familiarity - only divergence is documented.
 
-GLIDE Ruby supports all three PubSub subscription modes (exact, pattern, sharded) plus introspection commands. The API follows redis-rb conventions.
+## Divergence from redis-rb
 
-## Subscription Modes
+| | redis-rb | valkey-rb |
+|---|---|---|
+| `subscribe("ch") { \|on\| on.message { } }` block form | yes | **no - block is ignored** |
+| Channel args | varargs | varargs (same) |
+| Message delivery | block via connection loop | **`pubsub_callback` module method on the FFI side** |
+| Sharded `ssubscribe` / `spublish` | not implemented | **implemented** |
+| Introspection via `pubsub(:channels)` | yes | yes, plus `pubsub_channels` / `pubsub_numsub` / `pubsub_numpat` / `pubsub_shardchannels` / `pubsub_shardnumsub` direct methods |
 
-| Mode | Subscribe | Unsubscribe | Publish | Cluster Only |
-|------|-----------|-------------|---------|--------------|
-| Exact | `subscribe` | `unsubscribe` | `publish` | No |
-| Pattern | `psubscribe` | `punsubscribe` | `publish` | No |
-| Sharded | `ssubscribe` | `sunsubscribe` | `spublish` | Yes (Valkey 7.0+) |
-
-## Subscribe and Publish
+## Canonical shape - override pubsub_callback, then subscribe
 
 ```ruby
 require "valkey"
 
-# Subscriber - dedicated client
-subscriber = Valkey.new(host: "localhost", port: 6379)
-subscriber.subscribe("news", "events")
+# Override the callback BEFORE creating the client
+class Valkey
+  module PubSubCallback
+    def pubsub_callback(_client_ptr, kind, msg_ptr, msg_len, chan_ptr, chan_len, pat_ptr, pat_len)
+      message = msg_ptr.read_string(msg_len)
+      channel = chan_ptr.read_string(chan_len)
+      pattern = pat_ptr.read_string(pat_len) if pat_len.positive?
 
-# Publisher - separate client
-publisher = Valkey.new(host: "localhost", port: 6379)
-count = publisher.publish("events", "Hello subscribers!")
-puts "Delivered to #{count} subscribers"
+      # your handling here
+      puts "[#{channel}] (#{kind}) #{message}"
+    end
+  end
+end
+
+subscriber = Valkey.new
+subscriber.subscribe("news", "events")       # varargs
 ```
 
-## Pattern Subscriptions
+The callback fires on the FFI thread. Keep it non-blocking. Heavy work should enqueue onto your own queue for a worker thread to drain.
+
+## Publish
+
+```ruby
+publisher = Valkey.new
+count = publisher.publish("events", "Hello subscribers!")   # channel, message
+```
+
+Standard `(channel, message)` order - not reversed.
+
+## Pattern subscriptions
 
 ```ruby
 subscriber = Valkey.new
-subscriber.psubscribe("news.*", "events:*")
+subscriber.psubscribe("news.*", "events:*")   # varargs
 
-# Unsubscribe from specific patterns
-subscriber.punsubscribe("news.*")
-
-# Unsubscribe from all patterns
-subscriber.punsubscribe
+subscriber.punsubscribe                        # no args = all patterns
+subscriber.punsubscribe("news.*")              # specific pattern
 ```
 
-## Sharded PubSub (Cluster Mode)
+The `pubsub_callback` you overrode receives pattern subscriptions with a non-zero `pat_len`; check it to tell pattern vs exact delivery.
 
-Sharded channels are routed by hash slot. Requires Valkey 7.0+ and cluster mode.
+## Sharded PubSub (cluster)
+
+Unlike redis-rb, valkey-rb implements sharded PubSub:
 
 ```ruby
-client = Valkey.new(
+cluster = Valkey.new(
   nodes: [{ host: "node1.example.com", port: 6379 }],
   cluster_mode: true
 )
 
-# Subscribe to sharded channels
-client.ssubscribe("shard-news", "shard-updates")
-
-# Publish to sharded channel
-client.spublish("shard-news", "Breaking news!")
-
-# Unsubscribe
-client.sunsubscribe("shard-news")
-client.sunsubscribe  # all sharded channels
+cluster.ssubscribe("shard-news", "shard-updates")
+cluster.spublish("shard-news", "hi")    # standard order
+cluster.sunsubscribe                    # all sharded channels
+cluster.sunsubscribe("shard-news")      # specific
 ```
 
-## PubSub Introspection
+Requires Valkey 7.0+ server.
 
-Query active channels and subscriber counts without entering subscriber mode:
+## Introspection
+
+Direct methods (no subscriber mode required):
 
 ```ruby
-client = Valkey.new
-
-# List active channels
-channels = client.pubsub_channels
-# => ["news", "events"]
-
-# Filter by pattern
-channels = client.pubsub_channels("news.*")
-# => ["news.sports", "news.tech"]
-
-# Subscriber counts for specific channels
-counts = client.pubsub_numsub("news", "events")
-# => ["news", 5, "events", 3]
-
-# Number of active pattern subscriptions
-pat_count = client.pubsub_numpat
-# => 2
-
-# Sharded channel introspection (cluster only)
-sharded = client.pubsub_shardchannels
-shard_counts = client.pubsub_shardnumsub("shard1", "shard2")
+valkey.pubsub_channels                   # all active
+valkey.pubsub_channels("news.*")         # filtered
+valkey.pubsub_numsub("ch1", "ch2")       # => ["ch1", 5, "ch2", 3]
+valkey.pubsub_numpat                     # pattern count
+valkey.pubsub_shardchannels              # sharded active
+valkey.pubsub_shardnumsub("s1", "s2")
 ```
 
-### Convenience Method
+Convenience dispatcher:
 
 ```ruby
-# All introspection via pubsub() helper
-client.pubsub(:channels)
-client.pubsub(:channels, "news.*")
-client.pubsub(:numsub, "ch1", "ch2")
-client.pubsub(:numpat)
-client.pubsub(:shardchannels)
-client.pubsub(:shardnumsub, "shard1")
+valkey.pubsub(:channels)                 # -> pubsub_channels
+valkey.pubsub(:numsub, "ch1", "ch2")     # -> pubsub_numsub
+valkey.pubsub(:numpat)                   # -> pubsub_numpat
 ```
 
-## PubSub Callback
-
-Messages arrive via a callback at the FFI layer. The callback receives:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `kind` | Integer | Message kind (exact, pattern, sharded) |
-| `message` | String | The published payload |
-| `channel` | String | Channel the message was published to |
-| `pattern` | String | Matching pattern (pattern subscriptions only) |
-
-## redis-rb Migration
-
-The PubSub API follows redis-rb conventions:
+## Unsubscribe shapes
 
 ```ruby
-# redis-rb
-redis = Redis.new
-redis.subscribe("channel") do |on|
-  on.message { |ch, msg| puts "#{ch}: #{msg}" }
-end
-
-# valkey-rb
-valkey = Valkey.new
-valkey.subscribe("channel")
-# Messages delivered via callback mechanism
+valkey.unsubscribe                       # all exact channels
+valkey.unsubscribe("news", "events")     # specific (varargs)
+valkey.punsubscribe                      # all patterns
+valkey.punsubscribe("news.*")            # specific pattern
+valkey.sunsubscribe                      # all sharded
+valkey.sunsubscribe("shard-news")
 ```
 
-The subscribe/unsubscribe method signatures are identical. Message delivery mechanism differs - valkey-rb uses FFI callbacks through the Rust core rather than redis-rb's Ruby-level event loop.
+## Important notes
 
-## Important Notes
-
-1. **Separate clients for pub and sub.** A subscribing client enters a special mode where regular commands are unavailable.
-2. **Synchronous API.** Subscribe calls block the current thread in subscriber mode.
-3. **Automatic reconnection.** On disconnect, GLIDE resubscribes to all channels automatically via the Rust core.
-4. **Message loss during reconnect.** PubSub is at-most-once delivery. Use Streams for durability.
-5. **Full sharded PubSub.** Unlike redis-rb, valkey-rb supports sharded subscribe/publish out of the box.
+1. **Separate clients for pub and sub.** A subscribing client is in subscriber mode and cannot issue non-pubsub commands from the outer thread.
+2. **Automatic resubscribe on reconnect.** Rust core restores subscriptions.
+3. **At-most-once delivery.** Messages during a reconnect gap are lost. Use Streams for durability.
+4. **`pubsub_callback` runs on an FFI-managed thread.** Treat it like a signal handler - minimal, non-blocking.
+5. **Raw pointer parameters.** `msg_ptr`, `chan_ptr`, `pat_ptr` are `FFI::Pointer`. Call `read_string(len)` to materialize.


### PR DESCRIPTION
## Summary

Completes the paired language-skill validation series. Both valkey-glide-php and valkey-glide-ruby rewritten with the same agent-facing, divergence-only framing applied in PRs #14-#18. Both verified against v1.0.0 source. No migration skill pairs exist for these languages.

## What changed

**PHP (verified against `valkey-io/valkey-glide-php` tag v1.0.0):**

- `subscribe` / `psubscribe` take `(array \$channels, callable \$cb)` - the previous skill showed varargs. Pattern callback takes 3 args, not 4 like PHPRedis.
- `ssubscribe` / `sunsubscribe` / `spublish` are NOT implemented in v1.0.0 (stub has TODO-commented signature).
- `publish(channel, message)` is standard order - matches PHPRedis. PHP is another language that does NOT follow the Python/Node/Java reversed pattern.
- Standalone uses `new ValkeyGlide()` then `->connect(...)`; cluster takes config in the constructor.
- Requires PHP 8.2 or 8.3 (not 8.1, not 8.4).

**Ruby (verified against `valkey-io/valkey-glide-ruby` main @ v1.0.0):**

- Method is `statistics`, not `get_statistics`. Return shape is a FLAT hash of integer counters (`:total_connections`, `:total_clients`, compression counters) - NOT the `stats[:connection_stats][:active_connections]` shape the previous skill claimed.
- OpenTelemetry is configured via `Valkey::OpenTelemetry.init(traces:, metrics:, flush_interval_ms:)`, NOT via `Valkey.new(tracing: true)` - that constructor option is not read.
- `MULTI`/`EXEC`/`DISCARD` inside a `pipelined` block falls back to sequential execution (workaround for FFI stability). Atomic transactions must use `multi { }` at the top level.
- `subscribe(*channels)` is varargs; redis-rb's block-based form does not work. Override `Valkey::PubSubCallback#pubsub_callback` to handle messages.
- Error hierarchy is nested under `Valkey::BaseError < StandardError` with `CommandError` and `BaseConnectionError` as intermediate parents; previous skill listed only leaves.

Both skills bumped 2.0.0 -> 2.1.0 (editorial refactor). No cross-skill markdown links (avoids check-links CI pitfall seen in PR #14/#16).

## Cross-language recap after this PR

Reversed publish argument order is confirmed to be Python + Node + Java ONLY. Go, C#, PHP, Ruby all keep the standard `(channel, message)` order.

## Test plan

- [x] `subscribe`/`psubscribe` signatures grepped in `valkey_glide.stub.php` @ v1.0.0
- [x] `publish` arg order confirmed in both stubs
- [x] Ruby `statistics` method + return shape read from `lib/valkey.rb`
- [x] OTel init path read from `lib/valkey/opentelemetry.rb`
- [x] MULTI/EXEC FFI workaround read from `lib/valkey.rb` `send_batch_commands`
- [x] Error hierarchy read from `lib/valkey/errors.rb`
- [ ] CI (check-links, agnix lint, Gemini, Copilot, Claude, Cursor Bugbot)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates, but they correct several API-signature and behavior claims (notably PubSub and Ruby batching/OTel), which could impact users relying on the previous guidance.
> 
> **Overview**
> Updates the `valkey-glide-php` and `valkey-glide-ruby` skills to a **divergence-only, agent-facing** format validated against client v1.0.0, and bumps both skill versions to `2.1.0`.
> 
> For PHP, the docs correct key API details (notably strict `subscribe/psubscribe(array, callback)` signatures, 3-arg `psubscribe` callback, no sharded PubSub in v1.0.0, and standalone-vs-cluster construction differences) and refresh connection/auth/TLS/reconnect/read-strategy guidance.
> 
> For Ruby, the docs clarify valkey-rb-specific divergences (e.g., `statistics` API and flat return shape, OpenTelemetry via `Valkey::OpenTelemetry.init`, PubSub via overriding `pubsub_callback` instead of redis-rb block form, and the `pipelined`+transaction sequential fallback caveat), plus expand configuration and error-hierarchy documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edad1bb3e81d83b1a16f67e80aaa46c9772fbc2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->